### PR TITLE
feat: the composer highlights mentions as you type

### DIFF
--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick } from "svelte";
+  import { SvelteMap } from "svelte/reactivity";
   import type { Message } from "$lib/transport/transport.svelte";
   import { MessageType } from "$lib/types/message";
   import {
@@ -31,6 +32,7 @@
   import GifPicker from "./GifPicker.svelte";
   import GifImage from "./GifImage.svelte";
   import EmojiPickerPopup from "./EmojiPickerPopup.svelte";
+  import MentionInput from "./MentionInput.svelte";
   import UserListSidebar from "./UserListSidebar.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
   import { displayPrefs } from "$lib/display-prefs.svelte";
@@ -61,7 +63,7 @@
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
   import { joinCall } from "$lib/transport/call.svelte";
-  import { serialize, mentionsMe } from "$lib/mentions";
+  import { serialize, mentionsMe, segmentDraft } from "$lib/mentions";
   import { makeHostApi } from "$lib/plugins/host";
   import PluginIcon from "$lib/plugins/PluginIcon.svelte";
   import UserProfileCard from "./UserProfileCard.svelte";
@@ -143,8 +145,12 @@
   let mentionPopupOpen = $state(false);
   let mentionPrefix = $state("");
   let mentionSelectedIndex = $state(0);
-  /** Names the user picked from the popup this draft, mapped to dids. */
-  const draftMentionMap = new Map<string, string>();
+  /**
+   * Names the user picked from the popup this draft, mapped to dids. Reactive
+   * because the composer highlight is derived from it - a plain Map would
+   * leave a freshly picked mention unhighlighted until the next keystroke.
+   */
+  const draftMentionMap = new SvelteMap<string, string>();
   let replyTargetId = $state<string | null>(null);
   let reactionPickerFor = $state<string | null>(null);
   let reactionAnchor = $state<DOMRect | null>(null);
@@ -373,6 +379,14 @@
       commandPopupOpen = false;
     }
   }
+
+  /**
+   * What the composer highlights. It runs the same tokenizer the wire
+   * serializer uses, so the chips mark exactly the text that will ship as a
+   * signed @[did] token - a hand-typed @Name stays plain, and breaking a
+   * picked name un-highlights it immediately.
+   */
+  const draftSegments = $derived(segmentDraft(draft, draftMentionMap));
 
   const filteredMembersForMention = $derived.by(() => {
     if (!mentionPopupOpen) return [];
@@ -1832,19 +1846,18 @@
         }}
       />
       <div class="relative flex w-full items-center">
-        <textarea
-          bind:this={textareaEl}
+        <MentionInput
+          bind:el={textareaEl}
           bind:value={draft}
+          segments={draftSegments}
           onkeydown={handleKeydown}
+          placeholder="Type a message..."
           oninput={() => {
             autoResize();
             updateMentionState();
             updateCommandState();
           }}
-          placeholder="Type a message..."
-          rows={1}
-          class="w-full resize-none rounded-md border border-input bg-background pl-3 pr-28 py-2 text-sm text-foreground placeholder:text-muted-foreground font-mono focus:outline-none focus:ring-1 focus:ring-ring min-h-10 max-h-30 overflow-y-auto"
-        ></textarea>
+        />
         {#if commandHint}
           <p class="absolute bottom-full left-0 mb-1 rounded bg-popover border border-border px-2 py-1 font-mono text-xs text-muted-foreground">
             {commandHint}

--- a/frontend/src/lib/components/MentionInput.svelte
+++ b/frontend/src/lib/components/MentionInput.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import type { DraftSegment } from "$lib/mentions";
+
+  interface Props {
+    /** The raw draft text. */
+    value: string;
+    /**
+     * The draft split into plain and mention runs. Concatenating the segment
+     * text must reproduce `value` exactly, or the highlight drifts out of
+     * alignment with the real characters.
+     */
+    segments: DraftSegment[];
+    /** The underlying textarea, for caret math and focus by the parent. */
+    el?: HTMLTextAreaElement | null;
+    placeholder?: string;
+    oninput?: () => void;
+    onkeydown?: (e: KeyboardEvent) => void;
+  }
+
+  let {
+    value = $bindable(),
+    segments,
+    el = $bindable(null),
+    placeholder,
+    oninput,
+    onkeydown,
+  }: Props = $props();
+
+  /**
+   * A textarea cannot style its own content, so the highlight is a mirror
+   * behind transparent text. The mirror is only trustworthy while it shares
+   * every box and type metric with the textarea, so both read this one
+   * string. Change a value here and the two move together.
+   *
+   * Nothing in the mirror may alter glyph advance widths - the mention chips
+   * carry colour and background only, never a different weight or spacing.
+   *
+   * pr-28 keeps the text clear of the icon buttons the caller overlays on the
+   * right; widen it if a button is added there.
+   */
+  const BOX = "border py-2 pl-3 pr-28 font-mono text-sm leading-5";
+
+  let scrollTop = $state(0);
+  /**
+   * Content-box width of the textarea. A classic (space-taking) scrollbar
+   * narrows the real text once the draft overflows; copying the measured
+   * width stops the mirror wrapping a character later than the textarea.
+   */
+  let contentWidth = $state<number | null>(null);
+
+  $effect(() => {
+    const node = el;
+    if (!node || typeof ResizeObserver === "undefined") return;
+    const sync = () => {
+      contentWidth = node.clientWidth;
+    };
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(node);
+    return () => observer.disconnect();
+  });
+
+  // The caret moving can scroll the textarea without a scroll event firing in
+  // every browser, so resync whenever the draft changes.
+  $effect(() => {
+    void value;
+    if (el) scrollTop = el.scrollTop;
+  });
+</script>
+
+<!-- The wrapper carries the background: the textarea itself has to be
+     transparent for the mirror underneath it to show through. -->
+<div class="relative w-full rounded-md bg-background">
+  <div
+    aria-hidden="true"
+    class="pointer-events-none absolute left-px top-px overflow-hidden whitespace-pre-wrap break-words border-transparent text-foreground {BOX}"
+    style={`height:calc(100% - 2px);${contentWidth === null ? "" : `width:${contentWidth}px;`}`}
+  >
+    <div style={`transform:translateY(${-scrollTop}px);`}>
+      {#each segments as segment, index (index)}{#if segment.did === null}{segment.text}{:else}<span
+            class="rounded-sm bg-primary/15 text-primary">{segment.text}</span
+          >{/if}{/each}<!--
+        A draft ending in a newline leaves an empty final line that collapses
+        in a block container, so the mirror would come up one line short of
+        the textarea. The zero-width space keeps that line box alive.
+      -->{#if value.endsWith("\n")}{"\u200b"}{/if}
+    </div>
+  </div>
+
+  <!-- block, not the default inline-block: an inline-level textarea sits on a
+       text baseline and leaves descender space below it, which made the
+       wrapper taller than the textarea and let the mirror show a line the
+       textarea had already clipped. -->
+  <textarea
+    bind:this={el}
+    bind:value
+    {placeholder}
+    {onkeydown}
+    rows={1}
+    oninput={() => oninput?.()}
+    onscroll={(e) => (scrollTop = e.currentTarget.scrollTop)}
+    class="relative block max-h-30 min-h-10 w-full resize-none overflow-y-auto rounded-md border-input bg-transparent text-transparent caret-foreground placeholder:text-muted-foreground selection:bg-primary/30 focus:outline-none focus:ring-1 focus:ring-ring {BOX}"
+  ></textarea>
+</div>

--- a/frontend/src/lib/mentions.test.ts
+++ b/frontend/src/lib/mentions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { serialize, humanize, mentionsMe } from "./mentions";
+import { serialize, humanize, mentionsMe, segmentDraft } from "./mentions";
 
 describe("mentions", () => {
   describe("serialize", () => {
@@ -166,5 +166,88 @@ describe("humanize escaping", () => {
     const out = humanize("@[did:key:zEvil]", () => "<img src=x onerror=alert(1)>");
     expect(out).not.toContain("<img");
     expect(out).toContain("&lt;img");
+  });
+});
+
+describe("segmentDraft", () => {
+  const alice = new Map([["Alice", "did:key:z6MkAlice"]]);
+
+  it("returns nothing for an empty draft", () => {
+    expect(segmentDraft("", alice)).toEqual([]);
+  });
+
+  it("returns one plain run when no name is recorded", () => {
+    expect(segmentDraft("@Alice hi", new Map())).toEqual([
+      { text: "@Alice hi", did: null },
+    ]);
+  });
+
+  it("tags a recorded mention and leaves the rest plain", () => {
+    expect(segmentDraft("Hey @Alice!", alice)).toEqual([
+      { text: "Hey ", did: null },
+      { text: "@Alice", did: "did:key:z6MkAlice" },
+      { text: "!", did: null },
+    ]);
+  });
+
+  it("leaves an unrecorded @name plain", () => {
+    const segments = segmentDraft("@Alice and @Charlie", alice);
+    expect(segments).toEqual([
+      { text: "@Alice", did: "did:key:z6MkAlice" },
+      { text: " and @Charlie", did: null },
+    ]);
+  });
+
+  it("does not tag a name that is only a prefix of the typed word", () => {
+    const segments = segmentDraft("@Alice-bot pinged", alice);
+    expect(segments).toEqual([{ text: "@Alice-bot pinged", did: null }]);
+  });
+
+  it("prefers the longest recorded name on a collision", () => {
+    const map = new Map([
+      ["Ana", "did:key:z6MkAna"],
+      ["Anna", "did:key:z6MkAnna"],
+    ]);
+    expect(segmentDraft("@Anna and @Ana", map)).toEqual([
+      { text: "@Anna", did: "did:key:z6MkAnna" },
+      { text: " and ", did: null },
+      { text: "@Ana", did: "did:key:z6MkAna" },
+    ]);
+  });
+
+  it("handles names containing spaces and regex metacharacters", () => {
+    const map = new Map([["A. (dev)", "did:key:z6MkDev"]]);
+    expect(segmentDraft("ping @A. (dev) now", map)).toEqual([
+      { text: "ping ", did: null },
+      { text: "@A. (dev)", did: "did:key:z6MkDev" },
+      { text: " now", did: null },
+    ]);
+  });
+
+  it("concatenating the segments reproduces the draft exactly", () => {
+    const map = new Map([
+      ["Alice", "did:key:z6MkAlice"],
+      ["Bob", "did:key:z6MkBob"],
+    ]);
+    const draft = "@Alice, ping @Bob about @Charlie\nthanks";
+    const joined = segmentDraft(draft, map)
+      .map((s) => s.text)
+      .join("");
+    expect(joined).toBe(draft);
+  });
+
+  it("agrees with serialize about what is a mention", () => {
+    const map = new Map([
+      ["Alice", "did:key:z6MkAlice"],
+      ["Bob", "did:key:z6MkBob"],
+    ]);
+    const draft = "@Alice @Alice-bot @Bob @Charlie";
+    const highlighted = segmentDraft(draft, map)
+      .filter((s) => s.did !== null)
+      .map((s) => s.text);
+    expect(highlighted).toEqual(["@Alice", "@Bob"]);
+    expect(serialize(draft, map)).toBe(
+      "@[did:key:z6MkAlice] @Alice-bot @[did:key:z6MkBob] @Charlie"
+    );
   });
 });

--- a/frontend/src/lib/mentions.ts
+++ b/frontend/src/lib/mentions.ts
@@ -6,9 +6,72 @@
  * are tamper-proof.
  */
 
+/** One run of draft text, tagged with the DID when it is a real mention. */
+export interface DraftSegment {
+  /** The text exactly as it appears in the draft (mentions keep their `@`). */
+  text: string;
+  /** DID for a recorded mention, `null` for plain text. */
+  did: string | null;
+}
+
+/**
+ * Split a draft into plain-text and mention runs.
+ *
+ * This is the single place that decides which `@Name` in a draft is a real
+ * mention. Both the wire serializer and the composer's highlight read it, so
+ * what the user sees highlighted is exactly what gets signed as `@[did]` -
+ * they cannot drift apart.
+ *
+ * Only names the user picked from the mention popup count. Hand-typed
+ * `@Charlie` stays literal text, and `@Alice-bot` does not match `Alice`.
+ *
+ * @param content The draft with human-readable names
+ * @param nameToDidMap Map from display names to DIDs
+ * @returns The draft split into consecutive segments (concatenating `text`
+ *   reproduces `content` exactly)
+ */
+export function segmentDraft(
+  content: string,
+  nameToDidMap: Map<string, string>
+): DraftSegment[] {
+  if (!content) return [];
+
+  // Longest name first: a JS alternation takes the first branch that matches
+  // at a position, so this order IS the collision precedence. With both "Ana"
+  // and "Anna" recorded, "@Anna" must not resolve to "Ana".
+  const names = Array.from(nameToDidMap.keys()).sort(
+    (a, b) => b.length - a.length
+  );
+  if (names.length === 0) return [{ text: content, did: null }];
+
+  // The trailing guard keeps "@Alice-bot" and "@Alices" literal.
+  const pattern = new RegExp(
+    `@(?:${names.map(escapeRegex).join("|")})(?![\\w-])`,
+    "g"
+  );
+
+  const segments: DraftSegment[] = [];
+  let cursor = 0;
+
+  for (const match of content.matchAll(pattern)) {
+    const did = nameToDidMap.get(match[0].slice(1));
+    if (did === undefined) continue;
+    if (match.index > cursor) {
+      segments.push({ text: content.slice(cursor, match.index), did: null });
+    }
+    segments.push({ text: match[0], did });
+    cursor = match.index + match[0].length;
+  }
+
+  if (cursor < content.length) {
+    segments.push({ text: content.slice(cursor), did: null });
+  }
+
+  return segments;
+}
+
 /**
  * Replace all recorded @Name mentions with @[did] tokens in content.
- * Processes names in longest-first order to avoid prefix collisions.
  * Unrecorded @something text is left untouched.
  *
  * @param content The message content with human-readable names
@@ -19,21 +82,11 @@ export function serialize(
   content: string,
   nameToDidMap: Map<string, string>
 ): string {
-  // Sort by name length descending to handle prefix collisions
-  // e.g., if both "Ana" and "Anna" are mentioned, replace "Anna" first
-  const entries = Array.from(nameToDidMap.entries()).sort(
-    (a, b) => b[0].length - a[0].length
-  );
-
-  let result = content;
-  for (const [name, did] of entries) {
-    // Match @Name (with word boundary to avoid partial matches)
-    // Use case-sensitive replacement since names are exact
-    const regex = new RegExp(`@${escapeRegex(name)}(?![\\w-])`, "g");
-    result = result.replace(regex, `@[${did}]`);
-  }
-
-  return result;
+  return segmentDraft(content, nameToDidMap)
+    .map((segment) =>
+      segment.did === null ? segment.text : `@[${segment.did}]`
+    )
+    .join("");
 }
 
 /**


### PR DESCRIPTION
> **Stacked on #4.** Base is `feat/composer-emoji-picker`, so the diff here is feature-only. Merge #4 first; GitHub will retarget this to `main` automatically.

## What

Picking someone from the mention popup left plain text in the composer — the highlight only appeared once the message was sent. There was no way to tell a real mention from an `@` typed by hand.

`MentionInput.svelte` now renders the draft with mention chips live, as you type.

## How

A `<textarea>` cannot style its own content, so the component draws a mirror div behind transparent text. Two invariants keep that honest:

1. **Geometry parity.** The mirror is only trustworthy while it shares every box and type metric with the textarea, so both read one `BOX` class constant. The chips carry colour and background only — a different font weight would shift glyph advance widths and slide the text out from under the caret.
2. **Truthful highlighting.** The highlight runs the *same tokenizer the wire serializer runs*. `segmentDraft` is now the single place that decides which `@Name` is a real mention, and `serialize` is built on top of it. So the chips mark exactly the text that will ship as a signed `@[did]` token — they cannot drift apart.

That second point is the reason for the `mentions.ts` refactor rather than a second regex in the component. Consequences, all covered by tests:

- A hand-typed `@Charlie` stays plain — only names picked from the popup are real mentions.
- `@Alice-bot` does not match a recorded `Alice`.
- Breaking a picked name un-highlights it immediately, which is accurate feedback rather than a bug.

`draftMentionMap` becomes a `SvelteMap`. A plain `Map` is not reactive, so a freshly picked mention would not highlight until the next keystroke.

## Three alignment traps

None of these would surface in review, because transparent text hides misalignment. I found them by setting the real textarea text to red and looking for ghosting:

1. **`textarea` is `inline-block`.** The new wrapper picked up baseline descender space and stood ~6px taller than the textarea. The mirror sized against the wrapper and rendered a line the textarea had already clipped. Fixed with `display:block` — verified `rootH == taH == 120`, `mirrorH == clientHeight == 118`.
2. **Scrollbar width.** A space-taking scrollbar narrows the real text once a draft overflows (measured 688 vs a 698 padding box), so the mirror wrapped a character later. The mirror now copies `textarea.clientWidth` via a `ResizeObserver`.
3. **Selection.** Selected text sits under the textarea's own selection background, which painted over the mirror as a solid block. The selection is translucent (`selection:bg-primary/30`) so the text stays legible.

## Verified in a browser

- Glyph-exact overlap of mirror and real text, including on a wrapped line, at `scrollTop: 40`, and at both clip bounds.
- Scroll sync tracks the textarea.
- Selection stays readable.
- Placeholder still shows (`::placeholder` colour is opaque while the text colour is transparent).

## Verification

- `pnpm check` — 0 errors, 0 warnings
- `pnpm test` — 217 passed (9 new `segmentDraft` tests)
- `pnpm build` — green

`serialize` keeps its existing tests green, including the `Ana`/`Anna` prefix-collision and `@Alice-bot` cases, plus a new test asserting the highlight and the serializer agree on the same draft.

## Notes for the reviewer

- `pr-28` moves from the textarea into `MentionInput`'s `BOX`. It reserves room for the icon buttons the caller overlays on the right — widen it if a fourth button lands.
- The name -> DID association still lives only in the in-memory `draftMentionMap`, keyed by display name, so two peers sharing a display name still collide. Pre-existing; not touched here.
- Not exercised end-to-end in the running app: the relay is Go and `proxy.golang.org` is unreachable from my network, so I could not join a room. The component was verified through a temporary Vite harness page, then deleted. The `ChatView` wiring is typechecked but not clicked through — worth a manual pass with a relay up.
