### PR TITLE
feat: collapse the sidebar to a rail, put the chat beside the call

### DIFF
--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -38,7 +38,7 @@
   } from "$lib/storage";
   import { MessageType } from "$lib/types/message";
   import { loadProfile } from "$lib/profile.svelte";
-import { displayPrefs } from "$lib/display-prefs.svelte";
+  import { displayPrefs, setSidebarCollapsed } from "$lib/display-prefs.svelte";
   import { consumeLatestSharedPayload } from "$lib/share-target";
   import { humanizeMentions } from "$lib/mentions";
   import ReloadPrompt from "./ReloadPrompt.svelte";
@@ -756,7 +756,18 @@ import { displayPrefs } from "$lib/display-prefs.svelte";
   });
 </script>
 
-<svelte:window onpopstate={handlePopState} />
+<svelte:window
+  onpopstate={handlePopState}
+  onkeydown={(e) => {
+    // Cmd/Ctrl+B collapses the room sidebar. The composer is a plain
+    // textarea, so there is no native bold to steal.
+    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+    if (e.key.toLowerCase() !== "b") return;
+    if (isMobile) return;
+    e.preventDefault();
+    setSidebarCollapsed(!displayPrefs.sidebarCollapsed);
+  }}
+/>
 
 <QueryClientProvider client={queryClient}>
   {#if identityStore.loading && !identityStore.keypair}
@@ -808,6 +819,9 @@ import { displayPrefs } from "$lib/display-prefs.svelte";
         onRemoveRoom={handleRemoveRoom}
         onOpenCreateJoin={openCreateJoin}
         onOpenPhonebook={() => (phonebookOpen = true)}
+        collapsed={!isMobile && displayPrefs.sidebarCollapsed}
+        onToggleCollapsed={() =>
+          setSidebarCollapsed(!displayPrefs.sidebarCollapsed)}
       />
       <div class="flex-1 min-w-0">
         {#if activeRoomCode}

--- a/frontend/src/lib/components/CallStatus.svelte
+++ b/frontend/src/lib/components/CallStatus.svelte
@@ -16,6 +16,12 @@
   import { cn } from "$lib/utils";
   import type { TransportStatus } from "$lib/transport/types";
 
+  interface Props {
+    /** Icon-rail layout: one icon, the whole status in a tooltip. */
+    collapsed?: boolean;
+  }
+  let { collapsed = false }: Props = $props();
+
   type CallQuality = "connecting" | "p2p" | "relayed" | "degraded" | "failed";
 
   let quality = $state<CallQuality>("connecting");
@@ -168,51 +174,76 @@
 </script>
 
 {#if transportState.inCall}
-  <div
-    class={cn(
-      "flex items-center justify-between px-3 py-2 rounded-lg border text-sm mb-2",
-      config.bg,
-      config.border
-    )}
-  >
-    <div class="flex items-center gap-2">
-      <div class={cn("relative", config.color)}>
-        <StatusIcon class="size-5" />
-        {#if quality === "failed"}
-          <div class="absolute inset-0 flex items-center justify-center">
-            <div class="w-0.5 h-3 bg-current rotate-45"></div>
-          </div>
+  {#if collapsed}
+    <Tip
+      text={`${config.label} · ${transportState.roomName || "Voice"}${
+        quality === "relayed" ? " · relayed" : ""
+      }${deafened ? " · deafened" : ""}`}
+      side="right"
+    >
+      {#snippet children(props)}
+        <div
+          {...props}
+          class={cn(
+            "mx-2 mb-2 flex items-center justify-center rounded-lg border py-2",
+            config.bg,
+            config.border
+          )}
+        >
+          <StatusIcon class={cn("size-5", config.color)} />
+        </div>
+      {/snippet}
+    </Tip>
+  {:else}
+    <div
+      class={cn(
+        "flex items-center justify-between px-3 py-2 rounded-lg border text-sm mb-2",
+        config.bg,
+        config.border
+      )}
+    >
+      <div class="flex items-center gap-2">
+        <div class={cn("relative", config.color)}>
+          <StatusIcon class="size-5" />
+          {#if quality === "failed"}
+            <div class="absolute inset-0 flex items-center justify-center">
+              <div class="w-0.5 h-3 bg-current rotate-45"></div>
+            </div>
+          {/if}
+        </div>
+        <div class="flex flex-col">
+          <span class={cn("font-medium text-xs", config.color)}
+            >{config.label}</span
+          >
+          <span class="text-[10px] text-gray-400"
+            >{transportState.roomName || "Voice"}</span
+          >
+        </div>
+      </div>
+
+      <div class="flex items-center gap-1">
+        {#if quality === "relayed"}
+          <Tip text="Connected via TURN relay">
+            {#snippet children(props)}
+              <div
+                {...props}
+                class="p-1.5 rounded bg-yellow-500/10 text-yellow-400"
+              >
+                <Radio class="size-4" />
+              </div>
+            {/snippet}
+          </Tip>
+        {/if}
+        {#if deafened}
+          <Tip text="Deafened">
+            {#snippet children(props)}
+              <div {...props} class="p-1.5 rounded bg-red-500/20 text-red-400">
+                <Headphones class="size-4" />
+              </div>
+            {/snippet}
+          </Tip>
         {/if}
       </div>
-      <div class="flex flex-col">
-        <span class={cn("font-medium text-xs", config.color)}
-          >{config.label}</span
-        >
-        <span class="text-[10px] text-gray-400"
-          >{transportState.roomName || "Voice"}</span
-        >
-      </div>
     </div>
-
-    <div class="flex items-center gap-1">
-      {#if quality === "relayed"}
-        <Tip text="Connected via TURN relay">
-          {#snippet children(props)}
-            <div {...props} class="p-1.5 rounded bg-yellow-500/10 text-yellow-400">
-              <Radio class="size-4" />
-            </div>
-          {/snippet}
-        </Tip>
-      {/if}
-      {#if deafened}
-        <Tip text="Deafened">
-          {#snippet children(props)}
-            <div {...props} class="p-1.5 rounded bg-red-500/20 text-red-400">
-              <Headphones class="size-4" />
-            </div>
-          {/snippet}
-        </Tip>
-      {/if}
-    </div>
-  </div>
+  {/if}
 {/if}

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -1192,6 +1192,19 @@
     transportState.chatMode === "dm" && !!transportState.activeDmPeerId
   );
 
+  // Desktop only: below sm there is no room for two columns, and the call
+  // stage would squeeze the messages to nothing.
+  const callBeside = $derived(displayPrefs.callChatBeside && !isMobile);
+  // Opening the user list widens the chat column instead of crushing the
+  // message text into what the w-60 aside leaves behind.
+  const chatColClass = $derived(
+    callBeside && showCallView
+      ? `shrink-0 border-l border-border ${
+          showUserList && !isDmChat ? "w-156" : "w-96"
+        }`
+      : "flex-1"
+  );
+
   const dmPeerInPhonebook = $derived.by(() => {
     const peerId = transportState.activeDmPeerId;
     if (!peerId) return false;
@@ -1387,10 +1400,6 @@
     </div>
   </header>
 
-  {#if showCallView}
-    <VoiceVideoCallView />
-  {/if}
-
   {#if connecting}
     <div
       class="absolute inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center"
@@ -1403,6 +1412,29 @@
       </div>
     </div>
   {/if}
+
+  <!-- Call and chat. Stacked by default, side by side when callBeside. The
+       wrapper is always mounted: a remount would rebind messagesEl and drop
+       the scroll position on every switch. -->
+  <div
+    class="flex flex-1 min-h-0 overflow-hidden {callBeside
+      ? 'flex-row'
+      : 'flex-col'}"
+  >
+    {#if showCallView}
+      <!-- Own column: the call view also renders an error banner, which must
+           not become a second column of the row. -->
+      <div
+        class="flex min-h-0 flex-col {callBeside
+          ? 'min-w-0 flex-1'
+          : 'shrink-0'}"
+      >
+        <VoiceVideoCallView beside={callBeside} />
+      </div>
+    {/if}
+    <div
+      class="flex min-h-0 min-w-0 flex-col overflow-hidden {chatColClass}"
+    >
 
   <div class="flex flex-1 min-h-0 overflow-hidden">
     <div
@@ -1973,6 +2005,8 @@
         <Send class="size-4" />
       </Button>
     </form>
+  </div>
+    </div>
   </div>
 </div>
 

--- a/frontend/src/lib/components/RoomSidebar.svelte
+++ b/frontend/src/lib/components/RoomSidebar.svelte
@@ -3,6 +3,8 @@
   import {
     Hash,
     MessageSquare,
+    PanelLeftClose,
+    PanelLeftOpen,
     Plus,
     Trash2,
     User,
@@ -48,6 +50,9 @@
     roomActivity: Map<string, number>;
     isOpen?: boolean;
     onClose?: () => void;
+    /** Desktop icon rail. Ignored below sm, where the sidebar is a slide-over. */
+    collapsed?: boolean;
+    onToggleCollapsed?: () => void;
     onSelectRoom: (code: string) => void;
     onSelectDm: (peerId: string) => void;
     onAddToPhonebook: (peerId: string) => void;
@@ -73,6 +78,8 @@
     roomActivity,
     isOpen = false,
     onClose,
+    collapsed = false,
+    onToggleCollapsed,
     onSelectRoom,
     onSelectDm,
     onAddToPhonebook,
@@ -196,15 +203,47 @@
 <aside
   class="flex h-dvh w-68 shrink-0 flex-col border-r border-sidebar-border bg-sidebar
       fixed inset-y-0 left-0 z-40 transition-transform duration-200
-      sm:static sm:translate-x-0 sm:z-auto sm:transition-none
+      sm:static sm:translate-x-0 sm:z-auto sm:transition-[width] sm:duration-200
+      {collapsed ? 'sm:w-14' : 'sm:w-68'}
       {isOpen ? 'translate-x-0' : '-translate-x-full'}"
 >
   <!-- Header - h-13 is shared with the chat header (ChatView) so they align. -->
+  {#if collapsed}
+    <div
+      class="flex h-13 shrink-0 items-center justify-center border-b border-sidebar-border"
+    >
+      <Tip text="Expand sidebar" side="right">
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={onToggleCollapsed}
+            aria-label="Expand sidebar"
+            class="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-foreground cursor-pointer"
+          >
+            <PanelLeftOpen class="size-4" />
+          </button>
+        {/snippet}
+      </Tip>
+    </div>
+  {:else}
   <div
     class="flex h-13 items-center justify-between border-b border-sidebar-border px-3 shrink-0"
   >
     <div class="flex items-center gap-2">
-      <MessageSquare class="size-4 text-muted-foreground" />
+      <Tip text="Collapse sidebar" side="bottom">
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={onToggleCollapsed}
+            aria-label="Collapse sidebar"
+            class="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-foreground cursor-pointer"
+          >
+            <PanelLeftClose class="size-4" />
+          </button>
+        {/snippet}
+      </Tip>
       <span
         class="text-xs font-semibold text-muted-foreground mt-0.75 uppercase tracking-wider font-mono"
       >
@@ -241,7 +280,80 @@
       </Tip>
     {/if}
   </div>
+  {/if}
 
+  {#if collapsed}
+    <div class="flex flex-col items-center gap-1 px-2 pt-1.5">
+      <Tip text="Rooms" side="right">
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={() => onChangeTab("rooms")}
+            aria-label="Rooms"
+            class="inline-flex size-9 items-center justify-center rounded-md transition-colors cursor-pointer {activeTab ===
+            'rooms'
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:bg-accent/50'}"
+          >
+            <Hash class="size-4" />
+          </button>
+        {/snippet}
+      </Tip>
+      <Tip text="DMs" side="right">
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={() => onChangeTab("users")}
+            aria-label="DMs"
+            class="relative inline-flex size-9 items-center justify-center rounded-md transition-colors cursor-pointer {activeTab ===
+            'users'
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:bg-accent/50'}"
+          >
+            <MessageSquare class="size-4" />
+            {#if dmUnreadTotal > 0}
+              <span
+                class="absolute -top-1 -right-1 inline-flex min-w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] font-bold items-center justify-center px-1 tabular-nums"
+              >
+                {Math.min(dmUnreadTotal, 99)}
+              </span>
+            {/if}
+          </button>
+        {/snippet}
+      </Tip>
+      {#if activeTab === "rooms" && onOpenCreateJoin && shouldShowAddBtn}
+        <Tip text="Create or join a room" side="right">
+          {#snippet children(props)}
+            <button
+              {...props}
+              type="button"
+              onclick={onOpenCreateJoin}
+              aria-label="Create or join room"
+              class="inline-flex size-9 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-accent/40 text-muted-foreground hover:text-foreground hover:bg-sidebar-accent cursor-pointer"
+            >
+              <Plus class="size-4" />
+            </button>
+          {/snippet}
+        </Tip>
+      {:else if activeTab === "users" && onOpenPhonebook}
+        <Tip text="Phonebook" side="right">
+          {#snippet children(props)}
+            <button
+              {...props}
+              type="button"
+              onclick={onOpenPhonebook}
+              aria-label="Open phonebook"
+              class="inline-flex size-9 items-center justify-center rounded-md border border-sidebar-border bg-sidebar-accent/40 text-muted-foreground hover:text-foreground hover:bg-sidebar-accent cursor-pointer"
+            >
+              <Users class="size-4" />
+            </button>
+          {/snippet}
+        </Tip>
+      {/if}
+    </div>
+  {:else}
   <div class="grid grid-cols-2 gap-1 px-2 pt-1.5">
     <button
       type="button"
@@ -271,9 +383,92 @@
       {/if}
     </button>
   </div>
+  {/if}
 
   <!-- Room list -->
   <div class="flex-1 overflow-y-auto p-1.5">
+    {#if collapsed}
+      {#if activeTab === "rooms"}
+        {#each rooms as room (room.roomCode)}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <div
+            role="none"
+            oncontextmenu={(e) => openContextMenu(e, room.roomCode)}
+          >
+            <Tip text={room.name || room.roomCode} side="right">
+              {#snippet children(props)}
+                <button
+                  {...props}
+                  type="button"
+                  onclick={() => onSelectRoom(room.roomCode)}
+                  class="relative mb-1 flex w-full items-center justify-center rounded-md p-2 transition-colors cursor-pointer hover:bg-accent/50 {activeRoomCode ===
+                  room.roomCode
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground'}"
+                >
+                  <Hash class="size-4 shrink-0 opacity-70" />
+                  {#if (unreadCounts.get(room.roomCode) ?? 0) > 0 && activeRoomCode !== room.roomCode}
+                    <span
+                      class="absolute -top-0.5 -right-0.5 min-w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] font-bold flex items-center justify-center px-1 tabular-nums"
+                    >
+                      {Math.min(unreadCounts.get(room.roomCode) ?? 0, 99)}
+                    </span>
+                  {/if}
+                </button>
+              {/snippet}
+            </Tip>
+          </div>
+        {/each}
+      {:else}
+        {#each phonebook as entry (entry.peerId)}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <div
+            role="none"
+            oncontextmenu={(e) =>
+              openDmContextMenu(e, entry.peerId, !!entry.inPhonebook)}
+          >
+            <Tip text={entry.nickname} side="right">
+              {#snippet children(props)}
+                <button
+                  {...props}
+                  type="button"
+                  onclick={() => onSelectDm(entry.peerId)}
+                  class="relative mb-1 flex w-full items-center justify-center rounded-md p-2 transition-colors cursor-pointer hover:bg-accent/50 {activeDmPeerId ===
+                  entry.peerId
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground'}"
+                >
+                  <div
+                    class="flex size-6 shrink-0 items-center justify-center rounded-full bg-secondary text-secondary-foreground text-xs font-semibold font-mono"
+                    style={colorForPeer(entry.peerId)
+                      ? `color: ${colorForPeer(entry.peerId)}`
+                      : ""}
+                  >
+                    {#if entry.avatarUrl}
+                      <GifImage
+                        src={entry.avatarUrl}
+                        alt={entry.nickname}
+                        class="size-full rounded-full object-cover"
+                        animate="hover"
+                      />
+                    {:else}
+                      {(entry.nickname || "?").charAt(0).toUpperCase()}
+                    {/if}
+                  </div>
+                  {#if (dmUnreadCounts.get(entry.peerId) ?? 0) > 0}
+                    <span
+                      class="absolute -top-0.5 -right-0.5 min-w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] font-bold flex items-center justify-center px-1 tabular-nums"
+                    >
+                      {Math.min(dmUnreadCounts.get(entry.peerId) ?? 0, 99)}
+                    </span>
+                  {/if}
+                </button>
+              {/snippet}
+            </Tip>
+          </div>
+        {/each}
+      {/if}
+    {:else}
     {#if activeTab === "rooms" && rooms.length === 0}
       <div
         class="flex h-full flex-col items-center justify-center gap-2 text-sm text-muted-foreground"
@@ -391,11 +586,14 @@
         </div>
       {/each}
     {/if}
+    {/if}
   </div>
 
-  <PluginWidgetSlots />
-  <CallStatus />
-  <SidebarControls />
+  {#if !collapsed}
+    <PluginWidgetSlots />
+  {/if}
+  <CallStatus {collapsed} />
+  <SidebarControls {collapsed} />
 </aside>
 
 {#if contextMenu && activeTab === "rooms"}

--- a/frontend/src/lib/components/SidebarControls.svelte
+++ b/frontend/src/lib/components/SidebarControls.svelte
@@ -27,6 +27,15 @@
   import DeviceSyncDialog from "$lib/components/DeviceSyncDialog.svelte";
   import { toggleDeafen } from "$lib/transport/call.svelte";
 
+  interface Props {
+    /** Icon-rail layout: no name, no status text, controls stacked. */
+    collapsed?: boolean;
+  }
+  let { collapsed = false }: Props = $props();
+
+  // In a column the buttons must grow across, not along, the axis.
+  const mediaBtnWidth = $derived(collapsed ? "w-full" : "flex-1");
+
   let avatarDialogOpen = $state(false);
   let audioSettingsOpen = $state(false);
 
@@ -70,7 +79,9 @@
   <!-- In-call media row -->
   {#if transportState.inCall}
     <div
-      class="flex items-center justify-stretch gap-1 px-2 py-2 border-b border-sidebar-border"
+      class="flex px-2 py-2 border-b border-sidebar-border {collapsed
+        ? 'flex-col gap-1'
+        : 'items-center justify-stretch gap-1'}"
     >
       <Tip
         text={transportState.cameraOff ? "Turn on camera" : "Turn off camera"}
@@ -83,7 +94,7 @@
         aria-label={transportState.cameraOff
           ? "Turn on camera"
           : "Turn off camera"}
-        class="flex flex-1 items-center justify-center rounded-md h-9 cursor-pointer transition-colors
+        class="flex {mediaBtnWidth} items-center justify-center rounded-md h-9 cursor-pointer transition-colors
           {transportState.cameraOff
           ? 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
           : 'bg-destructive/20 text-destructive hover:bg-destructive/30'}"
@@ -112,7 +123,7 @@
         aria-label={transportState.screenSharing
           ? "Stop screen share"
           : "Share screen"}
-        class="flex flex-1 items-center justify-center rounded-md h-9 cursor-pointer transition-colors
+        class="flex {mediaBtnWidth} items-center justify-center rounded-md h-9 cursor-pointer transition-colors
           {transportState.screenSharing
           ? 'bg-destructive/20 text-destructive hover:bg-destructive/30'
           : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'}"
@@ -133,7 +144,7 @@
         type="button"
         onclick={leaveCall}
         aria-label="Leave call"
-        class="flex flex-1 items-center justify-center rounded-md h-9 cursor-pointer transition-colors bg-destructive/20 text-destructive hover:bg-destructive/30"
+        class="flex {mediaBtnWidth} items-center justify-center rounded-md h-9 cursor-pointer transition-colors bg-destructive/20 text-destructive hover:bg-destructive/30"
       >
         <PhoneOff class="size-4" />
       </button>
@@ -142,8 +153,12 @@
     </div>
   {/if}
 
-  <div class="flex gap-2 px-2 py-4.25 w-full justify-between">
-    <div class="flex items-center gap-2">
+  <div
+    class="flex w-full {collapsed
+      ? 'flex-col items-center gap-2 px-1 py-3'
+      : 'gap-2 px-2 py-4.25 justify-between'}"
+  >
+    <div class="flex items-center gap-2 {collapsed ? 'flex-col' : ''}">
       <div class="relative">
         <button
           type="button"
@@ -173,21 +188,28 @@
       </div>
 
       <!-- Name + status -->
-      <div class="flex flex-col gap-1.5 mt-1 w-full">
-        <div
-          class="truncate w-26 text-xs font-semibold text-foreground font-mono leading-tight"
-        >
-          {profileStore.nickname}
+      {#if !collapsed}
+        <div class="flex flex-col gap-1.5 mt-1 w-full">
+          <div
+            class="truncate w-26 text-xs font-semibold text-foreground font-mono leading-tight"
+          >
+            {profileStore.nickname}
+          </div>
+          <div class="text-xs text-muted-foreground font-mono leading-tight">
+            {transportState.relayConnected ? "Connected" : "Connecting..."}
+          </div>
         </div>
-        <div class="text-xs text-muted-foreground font-mono leading-tight">
-          {transportState.relayConnected ? "Connected" : "Connecting..."}
-        </div>
-      </div>
+      {/if}
     </div>
 
     <!-- Mic, Deafen, Settings -->
-    <div class="flex items-center gap-0.5 justify-end">
-      <Tip text={transportState.muted ? "Unmute" : "Mute"}>
+    <div
+      class="flex items-center gap-0.5 {collapsed ? 'flex-col' : 'justify-end'}"
+    >
+      <Tip
+        text={transportState.muted ? "Unmute" : "Mute"}
+        side={collapsed ? "right" : "top"}
+      >
         {#snippet children(props)}
       <button
         {...props}
@@ -208,7 +230,10 @@
         {/snippet}
       </Tip>
 
-      <Tip text={transportState.deafened ? "Undeafen" : "Deafen"}>
+      <Tip
+        text={transportState.deafened ? "Undeafen" : "Deafen"}
+        side={collapsed ? "right" : "top"}
+      >
         {#snippet children(props)}
       <button
         {...props}
@@ -229,7 +254,7 @@
         {/snippet}
       </Tip>
 
-      <Tip text="Settings">
+      <Tip text="Settings" side={collapsed ? "right" : "top"}>
         {#snippet children(props)}
       <button
         {...props}

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -58,9 +58,9 @@
     Puzzle,
     X as XIcon,
   } from "@lucide/svelte";
-  import { Check, MessageSquare, MonitorIcon, SlidersHorizontal, Users as UsersIcon, UserX } from "@lucide/svelte";
+  import { Check, Columns2, MessageSquare, MonitorIcon, Rows2, SlidersHorizontal, Users as UsersIcon, UserX } from "@lucide/svelte";
 import { profileStore, loadProfile } from "$lib/profile.svelte";
-import { displayPrefs } from "$lib/display-prefs.svelte";
+import { displayPrefs, setCallChatBeside } from "$lib/display-prefs.svelte";
 import { cn } from "$lib/utils";
 import { callTilesState, refreshCallTiles } from "$lib/plugins/call-tiles.svelte";
 import { getManifest } from "$lib/plugins/registry";
@@ -68,6 +68,12 @@ import { onCardStateChange } from "$lib/plugins/state.svelte";
 import PluginCallTileView from "./PluginCallTileView.svelte";
 import PluginIcon from "$lib/plugins/PluginIcon.svelte";
   import { Slider } from "./ui/slider";
+
+  interface Props {
+    /** The call stage is a column beside the chat, not a band above it. */
+    beside?: boolean;
+  }
+  let { beside = false }: Props = $props();
 
   $effect(() => {
     loadProfile();
@@ -208,7 +214,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
   function openViewMenu(e: MouseEvent): void {
     e.preventDefault();
     peerMenu = null;
-    viewMenu = clampMenu(e, 224, 248);
+    viewMenu = clampMenu(e, 224, 320);
   }
 
   function closeMenus(): void {
@@ -792,12 +798,14 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
     return kept.length ? kept : tiles;
   });
 
+  // Container queries, not viewport ones: beside the chat the stage is a
+  // narrow column inside a wide window.
   const gridCols = $derived.by(() => {
     const n = visibleTiles.length;
     if (n <= 1) return "grid-cols-1";
-    if (n <= 3) return "grid-cols-1 sm:grid-cols-2";
-    if (n <= 7) return "grid-cols-2 sm:grid-cols-3";
-    return "grid-cols-2 sm:grid-cols-4";
+    if (n <= 3) return "grid-cols-1 @md:grid-cols-2";
+    if (n <= 7) return "grid-cols-1 @xs:grid-cols-2 @xl:grid-cols-3";
+    return "grid-cols-1 @xs:grid-cols-2 @xl:grid-cols-4";
   });
 
   const rowClass = $derived.by(() => {
@@ -809,6 +817,14 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
     const cols = n <= 1 ? 1 : n <= 4 ? 2 : n <= 9 ? 3 : 4;
     const rows = Math.ceil(n / cols);
     return rows <= 1 ? "h-[35vh]" : "h-[45vh]";
+  });
+
+  // rowClass is viewport-height based and only means anything stacked. Beside
+  // the chat the panel just fills its row.
+  const panelSizeClass = $derived.by(() => {
+    if (isFullscreen) return "h-screen";
+    if (beside) return "min-h-0 flex-1";
+    return `shrink-0 border-b border-border ${rowClass}`;
   });
 
   // ── Focus ─────────────────────────────────────────────────────────────────
@@ -1261,10 +1277,13 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
   <!-- render nothing -->
 {:else if othersInCallNotUs}
   <div
-    class="flex flex-col border-b border-border shrink-0 h-[12vh] sm:h-[16vh] pb-14 relative bg-background"
+    class="flex flex-col relative pb-14 bg-background
+      {beside
+      ? 'min-h-0 flex-1'
+      : 'h-[12vh] sm:h-[16vh] shrink-0 border-b border-border'}"
   >
     <div class="flex-1 flex items-center justify-center">
-      <div class="flex items-center gap-1">
+      <div class="flex flex-wrap items-center justify-center gap-1">
         {#each [...callPeerIds] as peerId (peerId)}
           {@const label = getPeerLabel(peerId)}
           {@const avatar = getPeerAvatar(peerId)}
@@ -1340,8 +1359,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
     role="group"
     aria-label="Call"
     oncontextmenu={openViewMenu}
-    class="flex flex-col border-b border-border relative shrink-0 bg-background
-      {isFullscreen ? 'h-screen' : rowClass}
+    class="flex flex-col relative bg-background {panelSizeClass}
       {!isFullscreen && !hasActiveVideo ? 'pb-14' : ''}"
   >
     <!-- Always-mounted remote audio elements -->
@@ -1352,7 +1370,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
     {/each}
 
     <!-- Tile area -->
-    <div class="relative flex-1 min-h-0 overflow-hidden p-1.5">
+    <div class="@container relative flex-1 min-h-0 overflow-hidden p-1.5">
       {#if focusedTile}
         <div class="flex h-full gap-1.5">
           <div class="flex-1 min-w-0">
@@ -1369,7 +1387,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
           </div>
           {#if thumbnailTiles.length > 0}
             <div
-              class="flex flex-col gap-1 overflow-y-auto w-20 sm:w-28 shrink-0"
+              class="flex flex-col gap-1 overflow-y-auto w-20 @xl:w-28 shrink-0"
             >
               {#each thumbnailTiles as tile (tile.id)}
                 {@render callTile(
@@ -1590,7 +1608,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
           </div>
         </div>
       {:else}
-        <div class="flex items-center gap-4">
+        <div class="flex max-w-full flex-wrap items-center justify-center gap-4">
           <div
             class={cn(
               "flex gap-2",
@@ -1858,6 +1876,27 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
             <Check class="size-3.5 shrink-0 text-primary" />
           {/if}
         </button>
+        {#if !isSmallScreen}
+          <div class="my-1 border-t border-border"></div>
+          <p class="truncate px-3 pb-1 pt-0.5 text-xs text-muted-foreground">
+            Layout
+          </p>
+          {#each [{ beside: false, label: "Chat below", icon: Rows2 }, { beside: true, label: "Chat beside", icon: Columns2 }] as opt (opt.label)}
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked={displayPrefs.callChatBeside === opt.beside}
+              class="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted"
+              onclick={() => setCallChatBeside(opt.beside)}
+            >
+              <opt.icon class="size-4 shrink-0" />
+              <span class="flex-1 truncate text-left">{opt.label}</span>
+              {#if displayPrefs.callChatBeside === opt.beside}
+                <Check class="size-3.5 shrink-0 text-primary" />
+              {/if}
+            </button>
+          {/each}
+        {/if}
       </div>
     {/if}
 

--- a/frontend/src/lib/components/settings/AppSettings.svelte
+++ b/frontend/src/lib/components/settings/AppSettings.svelte
@@ -9,8 +9,10 @@ import {
 import { mediaPrefs, setGifAutoplay } from "$lib/media-prefs.svelte";
 import {
   displayPrefs,
+  setCallChatBeside,
   setItalicOwnName,
   setShowPeerNicknameColors,
+  setSidebarCollapsed,
 } from "$lib/display-prefs.svelte";
 </script>
 
@@ -113,6 +115,32 @@ import {
     <Switch
       checked={displayPrefs.showPeerNicknameColors}
       onCheckedChange={(checked) => setShowPeerNicknameColors(checked)}
+    />
+  </div>
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex flex-col gap-1 min-w-0">
+      <span class="text-xs font-mono">Collapse the sidebar</span>
+      <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+        Shrinks the room list to an icon rail. Cmd or Ctrl + B toggles it too.
+        Pinned plugin widgets hide while it is collapsed. No effect on a phone.
+      </span>
+    </div>
+    <Switch
+      checked={displayPrefs.sidebarCollapsed}
+      onCheckedChange={(checked) => setSidebarCollapsed(checked)}
+    />
+  </div>
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex flex-col gap-1 min-w-0">
+      <span class="text-xs font-mono">Chat beside the call</span>
+      <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+        In a call the video sits on the left and the chat is a column on the
+        right, instead of a band above the messages. No effect on a phone.
+      </span>
+    </div>
+    <Switch
+      checked={displayPrefs.callChatBeside}
+      onCheckedChange={(checked) => setCallChatBeside(checked)}
     />
   </div>
 </div>

--- a/frontend/src/lib/display-prefs.svelte.ts
+++ b/frontend/src/lib/display-prefs.svelte.ts
@@ -5,6 +5,8 @@
 
 const ITALIC_KEY = "awful:italic-own-name:v1";
 const PEER_COLORS_KEY = "awful:show-peer-colors:v1";
+const SIDEBAR_COLLAPSED_KEY = "awful:sidebar-collapsed:v1";
+const CALL_CHAT_BESIDE_KEY = "awful:call-chat-beside:v1";
 
 function readStored(key: string, defaultValue: boolean): boolean {
   if (typeof localStorage === "undefined") return defaultValue;
@@ -17,6 +19,10 @@ export const displayPrefs = $state({
   italicOwnName: readStored(ITALIC_KEY, false),
   /** Show other people's custom colors; off keeps every remote name default. */
   showPeerNicknameColors: readStored(PEER_COLORS_KEY, true),
+  /** Desktop only: the room sidebar shows as an icon rail. */
+  sidebarCollapsed: readStored(SIDEBAR_COLLAPSED_KEY, false),
+  /** Desktop only: in a call the chat sits beside the stage, not below it. */
+  callChatBeside: readStored(CALL_CHAT_BESIDE_KEY, false),
 });
 
 export function setItalicOwnName(on: boolean): void {
@@ -37,6 +43,24 @@ export function setShowPeerNicknameColors(on: boolean): void {
   }
 }
 
+export function setSidebarCollapsed(on: boolean): void {
+  displayPrefs.sidebarCollapsed = on;
+  try {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
+export function setCallChatBeside(on: boolean): void {
+  displayPrefs.callChatBeside = on;
+  try {
+    localStorage.setItem(CALL_CHAT_BESIDE_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
 // A second tab flipping a switch should be reflected here, not fought.
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (e) => {
@@ -44,5 +68,9 @@ if (typeof window !== "undefined") {
       displayPrefs.italicOwnName = e.newValue === "1";
     if (e.key === PEER_COLORS_KEY)
       displayPrefs.showPeerNicknameColors = e.newValue === "1";
+    if (e.key === SIDEBAR_COLLAPSED_KEY)
+      displayPrefs.sidebarCollapsed = e.newValue === "1";
+    if (e.key === CALL_CHAT_BESIDE_KEY)
+      displayPrefs.callChatBeside = e.newValue === "1";
   });
 }


### PR DESCRIPTION
Two device-local layout preferences. Both are off by default, both persist per device through `displayPrefs`, and both are ignored below the `sm` breakpoint, where the sidebar is already a slide-over and there is no room for two columns.

## Before and after

| | Before | After |
| --- | --- | --- |
| **Sidebar** | ![Sidebar expanded at 272px](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sidebar-collapse-call-sideways/sidebar-before.png) | ![Sidebar collapsed to a 56px icon rail](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sidebar-collapse-call-sideways/sidebar-after.png) |
| **Call layout** | ![Call stage above the messages](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sidebar-collapse-call-sideways/call-before.png) | ![Call stage on the left, chat a 384px column on the right](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sidebar-collapse-call-sideways/call-after.png) |

Both features default to off, so the before frames are this same build with the toggles off. They are identical to `main`.

## What changed

**The room sidebar collapses to a 56px icon rail.** Rooms and DMs become icon buttons whose tooltip carries the name, the tab strip becomes a vertical icon strip, and the call status plus the profile controls stack. `Cmd/Ctrl+B` toggles it, as does a switch in Settings > App > Appearance. Pinned plugin widgets are a hover-fan of labelled rows with no honest 56px form, so the rail hides them.

**In a call the chat can sit beside the stage.** The stage flexes on the left and the chat is a fixed 384px column on the right, with its own composer. Opening the user list widens that column to 624px rather than crushing the message text into what the 240px aside leaves behind. The call panel and the chat column share one border. Switch it from the call's right-click view menu (Layout) or from Settings.

The wrapper that holds the two is always mounted and only swaps its flex direction. Two `{#if}` arms would remount the message list and throw away the scroll position on every switch.

**The call tile grid now uses container queries.** The grid classes were viewport `sm:` variants, so a stage that is a narrow column inside a wide window read the window width and laid out too many columns. The tile area is now a `@container` and the grid measures itself. This also corrects the stacked layout, where the stage has never been as wide as the viewport either. The desktop control bar and the pre-join avatar row gained `flex-wrap`, which is inert at full width but stops them spilling out of a narrow stage.

## Verification

`npm run check` clean (4927 files, 0 errors). `npm run test` green (248 tests, 30 files).

Driven in a real browser at 1440x900 and 375x812:

- Collapse: the aside goes 272px to 56px, the room icon's tooltip renders to the right of the rail, plugin slots disappear, and mic/deafen/settings stay clickable. Survives a reload, and a second tab follows through the `storage` listener. Every rail control measures inside 56px with zero overflowing children.
- Collapse is desktop-only: at 375px with the pref stored on, the aside is the full-width slide-over and `Cmd/Ctrl+B` is inert.
- Chat below stays as it was: panel `h-[35vh]` with one tile, `h-[45vh]` with three, messages directly under it.
- Chat beside: stage 784px, chat column exactly 384px on the right, chat column `border-left: 1px` and panel `border-bottom: 0px`, so a single divider.
- User list in beside mode: the column goes 384px to 624px and the message text keeps its 383px.
- Container query: at a constant 1200px viewport the grid is one column when the stage is 304px and two columns at 544px and 928px. Viewport media queries cannot produce that.
- Beside is desktop-only: at 375px with the pref on, the messages sit below the panel.
- Both Settings switches reflect live state and change the layout without a reload.

The screenshots were taken against a local dev server. This environment cannot resolve `proxy.golang.org` or `go.googlesource.com`, so the Go relay could not be built and no libp2p transport was available. The call state was therefore driven through the same `transportState` fields `_joinCall` sets on success, with a real mic stream from a fake capture device. The network transport is untouched by this change.

The four screenshots live on `pr-media/sidebar-collapse-call-sideways`, a root commit that is never merged, so no image lands on `main`.