### PR TITLE
feat: emoji picker in the composer, anchored to its trigger

### DIFF
--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -147,7 +147,9 @@
   const draftMentionMap = new Map<string, string>();
   let replyTargetId = $state<string | null>(null);
   let reactionPickerFor = $state<string | null>(null);
-  let emojiPickerPos = $state({ x: 0, y: 0 });
+  let reactionAnchor = $state<DOMRect | null>(null);
+  let composerEmojiOpen = $state(false);
+  let composerEmojiAnchor = $state<DOMRect | null>(null);
   let gifPickerOpen = $state(false);
   let hasMoreHistory = $state(true);
   let loadingMore = $state(false);
@@ -553,9 +555,29 @@
     requestAnimationFrame(() => textareaEl?.focus());
   }
 
-  function openReactionPicker(msgId: string, e: MouseEvent) {
-    emojiPickerPos = { x: e.clientX - 40, y: e.clientY - 12 };
+  function openReactionPicker(msgId: string, trigger: HTMLElement) {
+    reactionAnchor = trigger.getBoundingClientRect();
     reactionPickerFor = msgId;
+  }
+
+  /** Drop an emoji in at the caret, replacing any selection. */
+  function insertEmoji(emoji: string) {
+    const el = textareaEl;
+    if (!el) {
+      draft += emoji;
+      return;
+    }
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+    draft = draft.slice(0, start) + emoji + draft.slice(end);
+    // The value lands on the next flush, so the caret has to wait for it.
+    requestAnimationFrame(() => {
+      if (!textareaEl) return;
+      const caret = start + emoji.length;
+      textareaEl.focus();
+      textareaEl.setSelectionRange(caret, caret);
+      autoResize();
+    });
   }
 
   function jumpToMessage(messageId: string) {
@@ -1638,7 +1660,7 @@
                       if (reactionPickerFor === msg.id) {
                         reactionPickerFor = null;
                       } else {
-                        openReactionPicker(msg.id, e as MouseEvent);
+                        openReactionPicker(msg.id, e.currentTarget);
                       }
                       activeMessageId = null;
                     }}
@@ -1821,7 +1843,7 @@
           }}
           placeholder="Type a message..."
           rows={1}
-          class="w-full resize-none rounded-md border border-input bg-background pl-3 pr-20 py-2 text-sm text-foreground placeholder:text-muted-foreground font-mono focus:outline-none focus:ring-1 focus:ring-ring min-h-10 max-h-30 overflow-y-auto"
+          class="w-full resize-none rounded-md border border-input bg-background pl-3 pr-28 py-2 text-sm text-foreground placeholder:text-muted-foreground font-mono focus:outline-none focus:ring-1 focus:ring-ring min-h-10 max-h-30 overflow-y-auto"
         ></textarea>
         {#if commandHint}
           <p class="absolute bottom-full left-0 mb-1 rounded bg-popover border border-border px-2 py-1 font-mono text-xs text-muted-foreground">
@@ -1882,6 +1904,26 @@
                 class="size-8 shrink-0 text-muted-foreground hover:text-foreground cursor-pointer"
               >
                 <Paperclip class="size-4" />
+              </Button>
+            {/snippet}
+          </Tip>
+          <Tip text="Insert emoji">
+            {#snippet children(props)}
+              <Button
+                {...props}
+                type="button"
+                variant="ghost"
+                size="icon"
+                onclick={(e: MouseEvent) => {
+                  composerEmojiAnchor = (
+                    e.currentTarget as HTMLElement
+                  ).getBoundingClientRect();
+                  composerEmojiOpen = !composerEmojiOpen;
+                }}
+                aria-label="Insert emoji"
+                class="size-8 shrink-0 text-muted-foreground hover:text-foreground cursor-pointer"
+              >
+                <Smile class="size-4" />
               </Button>
             {/snippet}
           </Tip>
@@ -1955,8 +1997,7 @@
 
 <EmojiPickerPopup
   open={reactionPickerFor !== null}
-  x={emojiPickerPos.x}
-  y={emojiPickerPos.y}
+  anchor={reactionAnchor}
   onClose={() => {
     reactionPickerFor = null;
     activeMessageId = null;
@@ -1967,6 +2008,13 @@
     reactionPickerFor = null;
     activeMessageId = null;
   }}
+/>
+
+<EmojiPickerPopup
+  open={composerEmojiOpen}
+  anchor={composerEmojiAnchor}
+  onClose={() => (composerEmojiOpen = false)}
+  onSelect={insertEmoji}
 />
 
 {#if userMenu}

--- a/frontend/src/lib/components/EmojiPickerPopup.svelte
+++ b/frontend/src/lib/components/EmojiPickerPopup.svelte
@@ -1,13 +1,42 @@
 <script lang="ts">
   interface Props {
     open: boolean;
-    x: number;
-    y: number;
+    /**
+     * Viewport rect of the element that opened the picker. Anchoring to the
+     * trigger rather than to the pointer is what makes keyboard activation
+     * land in the same place as a click - a synthetic click reports
+     * clientX/clientY of 0, which used to pin the panel to the top-left
+     * corner.
+     */
+    anchor: DOMRect | null;
+    /** Side to try first. The panel flips when that side has no room. */
+    prefer?: "above" | "below";
     onSelect: (emoji: string) => void;
     onClose: () => void;
   }
 
-  let { open, x, y, onSelect, onClose }: Props = $props();
+  let {
+    open,
+    anchor,
+    prefer = "above",
+    onSelect,
+    onClose,
+  }: Props = $props();
+
+  /** Keep-out distance from the viewport edges. */
+  const MARGIN = 8;
+  /** Breathing room between the trigger and the panel. */
+  const GAP = 6;
+
+  // Seeded with the panel's own CSS size (w-85, 420px of picker, 1px borders)
+  // so the very first frame is already in the right place; the bindings below
+  // then take over with the measured truth. These are border-box sizes, which
+  // is what the edge clamp below is written against.
+  let panelWidth = $state(340);
+  let panelHeight = $state(422);
+
+  let viewportWidth = $state(0);
+  let viewportHeight = $state(0);
 
   // The picker is a custom element, so it upgrades in place once the
   // definition loads - no need to carry the library before the first open.
@@ -15,17 +44,48 @@
     if (open) void import("emoji-picker-element");
   });
 
-  const left = $derived(
-    typeof window === "undefined"
-      ? x
-      : Math.max(8, Math.min(x, window.innerWidth - 360))
-  );
-  const top = $derived(
-    typeof window === "undefined"
-      ? y
-      : Math.max(8, Math.min(y, window.innerHeight - 460))
-  );
+  const position = $derived.by(() => {
+    if (!anchor || viewportWidth === 0) return { left: MARGIN, top: MARGIN };
+
+    const roomAbove = anchor.top - MARGIN - GAP;
+    const roomBelow = viewportHeight - anchor.bottom - MARGIN - GAP;
+    const preferAbove = prefer === "above";
+
+    // Take the preferred side when it fits, the other side when only that
+    // fits, and otherwise the roomier side - clamping then does the rest.
+    const preferredRoom = preferAbove ? roomAbove : roomBelow;
+    const otherRoom = preferAbove ? roomBelow : roomAbove;
+    let above: boolean;
+    if (preferredRoom >= panelHeight) above = preferAbove;
+    else if (otherRoom >= panelHeight) above = !preferAbove;
+    else above = roomAbove >= roomBelow;
+
+    const rawTop = above
+      ? anchor.top - GAP - panelHeight
+      : anchor.bottom + GAP;
+    // Centre on the trigger horizontally; the clamp pulls it back in when the
+    // trigger sits near an edge, which is the normal case for composer icons.
+    const rawLeft = anchor.left + anchor.width / 2 - panelWidth / 2;
+
+    const maxLeft = Math.max(MARGIN, viewportWidth - panelWidth - MARGIN);
+    const maxTop = Math.max(MARGIN, viewportHeight - panelHeight - MARGIN);
+
+    return {
+      left: Math.min(Math.max(rawLeft, MARGIN), maxLeft),
+      top: Math.min(Math.max(rawTop, MARGIN), maxTop),
+    };
+  });
 </script>
+
+<svelte:window
+  bind:innerWidth={viewportWidth}
+  bind:innerHeight={viewportHeight}
+  onkeydown={(e) => {
+    if (!open || e.key !== "Escape") return;
+    e.preventDefault();
+    onClose();
+  }}
+/>
 
 {#if open}
   <button
@@ -37,10 +97,15 @@
 
   <div
     class="fixed z-50 w-85 overflow-hidden rounded-md border border-border bg-card shadow-xl"
-    style={`left:${left}px; top:${top}px;`}
+    style={`left:${position.left}px; top:${position.top}px;`}
+    bind:offsetWidth={panelWidth}
+    bind:offsetHeight={panelHeight}
   >
+    <!-- display:block matters: an un-upgraded custom element is inline, and an
+         inline box ignores height, so without it the panel measures 0 tall on
+         the first open and the flip decision is made on a bogus size. -->
     <emoji-picker
-      style="height:420px;"
+      style="display:block;height:420px;"
       onemoji-click={(e: any) => {
         onSelect(e.detail.unicode);
         onClose();


### PR DESCRIPTION
## What

The composer could attach a file and send a GIF but had no way to enter an emoji. This adds a third icon button that opens the same picker the reactions use, and inserts the choice at the caret (replacing any selection), then restores focus.

Reusing `EmojiPickerPopup` meant fixing how it positions itself.

## Why the anchoring changed

| Before | After |
| --- | --- |
| `x`/`y` from `e.clientX`/`e.clientY` | `anchor: DOMRect` from the trigger |
| Clamped against hardcoded `360`/`460` size guesses | Measures itself via `bind:offsetWidth`/`offsetHeight` |
| Only clamped right/bottom, never flipped | Tries the preferred side, flips when it does not fit, keeps 8px off every edge |
| No Escape | Escape closes |

Two bugs this fixes:

1. **Keyboard activation was broken.** A keyboard-activated click reports `clientX`/`clientY` of `0`, so tabbing to a message's React button and pressing Enter pinned the panel to the top-left corner. It now reads the trigger's rect, which is real either way.
2. **A trigger near the bottom had nowhere to go** — which is exactly where a composer button sits. The old code placed the panel at `top: y` and clamped only against a guessed height, so it would have run off-screen.

Also: an un-upgraded custom element is inline and ignores `height`, so `<emoji-picker>` now carries `display:block`. Without it the panel measures 0 tall on first open and the flip decision runs on a bogus size.

## Measured behaviour

Verified in a browser against a trigger at each extreme:

- Composer button (bottom right, viewport 864x996): panel placed **above**, `rightMargin: 8`, `gapToTrigger: 6`.
- Trigger at the top (`top: 16`): **flips below**, `gapBelowTrigger: 6`, centred on the trigger to within 0.004px.
- Escape closes.

## Notes for the reviewer

- The textarea's right padding goes `pr-20` -> `pr-28` to clear the third button (32px button + 4px gap).
- `openReactionPicker` changes signature from `(msgId, e: MouseEvent)` to `(msgId, trigger: HTMLElement)`.
- The anchor rect is captured at click time, so it goes stale if the window is resized or scrolled while the panel is open. The panel closes on any outside click or on select, so I did not add element tracking for it. Say the word if you want it.

## Verification

- `pnpm check` — 0 errors, 0 warnings
- `pnpm test` — 208 passed
- `pnpm build` — green

Not exercised end-to-end in the running app: the relay is Go and `proxy.golang.org` is unreachable from my network, so I could not join a room. I verified the picker through a temporary Vite harness page, then deleted it.

---

Stacked below #5 (mention highlighting in the input), which depends on the `pr-28` change here.

