### PR TITLE
fix: the call context menu survives fullscreen

### DIFF
--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -1433,6 +1433,62 @@ import { cn } from "$lib/utils";
     </button>
       {/snippet}
     </Tip>
+
+    <!-- The menu belongs inside the panel. The panel is the element handed to
+         requestFullscreen, and only the fullscreen element's own subtree is
+         painted - a menu rendered as its sibling exists in the DOM but is
+         invisible for as long as the call is fullscreen, however high its
+         z-index. -->
+    {#if peerMenu}
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <div
+        role="menu"
+        tabindex="-1"
+        class="fixed z-50 w-56 rounded-md border border-border bg-popover py-1 shadow-xl font-mono"
+        style="top: {peerMenu.y}px; left: {peerMenu.x}px"
+        onkeydown={() => {}}
+        onclick={(e) => e.stopPropagation()}
+        oncontextmenu={(e) => e.preventDefault()}
+      >
+        <p class="truncate px-3 pb-1 pt-0.5 text-xs text-muted-foreground">
+          {peerMenu.label}
+        </p>
+
+        <button
+          type="button"
+          class="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted"
+          onclick={dmFromPeerMenu}
+        >
+          <MessageSquare class="size-4" />
+          Message
+        </button>
+
+        <div class="mt-1 border-t border-border px-3 pb-2 pt-2">
+          <div class="flex items-center justify-between pb-1.5">
+            <span class="text-xs text-muted-foreground">Volume</span>
+            <span
+              class="text-xs tabular-nums {peerVolumeSlider <= 0
+                ? 'text-destructive'
+                : 'text-primary'}">{peerVolumePercent}</span
+            >
+          </div>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={peerVolumeSlider}
+            aria-label={`Volume for ${peerMenu.label}`}
+            oninput={(e) => onPeerVolume(Number(e.currentTarget.value))}
+            class="h-1 w-full cursor-pointer appearance-none rounded-full accent-primary"
+            style={`background: linear-gradient(to right, var(--primary) ${peerVolumeSlider}%, var(--muted) ${peerVolumeSlider}%)`}
+          />
+          <p class="pt-1 text-[10px] text-muted-foreground">
+            Only changes what you hear
+          </p>
+        </div>
+      </div>
+    {/if}
   </div>
 {/if}
 
@@ -1442,57 +1498,6 @@ import { cn } from "$lib/utils";
     if (e.key === "Escape") closePeerMenu();
   }}
 />
-
-{#if peerMenu}
-  <!-- svelte-ignore a11y_click_events_have_key_events -->
-  <div
-    role="menu"
-    tabindex="-1"
-    class="fixed z-50 w-56 rounded-md border border-border bg-popover py-1 shadow-xl font-mono"
-    style="top: {peerMenu.y}px; left: {peerMenu.x}px"
-    onkeydown={() => {}}
-    onclick={(e) => e.stopPropagation()}
-    oncontextmenu={(e) => e.preventDefault()}
-  >
-    <p class="truncate px-3 pb-1 pt-0.5 text-xs text-muted-foreground">
-      {peerMenu.label}
-    </p>
-
-    <button
-      type="button"
-      class="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted"
-      onclick={dmFromPeerMenu}
-    >
-      <MessageSquare class="size-4" />
-      Message
-    </button>
-
-    <div class="mt-1 border-t border-border px-3 pb-2 pt-2">
-      <div class="flex items-center justify-between pb-1.5">
-        <span class="text-xs text-muted-foreground">Volume</span>
-        <span
-          class="text-xs tabular-nums {peerVolumeSlider <= 0
-            ? 'text-destructive'
-            : 'text-primary'}">{peerVolumePercent}</span
-        >
-      </div>
-      <input
-        type="range"
-        min="0"
-        max="100"
-        step="1"
-        value={peerVolumeSlider}
-        aria-label={`Volume for ${peerMenu.label}`}
-        oninput={(e) => onPeerVolume(Number(e.currentTarget.value))}
-        class="h-1 w-full cursor-pointer appearance-none rounded-full accent-primary"
-        style={`background: linear-gradient(to right, var(--primary) ${peerVolumeSlider}%, var(--muted) ${peerVolumeSlider}%)`}
-      />
-      <p class="pt-1 text-[10px] text-muted-foreground">
-        Only changes what you hear
-      </p>
-    </div>
-  </div>
-{/if}
 
 <style>
   /* Connecting tiles: a pronounced opacity wave - Tailwind's pulse was too


### PR DESCRIPTION
## The bug

Right-clicking a tile while the call is fullscreen appears to do nothing. The menu *is* opening — `peerMenu` flips and the volume slider is in the DOM — it simply cannot be seen.

`toggleFullscreen` hands **the panel** to `requestFullscreen` (`VoiceVideoCallView.svelte:761`), and the browser paints only the fullscreen element's own subtree. The menu was rendered as a **sibling** of that panel — the panel's `</div>` closed at `:1436`, the menu started at `:1446` — so while the call was fullscreen it was excluded from the render entirely. No `z-index` can rescue that; `z-50` was already higher than everything around it.

## The fix

Move the menu inside the panel. That is the whole change; the rest of the diff is the block relocating.

A fixed-position child of a fullscreen element still measures against the viewport, and no ancestor of the panel establishes a containing block for fixed positioning, so the existing clamped coordinates keep working in both states.

## Proof

I could not join a real call (the relay is Go and `proxy.golang.org` is unreachable from my network), so I reproduced the two arrangements on a page: one panel, two identically positioned `position: fixed; z-index: 50` menus — one a child of the panel, one a sibling — and put the panel into real fullscreen with a genuine user gesture.

With `document.fullscreenElement === panel`:

| menu | `elementFromPoint` at its centre | painted |
| --- | --- | --- |
| child of panel | `child-menu` | yes |
| sibling of panel | `panel` | **no** |

Both had identical rects (`[x, 120, 242, 34.5]`) and the same `z-index`. The only difference was DOM parentage. A screenshot in fullscreen shows only the child.

## Verification

- `pnpm check` — 0 errors, 0 warnings
- `pnpm test` — 208 passed
- `pnpm build` — green

## Notes

- Behaviour outside fullscreen is unchanged.
- Worth shipping on its own: right now the menu is unreachable for anyone in a fullscreen call.
- #7 builds a second menu on this same panel, so it depends on this relocation.

