### PR TITLE
Feat/nickname colors

### DIFF
--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -476,6 +476,15 @@
     await refreshPhonebook();
   }
 
+  /** User-picked nickname color for a contact row, if the peer has one. */
+  function colorForPeer(peerId: string): string | undefined {
+    const did = peerIdToDid(peerId);
+    return (
+      transportState.peerColors.get(peerId) ??
+      (did ? transportState.peerColors.get(did) : undefined)
+    );
+  }
+
   async function removePhonebookContact(peerId: string) {
     await removeFromPhonebook(peerId);
     await refreshPhonebook();
@@ -815,6 +824,7 @@
                 >
                   <div
                     class="size-8 rounded-full overflow-hidden bg-secondary text-secondary-foreground text-xs font-semibold font-mono flex items-center justify-center shrink-0"
+                    style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
                   >
                     {#if entry.avatarUrl}
                       <GifImage
@@ -835,7 +845,10 @@
                       handleSelectDm(contactId);
                     }}
                   >
-                    <div class="truncate text-sm font-medium">
+                    <div
+                      class="truncate text-sm font-medium"
+                      style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
+                    >
                       {entry.nickname}
                     </div>
                     <div class="truncate text-xs text-muted-foreground">
@@ -876,6 +889,7 @@
                 >
                   <div
                     class="size-8 rounded-full overflow-hidden bg-secondary text-secondary-foreground text-xs font-semibold font-mono flex items-center justify-center shrink-0"
+                    style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
                   >
                     {#if entry.avatarUrl}
                       <GifImage
@@ -896,7 +910,10 @@
                       handleSelectDm(contactId);
                     }}
                   >
-                    <div class="truncate text-sm font-medium">
+                    <div
+                      class="truncate text-sm font-medium"
+                      style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
+                    >
                       {entry.nickname}
                     </div>
                     <div class="truncate text-xs text-muted-foreground">
@@ -963,6 +980,7 @@
                   >
                     <div
                       class="size-8 rounded-full overflow-hidden bg-secondary text-secondary-foreground text-xs font-semibold font-mono flex items-center justify-center shrink-0"
+                      style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
                     >
                       {#if entry.avatarUrl}
                         <GifImage
@@ -983,7 +1001,10 @@
                         handleSelectDm(contactId);
                       }}
                     >
-                      <div class="truncate text-sm font-medium">
+                      <div
+                        class="truncate text-sm font-medium"
+                        style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
+                      >
                         {entry.nickname}
                       </div>
                       <div class="truncate text-xs text-muted-foreground">
@@ -1029,6 +1050,7 @@
                   >
                     <div
                       class="size-8 rounded-full overflow-hidden bg-secondary text-secondary-foreground text-xs font-semibold font-mono flex items-center justify-center shrink-0"
+                      style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
                     >
                       {#if entry.avatarUrl}
                         <GifImage
@@ -1049,7 +1071,10 @@
                         handleSelectDm(contactId);
                       }}
                     >
-                      <div class="truncate text-sm font-medium">
+                      <div
+                        class="truncate text-sm font-medium"
+                        style={colorForPeer(entry.peerId) ? `color: ${colorForPeer(entry.peerId)}` : ""}
+                      >
                         {entry.nickname}
                       </div>
                       <div class="truncate text-xs text-muted-foreground">

--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -36,6 +36,7 @@
     type PhonebookEntry,
   } from "$lib/storage";
   import { loadProfile } from "$lib/profile.svelte";
+import { displayPrefs } from "$lib/display-prefs.svelte";
   import { consumeLatestSharedPayload } from "$lib/share-target";
   import ReloadPrompt from "./ReloadPrompt.svelte";
   import InstallPrompt from "./InstallPrompt.svelte";
@@ -478,6 +479,7 @@
 
   /** User-picked nickname color for a contact row, if the peer has one. */
   function colorForPeer(peerId: string): string | undefined {
+    if (!displayPrefs.showPeerNicknameColors) return undefined;
     const did = peerIdToDid(peerId);
     return (
       transportState.peerColors.get(peerId) ??

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -99,6 +99,7 @@
     callPeerRooms,
     peerNames,
     peerAvatars,
+    peerColors,
     fileTransfers,
     connecting,
   } = $derived(transportState);
@@ -715,6 +716,11 @@
     );
   }
 
+  /** User-picked nickname color, keyed like names (by DID, peerId fallback). */
+  function senderColor(senderId: string): string | undefined {
+    return peerColors.get(senderDid(senderId)) ?? peerColors.get(senderId);
+  }
+
   /** Live name wins over the one stored with the message, so a rename shows up
    *  on everything that person ever said, not just what they say next. */
   function displayNameFor(senderId: string, stored?: string): string {
@@ -1136,6 +1142,13 @@
                       {isOwn
                         ? 'bg-primary/20 text-primary'
                         : 'bg-secondary text-secondary-foreground'}"
+                      style={isOwn
+                        ? profileStore.color
+                          ? `color: ${profileStore.color}`
+                          : ""
+                        : senderColor(msg.senderId)
+                          ? `color: ${senderColor(msg.senderId)}`
+                          : ""}
                     >
                       {#if isOwn && profileStore.avatarUrl}
                         <img
@@ -1159,6 +1172,13 @@
                         class="text-sm font-medium {isOwn
                           ? 'text-primary'
                           : 'text-foreground'}"
+                        style={isOwn
+                          ? profileStore.color
+                            ? `color: ${profileStore.color}`
+                            : ""
+                          : senderColor(msg.senderId)
+                            ? `color: ${senderColor(msg.senderId)}`
+                            : ""}
                       >
                         {isOwn
                           ? profileStore.nickname || "You"

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -31,6 +31,7 @@
   import EmojiPickerPopup from "./EmojiPickerPopup.svelte";
   import UserListSidebar from "./UserListSidebar.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
   import { viewportHeight } from "$lib/actions/viewport-height";
   import {
     transportState,
@@ -718,6 +719,7 @@
 
   /** User-picked nickname color, keyed like names (by DID, peerId fallback). */
   function senderColor(senderId: string): string | undefined {
+    if (!displayPrefs.showPeerNicknameColors) return undefined;
     return peerColors.get(senderDid(senderId)) ?? peerColors.get(senderId);
   }
 
@@ -1171,7 +1173,9 @@
                       <span
                         class="text-sm font-medium {isOwn
                           ? 'text-primary'
-                          : 'text-foreground'}"
+                          : 'text-foreground'} {isOwn && displayPrefs.italicOwnName
+                          ? 'italic'
+                          : ''}"
                         style={isOwn
                           ? profileStore.color
                             ? `color: ${profileStore.color}`

--- a/frontend/src/lib/components/RoomSidebar.svelte
+++ b/frontend/src/lib/components/RoomSidebar.svelte
@@ -12,6 +12,7 @@
   import GifImage from "./GifImage.svelte";
   import { Tip } from "$lib/components/ui/tooltip";
   import CallStatus from "./CallStatus.svelte";
+  import { transportState, peerIdToDid } from "$lib/transport/transport.svelte";
 
   interface DmPreview {
     text: string;
@@ -109,6 +110,13 @@
     dmContextMenu = null;
     confirmingRemove = false;
     confirmingRemoveDm = false;
+  }
+
+  const peerColors = $derived(transportState.peerColors);
+
+  function colorForPeer(peerId: string): string | undefined {
+    const did = peerIdToDid(peerId);
+    return peerColors.get(peerId) ?? (did ? peerColors.get(did) : undefined);
   }
 
   // Deleting a room or conversation destroys its stored history, so it takes
@@ -335,6 +343,9 @@
           >
             <div
               class="mt-px flex size-6 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground text-xs font-semibold font-mono"
+              style={colorForPeer(entry.peerId)
+                ? `color: ${colorForPeer(entry.peerId)}`
+                : ""}
             >
               {#if entry.avatarUrl}
                 <GifImage
@@ -348,7 +359,12 @@
               {/if}
             </div>
             <div class="min-w-0 flex-1">
-              <div class="truncate text-sm font-medium font-mono">
+              <div
+                class="truncate text-sm font-medium font-mono"
+                style={colorForPeer(entry.peerId)
+                  ? `color: ${colorForPeer(entry.peerId)}`
+                  : ""}
+              >
                 {entry.nickname}
               </div>
               <div class="truncate text-xs opacity-60 font-mono">

--- a/frontend/src/lib/components/RoomSidebar.svelte
+++ b/frontend/src/lib/components/RoomSidebar.svelte
@@ -13,6 +13,7 @@
   import { Tip } from "$lib/components/ui/tooltip";
   import CallStatus from "./CallStatus.svelte";
   import { transportState, peerIdToDid } from "$lib/transport/transport.svelte";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
 
   interface DmPreview {
     text: string;
@@ -116,6 +117,7 @@
 
   function colorForPeer(peerId: string): string | undefined {
     const did = peerIdToDid(peerId);
+    if (!displayPrefs.showPeerNicknameColors) return undefined;
     return peerColors.get(peerId) ?? (did ? peerColors.get(did) : undefined);
   }
 

--- a/frontend/src/lib/components/UserListSidebar.svelte
+++ b/frontend/src/lib/components/UserListSidebar.svelte
@@ -15,6 +15,7 @@
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
   import GifImage from "./GifImage.svelte";
   import { identityStore } from "$lib/identity/identity.svelte";
   import {
@@ -106,7 +107,10 @@
         const nameKey = peerIdToDid(did) || did;
         name = peerNames.get(nameKey) || peerNames.get(did) || did.slice(0, 12);
         avatarUrl = peerAvatars.get(nameKey) || peerAvatars.get(did) || null;
-        color = peerColors.get(nameKey) || peerColors.get(did) || null;
+        color =
+          displayPrefs.showPeerNicknameColors
+            ? peerColors.get(nameKey) || peerColors.get(did) || null
+            : null;
       }
 
       // In a call in THIS room: presence is announced per peer, self via

--- a/frontend/src/lib/components/UserListSidebar.svelte
+++ b/frontend/src/lib/components/UserListSidebar.svelte
@@ -49,6 +49,7 @@
     peerId: string | null;
     name: string;
     avatarUrl: string | null;
+    color: string | null;
     isOnline: boolean;
     isSelf: boolean;
     isRelayed: boolean;
@@ -59,6 +60,7 @@
   const peers = $derived(transportState.peers);
   const peerNames = $derived(transportState.peerNames);
   const peerAvatars = $derived(transportState.peerAvatars);
+  const peerColors = $derived(transportState.peerColors);
 
   const selfDid = $derived(selfId());
   const ownDid = $derived(identityStore.did);
@@ -93,15 +95,18 @@
 
       let name: string;
       let avatarUrl: string | null = null;
+      let color: string | null = null;
 
       if (isSelf) {
         name = profileStore.nickname || "You";
         avatarUrl = profileStore.avatarUrl || null;
+        color = profileStore.color || null;
       } else {
         // roomUsers can carry a raw peerId while these maps are DID-keyed.
         const nameKey = peerIdToDid(did) || did;
         name = peerNames.get(nameKey) || peerNames.get(did) || did.slice(0, 12);
         avatarUrl = peerAvatars.get(nameKey) || peerAvatars.get(did) || null;
+        color = peerColors.get(nameKey) || peerColors.get(did) || null;
       }
 
       // In a call in THIS room: presence is announced per peer, self via
@@ -119,6 +124,7 @@
         peerId: mappedPeerId,
         name,
         avatarUrl,
+        color,
         isOnline,
         isSelf,
         isRelayed: userIsRelayed,
@@ -276,6 +282,7 @@
           {user.isSelf
           ? 'bg-primary/20 text-primary'
           : 'bg-secondary text-secondary-foreground'}"
+        style={user.color ? `color: ${user.color}` : ""}
       >
         {#if user.avatarUrl}
           <GifImage
@@ -299,6 +306,7 @@
         class="text-sm font-medium truncate {user.isSelf
           ? 'text-primary'
           : ''} flex items-center gap-1"
+        style={user.color ? `color: ${user.color}` : ""}
       >
         {user.isSelf ? `${user.name} (You)` : user.name}
         {#if user.isRelayed}

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -20,6 +20,7 @@
     selfId,
     peerIdToDid,
     isRelayed,
+    peerId as selfPeerId,
   } from "$lib/transport/transport.svelte";
   import {
     setTransmissionOutputVolume,
@@ -55,8 +56,8 @@
     Workflow,
   } from "@lucide/svelte";
   import { MessageSquare, MonitorIcon } from "@lucide/svelte";
-  import { profileStore, loadProfile } from "$lib/profile.svelte";
-  import { cn } from "$lib/utils";
+import { profileStore, loadProfile } from "$lib/profile.svelte";
+import { cn } from "$lib/utils";
   import { Slider } from "./ui/slider";
 
   $effect(() => {
@@ -123,6 +124,18 @@
   function getPeerAvatar(peerId: string): string | null {
     const did = peerIdToDid(peerId);
     return peerAvatars.get(did) ?? peerAvatars.get(peerId) ?? null;
+  }
+
+  function getPeerColor(peerId: string): string | null {
+    if (peerId === selfId() || peerId === selfPeerId()) {
+      return profileStore.color ?? null;
+    }
+    const did = peerIdToDid(peerId);
+    return (
+      transportState.peerColors.get(peerId) ??
+      (did ? transportState.peerColors.get(did) : undefined) ??
+      null
+    );
   }
 
   // ── Per-peer volume menu ──────────────────────────────────────────────────
@@ -694,6 +707,7 @@
 )}
   {@const hasVideo = tile.videoTrack !== null}
   {@const isPendingTx = tile.kind === "transmission" && tile.isPending}
+  {@const tileColor = getPeerColor(tile.peerId)}
   <button
     type="button"
     oncontextmenu={(e) => openPeerMenu(e, tile)}
@@ -739,6 +753,7 @@
           ? 'bg-primary/20 text-primary'
           : 'bg-secondary text-secondary-foreground'} font-semibold overflow-hidden font-mono transition-shadow duration-200
         {compact ? 'size-8 text-sm' : 'size-16 text-2xl'}"
+        style={tileColor ? `color: ${tileColor}` : ""}
       >
         {#if tile.avatarUrl}
           <GifImage
@@ -795,7 +810,10 @@
         {#if tile.kind === "camera" && tile.deafened}
           <HeadphoneOff class="size-3 text-red-400" />
         {/if}
-        <span class="text-xs mt-0.75 leading-none text-white font-mono">
+        <span
+          class="text-xs mt-0.75 leading-none text-white font-mono"
+          style={tileColor ? `color: ${tileColor}` : ""}
+        >
           {tile.kind === "transmission"
             ? `${tile.label}'s screen`
             : tile.isLocal

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -57,6 +57,7 @@
   } from "@lucide/svelte";
   import { MessageSquare, MonitorIcon } from "@lucide/svelte";
 import { profileStore, loadProfile } from "$lib/profile.svelte";
+import { displayPrefs } from "$lib/display-prefs.svelte";
 import { cn } from "$lib/utils";
   import { Slider } from "./ui/slider";
 
@@ -130,6 +131,7 @@ import { cn } from "$lib/utils";
     if (peerId === selfId() || peerId === selfPeerId()) {
       return profileStore.color ?? null;
     }
+    if (!displayPrefs.showPeerNicknameColors) return null;
     const did = peerIdToDid(peerId);
     return (
       transportState.peerColors.get(peerId) ??

--- a/frontend/src/lib/components/settings/AppSettings.svelte
+++ b/frontend/src/lib/components/settings/AppSettings.svelte
@@ -7,6 +7,11 @@ import {
   setNotificationsEnabled,
 } from "$lib/notify.svelte";
 import { mediaPrefs, setGifAutoplay } from "$lib/media-prefs.svelte";
+import {
+  displayPrefs,
+  setItalicOwnName,
+  setShowPeerNicknameColors,
+} from "$lib/display-prefs.svelte";
 </script>
 
 <div class="flex flex-col gap-6">
@@ -82,6 +87,32 @@ import { mediaPrefs, setGifAutoplay } from "$lib/media-prefs.svelte";
     <Switch
       checked={mediaPrefs.gifAutoplay}
       onCheckedChange={(checked) => setGifAutoplay(checked)}
+    />
+  </div>
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex flex-col gap-1 min-w-0">
+      <span class="text-xs font-mono">Italicize my name</span>
+      <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+        Renders your name above your own messages in italics. Only affects
+        your view of the chat.
+      </span>
+    </div>
+    <Switch
+      checked={displayPrefs.italicOwnName}
+      onCheckedChange={(checked) => setItalicOwnName(checked)}
+    />
+  </div>
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex flex-col gap-1 min-w-0">
+      <span class="text-xs font-mono">Show others' nickname colors</span>
+      <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+        Off keeps every remote name in the default color and hides the
+        initials tint. Your own color still shows to you.
+      </span>
+    </div>
+    <Switch
+      checked={displayPrefs.showPeerNicknameColors}
+      onCheckedChange={(checked) => setShowPeerNicknameColors(checked)}
     />
   </div>
 </div>

--- a/frontend/src/lib/components/settings/ProfileSettings.svelte
+++ b/frontend/src/lib/components/settings/ProfileSettings.svelte
@@ -2,7 +2,7 @@
   import { Input } from "$lib/components/ui/input";
 import { Label } from "$lib/components/ui/label";
   import { Button } from "$lib/components/ui/button";
-  import { profileStore, saveName } from "$lib/profile.svelte";
+  import { profileStore, saveName, saveColor } from "$lib/profile.svelte";
   import { lock } from "$lib/identity/identity.svelte";
   import { Pencil, LogOut } from "@lucide/svelte";
 
@@ -15,9 +15,11 @@ import { Label } from "$lib/components/ui/label";
   let { isMobile = false, onAvatarClick }: Props = $props();
 
   let nameValue = $state("");
+  let colorValue = $state("#3b82f6");
 
   $effect(() => {
     nameValue = profileStore.nickname;
+    colorValue = profileStore.color ?? "#3b82f6";
   });
 
   const profileInitial = $derived(
@@ -82,6 +84,41 @@ import { Label } from "$lib/components/ui/label";
         placeholder="Your display name"
         class="bg-background border-input text-foreground placeholder:text-muted-foreground font-mono focus-visible:ring-ring text-center w-full max-w-64 md:max-w-80"
       />
+
+      <div class="flex flex-col gap-2 w-full max-w-64 md:max-w-80">
+        <Label
+          class="text-xs font-mono text-muted-foreground uppercase tracking-wider"
+          >Nickname color</Label
+        >
+        <div class="flex items-center gap-2">
+          <input
+            type="color"
+            bind:value={colorValue}
+            onchange={() => saveColor(colorValue).catch(() => {})}
+            aria-label="Nickname color"
+            class="size-8 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0.5"
+          />
+          <span
+            class="flex-1 truncate text-sm font-medium font-mono"
+            style={profileStore.color
+              ? `color: ${profileStore.color}`
+              : ""}
+            >{profileStore.nickname || "Anonymous"}
+            {#if !profileStore.color}(default){/if}</span
+          >
+          <button
+            type="button"
+            onclick={() => {
+              colorValue = "#3b82f6";
+              saveColor(null).catch(() => {});
+            }}
+            aria-label="Reset nickname color to default"
+            class="text-xs font-mono text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/lib/display-prefs.svelte.ts
+++ b/frontend/src/lib/display-prefs.svelte.ts
@@ -1,0 +1,48 @@
+/**
+ * Display preferences for the chat view. Device-local, like media-prefs: a
+ * preference about this screen, not part of the identity or profile.
+ */
+
+const ITALIC_KEY = "awful:italic-own-name:v1";
+const PEER_COLORS_KEY = "awful:show-peer-colors:v1";
+
+function readStored(key: string, defaultValue: boolean): boolean {
+  if (typeof localStorage === "undefined") return defaultValue;
+  const v = localStorage.getItem(key);
+  return v === null ? defaultValue : v === "1";
+}
+
+export const displayPrefs = $state({
+  /** Render your own name above your messages in italics. */
+  italicOwnName: readStored(ITALIC_KEY, false),
+  /** Show other people's custom colors; off keeps every remote name default. */
+  showPeerNicknameColors: readStored(PEER_COLORS_KEY, true),
+});
+
+export function setItalicOwnName(on: boolean): void {
+  displayPrefs.italicOwnName = on;
+  try {
+    localStorage.setItem(ITALIC_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
+export function setShowPeerNicknameColors(on: boolean): void {
+  displayPrefs.showPeerNicknameColors = on;
+  try {
+    localStorage.setItem(PEER_COLORS_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
+// A second tab flipping a switch should be reflected here, not fought.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === ITALIC_KEY)
+      displayPrefs.italicOwnName = e.newValue === "1";
+    if (e.key === PEER_COLORS_KEY)
+      displayPrefs.showPeerNicknameColors = e.newValue === "1";
+  });
+}

--- a/frontend/src/lib/profile.svelte.ts
+++ b/frontend/src/lib/profile.svelte.ts
@@ -11,11 +11,14 @@ import { broadcastProfile } from "$lib/transport/transport.svelte";
 interface ProfileStore {
   nickname: string;
   avatarUrl: string | undefined;
+  /** User-picked nickname color, hex like "#aabbcc". Absent = default. */
+  color: string | undefined;
 }
 
 export const profileStore = $state<ProfileStore>({
   nickname: "Anonymous",
   avatarUrl: undefined,
+  color: undefined,
 });
 
 let _blobUrl: string | undefined;
@@ -29,6 +32,7 @@ export async function loadProfile(): Promise<void> {
     await rekeyOwnProfile(p.did ?? "", identityStore.did);
   }
   profileStore.nickname = p.nickname || "Anonymous";
+  profileStore.color = p.color;
   if (_blobUrl) {
     URL.revokeObjectURL(_blobUrl);
     _blobUrl = undefined;
@@ -84,6 +88,19 @@ export async function saveName(name: string, did?: string): Promise<void> {
   await chained(async () => {
     await ensureProfile(did);
     await updateOwnProfile({ nickname: name });
+  });
+  broadcastProfile();
+}
+
+/**
+ * @param color - the picked hex color, or undefined/null to reset to default.
+ * Values are sanitized on receipt from the wire; here we trust the picker.
+ */
+export async function saveColor(color: string | undefined | null): Promise<void> {
+  profileStore.color = color ?? undefined;
+  await chained(async () => {
+    await ensureProfile();
+    await updateOwnProfile({ color: color ?? undefined });
   });
   broadcastProfile();
 }

--- a/frontend/src/lib/storage.test.ts
+++ b/frontend/src/lib/storage.test.ts
@@ -19,6 +19,9 @@ import {
   putPhonebookEntry,
   getPhonebookEntries,
   markOwnMessagesReadUpTo,
+  getOwnProfile,
+  putOwnProfile,
+  updateOwnProfile,
 } from "./storage";
 import { MessageType, type Message } from "./types/message";
 
@@ -194,6 +197,32 @@ describe("dedupePhonebook", () => {
     expect(dupes[0].favorite).toBe(true);
     expect(dupes[0].addedAt).toBe(1_000);
     expect(entries.some((e) => e.peerId === "12D3KooWLoner")).toBe(true);
+  });
+});
+
+describe("own profile color", () => {
+  it("persists a selected nickname color", async () => {
+    await putOwnProfile({
+      did: "did:key:zMe",
+      isMe: true,
+      nickname: "Me",
+      updatedAt: 1_000,
+    });
+    await updateOwnProfile({ color: "#ab12cd" });
+    expect((await getOwnProfile())?.color).toBe("#ab12cd");
+    expect((await getOwnProfile())?.nickname).toBe("Me");
+  });
+
+  it("clears an existing color", async () => {
+    await putOwnProfile({
+      did: "did:key:zMe",
+      isMe: true,
+      nickname: "Me",
+      color: "#ab12cd",
+      updatedAt: 1_000,
+    });
+    await updateOwnProfile({ color: undefined });
+    expect((await getOwnProfile())?.color).toBeUndefined();
   });
 });
 

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -42,6 +42,8 @@ export interface OwnProfile {
   nickname: string;
   pfpData?: ArrayBuffer; // local upload
   pfpURL?: string; // external URL - stored as-is
+  /** User-picked nickname color, hex like "#aabbcc". Absent = default. */
+  color?: string;
   updatedAt: number;
 }
 
@@ -51,6 +53,8 @@ export interface PeerProfile {
   nickname: string;
   pfpData?: ArrayBuffer;
   pfpURL?: string;
+  /** User-picked nickname color, hex like "#aabbcc". Absent = default. */
+  color?: string;
   updatedAt: number;
 }
 
@@ -776,7 +780,7 @@ export async function rekeyOwnProfile(
  * pfpData and pfpURL are mutually exclusive - setting one clears the other.
  */
 export async function updateOwnProfile(
-  patch: Partial<Pick<OwnProfile, "nickname" | "pfpData" | "pfpURL">>
+  patch: Partial<Pick<OwnProfile, "nickname" | "pfpData" | "pfpURL" | "color">>
 ): Promise<void> {
   const database = await getDB();
   const tx = database.transaction("profiles", "readwrite");

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -65,7 +65,7 @@ import {
   verifyPeerBinding,
   verifySignature,
 } from "../messaging";
-import { encode, decode, normalizeAvatarUrl } from "../utils";
+import { encode, decode, normalizeAvatarUrl, normalizeNicknameColor } from "../utils";
 import { _sendCallPresence, _sendCallState, leaveCall } from "./call.svelte";
 import { _sendWatchPresence } from "./transmission.svelte";
 import {
@@ -168,6 +168,8 @@ interface TransportState {
   /** Bumped on every peer->DID mapping change; see peerIdToDid(). */
   peerDidVersion: number;
   peerAvatars: Map<string, string>;
+  /** User-picked nickname colors, keyed like peerNames (by DID). */
+  peerColors: Map<string, string>;
   error: string | null;
   callPeerIds: Set<string>;
   callPeerRooms: Map<string, string>; // peerId -> roomCode they're calling in
@@ -207,6 +209,7 @@ export const transportState = $state<TransportState>({
   peerNames: new Map(),
   peerDidVersion: 0,
   peerAvatars: new Map(),
+  peerColors: new Map(),
   error: null,
   callPeerIds: new Set(),
   callPeerRooms: new Map(),
@@ -403,6 +406,7 @@ async function _sendProfile(peerId?: string, isReply = false): Promise<void> {
     name,
     did,
     avatarUrl,
+    color: profile?.color ?? null,
     peerId: _transport.selfId(),
     bindingSig: binding?.bindingSig,
     reply: isReply || undefined,
@@ -605,12 +609,15 @@ export async function _loadHistory(
   if (profiles.length > 0) {
     const names = new Map(transportState.peerNames);
     const avatars = new Map(transportState.peerAvatars);
+    const colors = new Map(transportState.peerColors);
     for (const p of profiles) {
       names.set(p.did, p.nickname);
       if (p.pfpURL) avatars.set(p.did, p.pfpURL);
+      if (p.color) colors.set(p.did, p.color);
     }
     transportState.peerNames = names;
     transportState.peerAvatars = avatars;
+    transportState.peerColors = colors;
   }
 
   for (const msg of msgs) {
@@ -812,6 +819,10 @@ async function _handleProfile(peerId: string, msg: WireProfile): Promise<void> {
   _syncPeer(peerId);
 
   const avatarUrl = normalizeAvatarUrl(msg.avatarUrl);
+  // `color` absent = older build, which has no such field - keep any cached
+  // color. Explicit null (or junk that fails sanitizing) = "no color".
+  const hasColorField = msg.color !== undefined;
+  const color = hasColorField ? normalizeNicknameColor(msg.color) : undefined;
 
   const names = new Map(transportState.peerNames);
   names.set(did, msg.name);
@@ -822,6 +833,13 @@ async function _handleProfile(peerId: string, msg: WireProfile): Promise<void> {
   else avatars.delete(did);
   transportState.peerAvatars = avatars;
 
+  if (hasColorField) {
+    const colors = new Map(transportState.peerColors);
+    if (color) colors.set(did, color);
+    else colors.delete(did);
+    transportState.peerColors = colors;
+  }
+
   getPeerProfile(did)
     .then((existing) =>
       putPeerProfile({
@@ -830,6 +848,7 @@ async function _handleProfile(peerId: string, msg: WireProfile): Promise<void> {
         nickname: msg.name,
         pfpURL: avatarUrl,
         updatedAt: Date.now(),
+        color: hasColorField ? (color ?? undefined) : existing?.color,
         ...(existing?.pfpData ? { pfpData: existing.pfpData } : {}),
       }).catch(() => {})
     )
@@ -1765,6 +1784,7 @@ function _disconnectWithoutBroadcasting(): void {
   transportState.participants = new Map();
   transportState.peerNames = new Map();
   transportState.peerAvatars = new Map();
+  transportState.peerColors = new Map();
   transportState.error = null;
   transportState.callPeerIds = new Set();
   transportState.sfuPeerIds = new Set();

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -133,6 +133,8 @@ export interface WireProfile {
   name: string;
   did: string | null;
   avatarUrl: string | null;
+  /** User-picked nickname color, hex like "#aabbcc". Absent = default. */
+  color?: string;
   /**
    * Proof that `did` owns the libp2p peerId this arrived from: the sender's
    * peerId, signed by the identity key behind `did`. The peerId can no longer

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { decode, encode, hex, normalizeAvatarUrl, unhex } from "./utils";
+import {
+  decode,
+  encode,
+  hex,
+  normalizeAvatarUrl,
+  normalizeNicknameColor,
+  unhex,
+} from "./utils";
 
 describe("hex codec", () => {
   it("round-trips bytes", () => {
@@ -53,5 +60,24 @@ describe("normalizeAvatarUrl", () => {
   it("rejects non-strings and garbage", () => {
     expect(normalizeAvatarUrl(42)).toBeUndefined();
     expect(normalizeAvatarUrl("not a url")).toBeUndefined();
+  });
+});
+
+describe("normalizeNicknameColor", () => {
+  it("accepts 6-digit hex and lowercases it", () => {
+    expect(normalizeNicknameColor("#AB12CD")).toBe("#ab12cd");
+    expect(normalizeNicknameColor("#aabbcc")).toBe("#aabbcc");
+  });
+
+  it("rejects anything a style attribute could abuse", () => {
+    expect(normalizeNicknameColor("red")).toBeUndefined();
+    expect(normalizeNicknameColor("url(javascript:alert(1))")).toBeUndefined();
+    expect(normalizeNicknameColor("#12345")).toBeUndefined();
+    expect(normalizeNicknameColor("#1234567")).toBeUndefined();
+    expect(normalizeNicknameColor("rgb(1,2,3)")).toBeUndefined();
+    expect(normalizeNicknameColor("")).toBeUndefined();
+    expect(normalizeNicknameColor(42)).toBeUndefined();
+    expect(normalizeNicknameColor(null)).toBeUndefined();
+    expect(normalizeNicknameColor(undefined)).toBeUndefined();
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -53,6 +53,18 @@ const DATA_AVATAR_RE =
 /** ~1.4 MB of base64, i.e. about a 1 MB image. */
 const MAX_DATA_AVATAR_LEN = 1_400_000;
 
+/**
+ * Only 6-digit hex colors survive. Nickname colors end up in inline style
+ * attributes, so anything wider (CSS expressions, url(), named colors) is
+ * rejected instead of trusted from the wire.
+ */
+const NICKNAME_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export function normalizeNicknameColor(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return NICKNAME_COLOR_RE.test(value) ? value.toLowerCase() : undefined;
+}
+
 export function normalizeAvatarUrl(url: unknown): string | undefined {
   if (typeof url !== "string") return undefined;
   // An avatar picked from the device is sent inline as a data: URL - rejecting


### PR DESCRIPTION
## Summary
- Let users pick a custom nickname color that's broadcast with their profile so every peer sees it.
- Color is rendered on message senders, initials avatars, the user list, DM sidebar, call tiles, and the phonebook.
- Add two device-local appearance toggles under App > Appearance: italicize your own name, and hide peers' nickname colors.