### PR TITLE
feat: crop the profile picture and banner, GIFs included

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,8 @@
     "@scure/bip39": "^2.0.1",
     "@tanstack/svelte-query": "^6.1.12",
     "emoji-picker-element": "^1.29.1",
+    "gifenc": "^1.0.3",
+    "gifuct-js": "^2.1.2",
     "html5-qrcode": "^2.3.8",
     "idb": "^8.0.3",
     "libp2p": "~3.1.7",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -59,6 +59,12 @@ importers:
       emoji-picker-element:
         specifier: ^1.29.1
         version: 1.29.1
+      gifenc:
+        specifier: ^1.0.3
+        version: 1.0.3
+      gifuct-js:
+        specifier: ^2.1.2
+        version: 2.1.2
       html5-qrcode:
         specifier: ^2.3.8
         version: 2.3.8
@@ -773,9 +779,6 @@ packages:
     resolution: {integrity: sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==}
     engines: {node: '>=6'}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
-
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -953,98 +956,47 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    cpu: [x64]
-    os: [linux]
-
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
+    libc: [musl]
 
   '@internationalized/date@3.12.0':
     resolution: {integrity: sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==}
@@ -1390,66 +1342,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1598,24 +1563,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1863,7 +1832,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   asap@2.0.6:
-    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    resolution: {integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=}
 
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
@@ -2250,7 +2219,7 @@ packages:
     resolution: {integrity: sha512-3D+EY5nsRhqnOwDxveBv5T8wGo4DEvYxjDtPGmdOX+gfr5gE92c2RC0w2wa+xEefm07QuVqqcF3nZJUZ92l/og==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
@@ -2434,7 +2403,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -2454,7 +2423,7 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    resolution: {integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=}
     engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
@@ -2546,7 +2515,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    resolution: {integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=}
     engines: {node: '>= 0.6'}
 
   event-target-shim@5.0.1:
@@ -2658,7 +2627,7 @@ packages:
     resolution: {integrity: sha512-Ji7fEnMdZDGbS5oXElpRJsn9jPvBR8h/037D3bzreNmS8809cISq/2D9//JbA/TaZmkkN8cmecXwmQHmM+NHhg==}
 
   fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
     engines: {node: '>= 0.6'}
 
   fs-chunk-store@3.0.1:
@@ -2672,7 +2641,7 @@ packages:
     engines: {node: '>=10'}
 
   fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -2731,18 +2700,22 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  gifenc@1.0.3:
+    resolution: {integrity: sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==}
+
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -2865,12 +2838,11 @@ packages:
     resolution: {integrity: sha512-1bHBna0hCa6arRXicu91IiL9RvvkbNYLVq+mzWdaLGZC3hXvX4doh8e1dLhMKez5siu63CYgO5NrGJbRX5lbPA==}
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
     engines: {node: '>=0.8.19'}
 
   inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2984,7 +2956,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   is-module@1.0.0:
-    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
 
   is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
@@ -3007,7 +2979,7 @@ packages:
     engines: {node: '>=0.12.0'}
 
   is-obj@1.0.1:
-    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
+    resolution: {integrity: sha1-PkcprB9f3gJc19g6iW2rn09n2w8=}
     engines: {node: '>=0.10.0'}
 
   is-reference@3.0.3:
@@ -3018,7 +2990,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   is-regexp@1.0.0:
-    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
+    resolution: {integrity: sha1-/S2INUXEa6xaYz57mgnof6LLUGk=}
     engines: {node: '>=0.10.0'}
 
   is-set@2.0.3:
@@ -3068,7 +3040,7 @@ packages:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
 
   isomorphic-timers-promises@1.0.1:
     resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
@@ -3194,6 +3166,9 @@ packages:
   join-async-iterator@1.1.1:
     resolution: {integrity: sha512-ATse+nuNeKZ9K1y27LKdvPe/GCe9R/u9dw9vI248e+vILeRK3IcJP4JUPAlSmKRCDK0cKhEwfmiw4Skqx7UnGQ==}
 
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3285,24 +3260,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3338,13 +3317,13 @@ packages:
     engines: {node: '>=10'}
 
   lodash.debounce@4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+    resolution: {integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=}
 
   lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+    resolution: {integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=}
 
   lodash.throttle@4.1.1:
-    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+    resolution: {integrity: sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -3564,7 +3543,7 @@ packages:
     engines: {node: '>=4'}
 
   ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -3619,7 +3598,7 @@ packages:
     hasBin: true
 
   node-int64@0.4.0:
-    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3659,7 +3638,7 @@ packages:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    resolution: {integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=}
     engines: {node: '>= 0.8'}
 
   on-finished@2.4.1:
@@ -3759,7 +3738,7 @@ packages:
     engines: {node: '>=8'}
 
   path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
     engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
@@ -4063,7 +4042,6 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   ripemd160@2.0.3:
@@ -4152,7 +4130,7 @@ packages:
     engines: {node: '>= 0.8.0'}
 
   serialize-error@2.1.0:
-    resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
+    resolution: {integrity: sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=}
     engines: {node: '>=0.10.0'}
 
   serialize-javascript@6.0.2:
@@ -4279,7 +4257,7 @@ packages:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
   source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    resolution: {integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=}
     engines: {node: '>=0.10.0'}
 
   source-map@0.6.1:
@@ -4289,11 +4267,9 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
-    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
-    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -4308,7 +4284,7 @@ packages:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
 
   sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -4325,7 +4301,7 @@ packages:
     engines: {node: '>=6'}
 
   statuses@1.5.0:
-    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
     engines: {node: '>= 0.6'}
 
   statuses@2.0.2:
@@ -4565,7 +4541,7 @@ packages:
     resolution: {integrity: sha512-JLSOyvQVLI6JTWqioY4vFL0JkEUKQcaHQsU3loxkCvPTSttw8ePs2tFwsP4XIjw99Fz8EdOzt/4faykcbnPbCQ==}
 
   tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+    resolution: {integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4700,7 +4676,7 @@ packages:
     resolution: {integrity: sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==}
 
   unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
     engines: {node: '>= 0.8'}
 
   upath@1.2.0:
@@ -4740,7 +4716,7 @@ packages:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
 
   utp-native@2.5.3:
@@ -5835,11 +5811,6 @@ snapshots:
       '@leichtgewicht/ip-codec': 2.0.5
       utf8-codec: 1.0.0
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -5930,78 +5901,27 @@ snapshots:
   '@floating-ui/utils@0.2.11': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-linux-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
     optional: true
 
   '@img/sharp-linux-arm@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-s390x@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
     optional: true
 
   '@img/sharp-linuxmusl-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-    optional: true
-
-  '@img/sharp-wasm32@0.33.5':
-    dependencies:
-      '@emnapi/runtime': 1.9.2
-    optional: true
-
-  '@img/sharp-win32-ia32@0.33.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@internationalized/date@3.12.0':
@@ -8158,6 +8078,12 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
+  gifenc@1.0.3: {}
+
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
+
   github-from-package@0.0.0: {}
 
   glob@11.1.0:
@@ -8692,6 +8618,8 @@ snapshots:
   jiti@2.6.1: {}
 
   join-async-iterator@1.1.1: {}
+
+  js-binary-schema-parser@2.0.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -9954,23 +9882,12 @@ snapshots:
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
       '@img/sharp-linux-arm': 0.33.5
       '@img/sharp-linux-arm64': 0.33.5
       '@img/sharp-linux-s390x': 0.33.5
       '@img/sharp-linux-x64': 0.33.5
       '@img/sharp-linuxmusl-arm64': 0.33.5
       '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
 
   shebang-command@2.0.0:
     dependencies:

--- a/frontend/public/third-party-notices.txt
+++ b/frontend/public/third-party-notices.txt
@@ -1847,6 +1847,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 --------------------------------------------------------------------------------
+gifuct-js (MIT)
+js-binary-schema-parser (MIT)
+--------------------------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Matt Way
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
 readable-stream (MIT)
 string_decoder (MIT)
 --------------------------------------------------------------------------------
@@ -3998,6 +4025,33 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
+fsevents (MIT)
+--------------------------------------------------------------------------------
+
+MIT License
+-----------
+
+Copyright (C) 2010-2020 by Philipp Dunkel, Ben Noordhuis, Elan Shankar, Paul Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--------------------------------------------------------------------------------
 gensync (MIT)
 --------------------------------------------------------------------------------
 
@@ -4034,6 +4088,31 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+gifenc (MIT)
+--------------------------------------------------------------------------------
+
+The MIT License (MIT)
+Copyright (c) 2017 Matt DesLauriers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
 hashlru (MIT)

--- a/frontend/src/lib/components/AvatarPickerDialog.svelte
+++ b/frontend/src/lib/components/AvatarPickerDialog.svelte
@@ -7,7 +7,7 @@
   import { Drawer, DrawerContent } from "$lib/components/ui/drawer";
   import { saveAvatar, saveBanner, profileStore } from "$lib/profile.svelte";
   import ImageCropper from "$lib/components/ImageCropper.svelte";
-  import { cropImageToDataUrl, type CropRect, type CropTarget } from "$lib/crop";
+  import { cropImageToDataUrl, type CropView, type CropTarget } from "$lib/crop";
   import {
     searchGifs,
     getTrendingGifs,
@@ -43,12 +43,12 @@
   let cropping = $state(false);
   let cropBusy = $state(false);
 
-  async function applyCrop(rect: CropRect) {
+  async function applyCrop(view: CropView) {
     if (!preview || cropBusy) return;
     cropBusy = true;
     error = undefined;
     try {
-      preview = await cropImageToDataUrl(preview, rect, cropTarget);
+      preview = await cropImageToDataUrl(preview, view, cropTarget);
       cropping = false;
     } catch {
       error =

--- a/frontend/src/lib/components/AvatarPickerDialog.svelte
+++ b/frontend/src/lib/components/AvatarPickerDialog.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { createInfiniteQuery } from "@tanstack/svelte-query";
-  import { X, Upload, Search, Link } from "@lucide/svelte";
+  import { X, Upload, Search, Link, Crop } from "@lucide/svelte";
   import { Dialog as DialogPrimitive } from "bits-ui";
   import Button from "$lib/components/ui/button/button.svelte";
   import Input from "$lib/components/ui/input/input.svelte";
   import { Drawer, DrawerContent } from "$lib/components/ui/drawer";
   import { saveAvatar, saveBanner, profileStore } from "$lib/profile.svelte";
+  import ImageCropper from "$lib/components/ImageCropper.svelte";
+  import { cropImageToDataUrl, type CropRect, type CropTarget } from "$lib/crop";
   import {
     searchGifs,
     getTrendingGifs,
@@ -29,6 +31,33 @@
   let error = $state<string | undefined>(undefined);
 
   const MAX_AVATAR_BYTES = $derived(isBanner ? 1_000_000 : 512 * 1024);
+
+  // Crop editor state. The output aspect and the byte budget differ per target:
+  // a square avatar shown as a circle, a wide 3:1 banner. The budget keeps the
+  // re-encoded data URL under the profile-meta limit after base64 inflation.
+  const cropTarget = $derived<CropTarget & { aspect: number; circle: boolean }>(
+    isBanner
+      ? { outWidth: 720, outHeight: 240, maxBytes: 700_000, aspect: 3, circle: false }
+      : { outWidth: 256, outHeight: 256, maxBytes: 400_000, aspect: 1, circle: true }
+  );
+  let cropping = $state(false);
+  let cropBusy = $state(false);
+
+  async function applyCrop(rect: CropRect) {
+    if (!preview || cropBusy) return;
+    cropBusy = true;
+    error = undefined;
+    try {
+      preview = await cropImageToDataUrl(preview, rect, cropTarget);
+      cropping = false;
+    } catch {
+      error =
+        "This image can't be cropped here. Try the Upload tab with a saved copy.";
+      cropping = false;
+    } finally {
+      cropBusy = false;
+    }
+  }
 
   $effect(() => {
     if (open) {
@@ -205,6 +234,8 @@
     searchQuery = "";
     debouncedQuery = "";
     activeTab = "upload";
+    cropping = false;
+    cropBusy = false;
     error = undefined;
     onClose();
   }
@@ -250,6 +281,19 @@
     </button>
   </div>
 
+  {#if cropping && preview}
+    <div class="h-[24rem]">
+      <ImageCropper
+        src={preview}
+        aspect={cropTarget.aspect}
+        circle={cropTarget.circle}
+        busy={cropBusy}
+        onCancel={() => (cropping = false)}
+        onApply={applyCrop}
+      />
+    </div>
+  {:else}
+
   <div class="flex justify-center pt-4 pb-2 shrink-0">
     <div class="relative group">
       <div
@@ -284,6 +328,19 @@
       {/if}
     </div>
   </div>
+
+  {#if preview}
+    <div class="flex justify-center pb-2 shrink-0">
+      <button
+        type="button"
+        onclick={() => (cropping = true)}
+        class="flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-mono text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <Crop class="size-3.5" />
+        Crop
+      </button>
+    </div>
+  {/if}
 
   <!-- Tabs -->
   <div class="flex px-4 gap-1 shrink-0 border-b border-border">
@@ -448,6 +505,7 @@
     <Button size="sm" onclick={handleSave}
             disabled={saving}>Save</Button>
   </div>
+  {/if}
 {/snippet}
 
 {#if isMobile}

--- a/frontend/src/lib/components/ImageCropper.svelte
+++ b/frontend/src/lib/components/ImageCropper.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  /**
+   * Interactive crop editor. The image sits behind a fixed crop frame; the
+   * user pans it by dragging and zooms with the slider or the wheel. Apply
+   * emits a normalized crop rectangle - the heavy pixel work happens in the
+   * caller through `cropImageToDataUrl`.
+   *
+   * An animated GIF keeps playing while it is framed, so the user sees exactly
+   * what they crop.
+   */
+  import { RotateCcw } from "@lucide/svelte";
+  import Button from "$lib/components/ui/button/button.svelte";
+  import type { CropRect } from "$lib/crop";
+  import { coverBaseScale, clampOffset, rectFromView } from "$lib/crop-geometry";
+
+  interface Props {
+    src: string;
+    /** Output aspect ratio, width / height. */
+    aspect: number;
+    /** Show the frame as a circle (avatar) instead of a rectangle (banner). */
+    circle?: boolean;
+    onCancel: () => void;
+    onApply: (rect: CropRect) => void;
+    /** True while the caller re-encodes the crop. */
+    busy?: boolean;
+  }
+
+  let { src, aspect, circle = false, onCancel, onApply, busy = false }: Props =
+    $props();
+
+  // Frame footprint on screen, fitted into the dialog content area.
+  const MAX_W = 288;
+  const MAX_H = 232;
+  const frameW = $derived(
+    Math.round(Math.min(MAX_W, MAX_H * aspect))
+  );
+  const frameH = $derived(Math.round(frameW / aspect));
+
+  const MAX_ZOOM = 4;
+  let natW = $state(0);
+  let natH = $state(0);
+  let baseScale = $state(1);
+  let zoom = $state(1);
+  let offsetX = $state(0);
+  let offsetY = $state(0);
+  let loadError = $state(false);
+
+  const scale = $derived(baseScale * zoom);
+  const ready = $derived(natW > 0 && natH > 0);
+
+  function recenter() {
+    const dispW = natW * scale;
+    const dispH = natH * scale;
+    offsetX = clampOffset((frameW - dispW) / 2, dispW, frameW);
+    offsetY = clampOffset((frameH - dispH) / 2, dispH, frameH);
+  }
+
+  function reset() {
+    if (!ready) return;
+    baseScale = coverBaseScale(natW, natH, frameW, frameH);
+    zoom = 1;
+    recenter();
+  }
+
+  function onImgLoad(e: Event) {
+    const img = e.target as HTMLImageElement;
+    natW = img.naturalWidth;
+    natH = img.naturalHeight;
+    loadError = natW === 0 || natH === 0;
+    if (!loadError) reset();
+  }
+
+  // Keep the frame centre fixed while zooming so the image does not jump.
+  function applyZoom(nextZoom: number) {
+    const clamped = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
+    const oldScale = scale;
+    const newScale = baseScale * clamped;
+    const focalX = (frameW / 2 - offsetX) / oldScale;
+    const focalY = (frameH / 2 - offsetY) / oldScale;
+    zoom = clamped;
+    const dispW = natW * newScale;
+    const dispH = natH * newScale;
+    offsetX = clampOffset(frameW / 2 - focalX * newScale, dispW, frameW);
+    offsetY = clampOffset(frameH / 2 - focalY * newScale, dispH, frameH);
+  }
+
+  function onWheel(e: WheelEvent) {
+    e.preventDefault();
+    applyZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
+  }
+
+  let dragging = false;
+  let lastX = 0;
+  let lastY = 0;
+
+  function onPointerDown(e: PointerEvent) {
+    if (!ready) return;
+    dragging = true;
+    lastX = e.clientX;
+    lastY = e.clientY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging) return;
+    const dispW = natW * scale;
+    const dispH = natH * scale;
+    offsetX = clampOffset(offsetX + (e.clientX - lastX), dispW, frameW);
+    offsetY = clampOffset(offsetY + (e.clientY - lastY), dispH, frameH);
+    lastX = e.clientX;
+    lastY = e.clientY;
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    dragging = false;
+    (e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId);
+  }
+
+  function apply() {
+    if (!ready) return;
+    onApply(
+      rectFromView({ natW, natH, frameW, frameH, scale, offsetX, offsetY })
+    );
+  }
+</script>
+
+<div class="flex h-full flex-col items-center gap-3 p-4">
+  {#if loadError}
+    <div
+      class="flex flex-1 items-center justify-center text-sm text-destructive font-mono"
+    >
+      This image could not be loaded for cropping.
+    </div>
+  {:else}
+    <div class="flex flex-1 items-center justify-center">
+      <div
+        role="application"
+        aria-label="Drag to reposition"
+        class="relative touch-none overflow-hidden bg-muted select-none {circle
+          ? 'rounded-full'
+          : 'rounded-lg'} ring-2 ring-primary/60 {ready
+          ? 'cursor-grab active:cursor-grabbing'
+          : ''}"
+        style="width:{frameW}px;height:{frameH}px;"
+        onpointerdown={onPointerDown}
+        onpointermove={onPointerMove}
+        onpointerup={onPointerUp}
+        onpointercancel={onPointerUp}
+        onwheel={onWheel}
+      >
+        <img
+          {src}
+          alt="Crop preview"
+          draggable="false"
+          onload={onImgLoad}
+          onerror={() => (loadError = true)}
+          class="pointer-events-none absolute left-0 top-0 max-w-none origin-top-left"
+          style="width:{natW}px;height:{natH}px;transform:translate({offsetX}px,{offsetY}px) scale({scale});"
+        />
+      </div>
+    </div>
+
+    <div class="flex w-full items-center gap-3 px-1">
+      <span class="text-xs font-mono text-muted-foreground select-none">Zoom</span>
+      <input
+        type="range"
+        min="1"
+        max={MAX_ZOOM}
+        step="0.01"
+        value={zoom}
+        oninput={(e) => applyZoom(Number((e.target as HTMLInputElement).value))}
+        disabled={!ready}
+        aria-label="Zoom"
+        class="h-1.5 flex-1 cursor-pointer accent-primary"
+      />
+      <button
+        type="button"
+        onclick={reset}
+        disabled={!ready}
+        aria-label="Reset crop"
+        class="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-40"
+      >
+        <RotateCcw class="size-4" />
+      </button>
+    </div>
+  {/if}
+
+  <div class="flex w-full items-center justify-end gap-2">
+    <Button variant="ghost" size="sm" onclick={onCancel} disabled={busy}>
+      Cancel
+    </Button>
+    <Button size="sm" onclick={apply} disabled={!ready || busy}>
+      {busy ? "Cropping..." : "Apply crop"}
+    </Button>
+  </div>
+</div>

--- a/frontend/src/lib/components/ImageCropper.svelte
+++ b/frontend/src/lib/components/ImageCropper.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   /**
-   * Interactive crop editor. The image sits behind a fixed crop frame; the
-   * user pans it by dragging and zooms with the slider or the wheel. Apply
-   * emits a normalized crop rectangle - the heavy pixel work happens in the
-   * caller through `cropImageToDataUrl`.
+   * Interactive crop editor. The image sits behind a fixed crop frame; the user
+   * pans it by dragging, zooms with the slider or the wheel, and rotates it with
+   * the rotation slider. Apply emits a {@link CropView} - the heavy pixel work
+   * happens in the caller through `cropImageToDataUrl`.
    *
    * An animated GIF keeps playing while it is framed, so the user sees exactly
    * what they crop.
    */
-  import { RotateCcw } from "@lucide/svelte";
+  import { RotateCcw, RotateCw } from "@lucide/svelte";
   import Button from "$lib/components/ui/button/button.svelte";
-  import type { CropRect } from "$lib/crop";
-  import { coverBaseScale, clampOffset, rectFromView } from "$lib/crop-geometry";
+  import type { CropView } from "$lib/crop";
+  import { coverScale, clampPan } from "$lib/crop-geometry";
 
   interface Props {
     src: string;
@@ -20,7 +20,7 @@
     /** Show the frame as a circle (avatar) instead of a rectangle (banner). */
     circle?: boolean;
     onCancel: () => void;
-    onApply: (rect: CropRect) => void;
+    onApply: (view: CropView) => void;
     /** True while the caller re-encodes the crop. */
     busy?: boolean;
   }
@@ -31,35 +31,42 @@
   // Frame footprint on screen, fitted into the dialog content area.
   const MAX_W = 288;
   const MAX_H = 232;
-  const frameW = $derived(
-    Math.round(Math.min(MAX_W, MAX_H * aspect))
-  );
+  const frameW = $derived(Math.round(Math.min(MAX_W, MAX_H * aspect)));
   const frameH = $derived(Math.round(frameW / aspect));
 
   const MAX_ZOOM = 4;
   let natW = $state(0);
   let natH = $state(0);
-  let baseScale = $state(1);
   let zoom = $state(1);
-  let offsetX = $state(0);
-  let offsetY = $state(0);
+  let angleDeg = $state(0);
+  let panX = $state(0);
+  let panY = $state(0);
   let loadError = $state(false);
 
+  const baseScale = $derived(coverScale(natW, natH, frameW, frameH, angleDeg));
   const scale = $derived(baseScale * zoom);
   const ready = $derived(natW > 0 && natH > 0);
 
-  function recenter() {
-    const dispW = natW * scale;
-    const dispH = natH * scale;
-    offsetX = clampOffset((frameW - dispW) / 2, dispW, frameW);
-    offsetY = clampOffset((frameH - dispH) / 2, dispH, frameH);
+  function currentView(): CropView {
+    return { natW, natH, frameW, frameH, scale, panX, panY, angleDeg };
   }
 
-  function reset() {
+  // Whenever the scale or the angle changes, the pan can fall outside the
+  // covered range - pull it back in. clampPan is idempotent, so this settles.
+  $effect(() => {
     if (!ready) return;
-    baseScale = coverBaseScale(natW, natH, frameW, frameH);
+    const c = clampPan(currentView());
+    if (Math.abs(c.panX - panX) > 1e-6 || Math.abs(c.panY - panY) > 1e-6) {
+      panX = c.panX;
+      panY = c.panY;
+    }
+  });
+
+  function reset() {
     zoom = 1;
-    recenter();
+    angleDeg = 0;
+    panX = 0;
+    panY = 0;
   }
 
   function onImgLoad(e: Event) {
@@ -70,23 +77,20 @@
     if (!loadError) reset();
   }
 
-  // Keep the frame centre fixed while zooming so the image does not jump.
-  function applyZoom(nextZoom: number) {
-    const clamped = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
-    const oldScale = scale;
-    const newScale = baseScale * clamped;
-    const focalX = (frameW / 2 - offsetX) / oldScale;
-    const focalY = (frameH / 2 - offsetY) / oldScale;
-    zoom = clamped;
-    const dispW = natW * newScale;
-    const dispH = natH * newScale;
-    offsetX = clampOffset(frameW / 2 - focalX * newScale, dispW, frameW);
-    offsetY = clampOffset(frameH / 2 - focalY * newScale, dispH, frameH);
+  function applyZoom(next: number) {
+    zoom = Math.min(MAX_ZOOM, Math.max(1, next));
   }
 
   function onWheel(e: WheelEvent) {
     e.preventDefault();
     applyZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1));
+  }
+
+  function rotateBy(delta: number) {
+    let a = (angleDeg + delta) % 360;
+    if (a > 180) a -= 360;
+    if (a < -180) a += 360;
+    angleDeg = a;
   }
 
   let dragging = false;
@@ -103,10 +107,13 @@
 
   function onPointerMove(e: PointerEvent) {
     if (!dragging) return;
-    const dispW = natW * scale;
-    const dispH = natH * scale;
-    offsetX = clampOffset(offsetX + (e.clientX - lastX), dispW, frameW);
-    offsetY = clampOffset(offsetY + (e.clientY - lastY), dispH, frameH);
+    const c = clampPan({
+      ...currentView(),
+      panX: panX + (e.clientX - lastX),
+      panY: panY + (e.clientY - lastY),
+    });
+    panX = c.panX;
+    panY = c.panY;
     lastX = e.clientX;
     lastY = e.clientY;
   }
@@ -118,9 +125,7 @@
 
   function apply() {
     if (!ready) return;
-    onApply(
-      rectFromView({ natW, natH, frameW, frameH, scale, offsetX, offsetY })
-    );
+    onApply(currentView());
   }
 </script>
 
@@ -154,14 +159,18 @@
           draggable="false"
           onload={onImgLoad}
           onerror={() => (loadError = true)}
-          class="pointer-events-none absolute left-0 top-0 max-w-none origin-top-left"
-          style="width:{natW}px;height:{natH}px;transform:translate({offsetX}px,{offsetY}px) scale({scale});"
+          class="pointer-events-none absolute max-w-none"
+          style="width:{natW}px;height:{natH}px;left:{(frameW - natW) /
+            2}px;top:{(frameH - natH) /
+            2}px;transform-origin:center;transform:translate({panX}px,{panY}px) rotate({angleDeg}deg) scale({scale});"
         />
       </div>
     </div>
 
     <div class="flex w-full items-center gap-3 px-1">
-      <span class="text-xs font-mono text-muted-foreground select-none">Zoom</span>
+      <span class="w-12 text-xs font-mono text-muted-foreground select-none"
+        >Zoom</span
+      >
       <input
         type="range"
         min="1"
@@ -181,6 +190,32 @@
         class="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-40"
       >
         <RotateCcw class="size-4" />
+      </button>
+    </div>
+
+    <div class="flex w-full items-center gap-3 px-1">
+      <span class="w-12 text-xs font-mono text-muted-foreground select-none"
+        >Rotate</span
+      >
+      <input
+        type="range"
+        min="-180"
+        max="180"
+        step="1"
+        value={angleDeg}
+        oninput={(e) => (angleDeg = Number((e.target as HTMLInputElement).value))}
+        disabled={!ready}
+        aria-label="Rotate"
+        class="h-1.5 flex-1 cursor-pointer accent-primary"
+      />
+      <button
+        type="button"
+        onclick={() => rotateBy(90)}
+        disabled={!ready}
+        aria-label="Rotate 90 degrees"
+        class="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors disabled:opacity-40"
+      >
+        <RotateCw class="size-4" />
       </button>
     </div>
   {/if}

--- a/frontend/src/lib/crop-geometry.test.ts
+++ b/frontend/src/lib/crop-geometry.test.ts
@@ -1,72 +1,76 @@
 import { describe, it, expect } from "vitest";
-import {
-  coverBaseScale,
-  clampOffset,
-  rectFromView,
-} from "./crop-geometry";
+import { coverScale, clampPan } from "./crop-geometry";
+import type { CropView } from "./crop";
 
-describe("coverBaseScale", () => {
-  it("picks the larger ratio so the frame is always covered", () => {
+function view(partial: Partial<CropView>): CropView {
+  return {
+    natW: 100,
+    natH: 100,
+    frameW: 100,
+    frameH: 100,
+    scale: 1,
+    panX: 0,
+    panY: 0,
+    angleDeg: 0,
+    ...partial,
+  };
+}
+
+describe("coverScale", () => {
+  it("matches the plain cover ratio at angle 0", () => {
     // A wide frame over a square image is bound by the width ratio.
-    expect(coverBaseScale(100, 100, 50, 25)).toBe(0.5);
+    expect(coverScale(100, 100, 50, 25, 0)).toBe(0.5);
     // A tall frame over a wide image is bound by the height ratio.
-    expect(coverBaseScale(200, 100, 50, 80)).toBe(0.8);
+    expect(coverScale(200, 100, 50, 80, 0)).toBeCloseTo(0.8, 10);
+  });
+
+  it("is unchanged by a 90 degree turn of a square frame", () => {
+    // A square frame over a square image needs the same scale at 0 and 90.
+    expect(coverScale(100, 100, 80, 80, 90)).toBeCloseTo(0.8, 10);
+  });
+
+  it("needs a larger scale at 45 degrees", () => {
+    const at0 = coverScale(100, 100, 100, 100, 0);
+    const at45 = coverScale(100, 100, 100, 100, 45);
+    expect(at0).toBe(1);
+    // sqrt(2) more room is needed to keep the frame covered when turned 45.
+    expect(at45).toBeCloseTo(Math.SQRT2, 6);
   });
 
   it("returns 1 for degenerate sizes", () => {
-    expect(coverBaseScale(0, 100, 50, 50)).toBe(1);
+    expect(coverScale(0, 100, 50, 50, 0)).toBe(1);
   });
 });
 
-describe("clampOffset", () => {
+describe("clampPan", () => {
   it("keeps a larger image from uncovering the frame", () => {
-    // disp 200, frame 100 -> offset allowed in [-100, 0]
-    expect(clampOffset(10, 200, 100)).toBe(0);
-    expect(clampOffset(-40, 200, 100)).toBe(-40);
-    expect(clampOffset(-150, 200, 100)).toBe(-100);
-  });
-});
-
-describe("rectFromView", () => {
-  it("selects the centered half of a wide image at cover scale", () => {
-    const rect = rectFromView({
-      natW: 200,
-      natH: 100,
-      frameW: 100,
-      frameH: 100,
-      scale: 1, // cover scale for this pairing
-      offsetX: -50, // centered
-      offsetY: 0,
+    // scale 2, square: half-image 100, frame half-extent 50 -> pan range +-50.
+    expect(clampPan(view({ scale: 2, panX: 10, panY: -20 }))).toEqual({
+      panX: 10,
+      panY: -20,
     });
-    expect(rect).toEqual({ x: 0.25, y: 0, w: 0.5, h: 1 });
+    const clamped = clampPan(view({ scale: 2, panX: 999, panY: -999 }));
+    expect(clamped.panX).toBeCloseTo(50, 6);
+    expect(clamped.panY).toBeCloseTo(-50, 6);
   });
 
-  it("shrinks the selection as the user zooms in", () => {
-    const rect = rectFromView({
-      natW: 100,
-      natH: 100,
-      frameW: 100,
-      frameH: 100,
-      scale: 2, // zoomed 2x
-      offsetX: -50,
-      offsetY: -50,
-    });
-    expect(rect).toEqual({ x: 0.25, y: 0.25, w: 0.5, h: 0.5 });
+  it("pins the pan to zero at the cover scale", () => {
+    // At exactly cover scale there is no slack in either axis.
+    const s = coverScale(100, 100, 100, 100, 0); // 1
+    const clamped = clampPan(view({ scale: s, panX: 40, panY: 40 }));
+    expect(clamped.panX).toBeCloseTo(0, 6);
+    expect(clamped.panY).toBeCloseTo(0, 6);
   });
 
-  it("clamps the rectangle inside the image bounds", () => {
-    const rect = rectFromView({
-      natW: 100,
-      natH: 100,
-      frameW: 100,
-      frameH: 100,
-      scale: 2,
-      offsetX: 999, // out of range, should clamp to a valid window
-      offsetY: -999,
-    });
-    expect(rect.x).toBeGreaterThanOrEqual(0);
-    expect(rect.y).toBeGreaterThanOrEqual(0);
-    expect(rect.x + rect.w).toBeLessThanOrEqual(1);
-    expect(rect.y + rect.h).toBeLessThanOrEqual(1);
+  it("clamps along the rotated image axes", () => {
+    // Turned 90 degrees, an over-large pan still lands inside the covered box.
+    const v = view({ scale: 2, angleDeg: 90, panX: 999, panY: 999 });
+    const clamped = clampPan(v);
+    // Map back into image axes; both components must sit within the +-50 range.
+    const r = (v.angleDeg * Math.PI) / 180;
+    const dx = Math.cos(r) * clamped.panX + Math.sin(r) * clamped.panY;
+    const dy = -Math.sin(r) * clamped.panX + Math.cos(r) * clamped.panY;
+    expect(Math.abs(dx)).toBeLessThanOrEqual(50 + 1e-6);
+    expect(Math.abs(dy)).toBeLessThanOrEqual(50 + 1e-6);
   });
 });

--- a/frontend/src/lib/crop-geometry.test.ts
+++ b/frontend/src/lib/crop-geometry.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  coverBaseScale,
+  clampOffset,
+  rectFromView,
+} from "./crop-geometry";
+
+describe("coverBaseScale", () => {
+  it("picks the larger ratio so the frame is always covered", () => {
+    // A wide frame over a square image is bound by the width ratio.
+    expect(coverBaseScale(100, 100, 50, 25)).toBe(0.5);
+    // A tall frame over a wide image is bound by the height ratio.
+    expect(coverBaseScale(200, 100, 50, 80)).toBe(0.8);
+  });
+
+  it("returns 1 for degenerate sizes", () => {
+    expect(coverBaseScale(0, 100, 50, 50)).toBe(1);
+  });
+});
+
+describe("clampOffset", () => {
+  it("keeps a larger image from uncovering the frame", () => {
+    // disp 200, frame 100 -> offset allowed in [-100, 0]
+    expect(clampOffset(10, 200, 100)).toBe(0);
+    expect(clampOffset(-40, 200, 100)).toBe(-40);
+    expect(clampOffset(-150, 200, 100)).toBe(-100);
+  });
+});
+
+describe("rectFromView", () => {
+  it("selects the centered half of a wide image at cover scale", () => {
+    const rect = rectFromView({
+      natW: 200,
+      natH: 100,
+      frameW: 100,
+      frameH: 100,
+      scale: 1, // cover scale for this pairing
+      offsetX: -50, // centered
+      offsetY: 0,
+    });
+    expect(rect).toEqual({ x: 0.25, y: 0, w: 0.5, h: 1 });
+  });
+
+  it("shrinks the selection as the user zooms in", () => {
+    const rect = rectFromView({
+      natW: 100,
+      natH: 100,
+      frameW: 100,
+      frameH: 100,
+      scale: 2, // zoomed 2x
+      offsetX: -50,
+      offsetY: -50,
+    });
+    expect(rect).toEqual({ x: 0.25, y: 0.25, w: 0.5, h: 0.5 });
+  });
+
+  it("clamps the rectangle inside the image bounds", () => {
+    const rect = rectFromView({
+      natW: 100,
+      natH: 100,
+      frameW: 100,
+      frameH: 100,
+      scale: 2,
+      offsetX: 999, // out of range, should clamp to a valid window
+      offsetY: -999,
+    });
+    expect(rect.x).toBeGreaterThanOrEqual(0);
+    expect(rect.y).toBeGreaterThanOrEqual(0);
+    expect(rect.x + rect.w).toBeLessThanOrEqual(1);
+    expect(rect.y + rect.h).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/lib/crop-geometry.ts
+++ b/frontend/src/lib/crop-geometry.ts
@@ -1,68 +1,65 @@
 /**
  * Pure geometry for the image cropper. The cropper shows the image behind a
- * fixed crop frame; the user pans and zooms the image. These helpers convert
- * that view state into a normalized {@link CropRect} and keep the image large
- * enough to always cover the frame.
+ * fixed crop frame; the user pans, zooms, and rotates it. These helpers keep
+ * the image large enough to cover the frame at any angle and keep the pan
+ * inside the covered range.
+ *
+ * The transform is applied about the image center: a natural-image point p
+ * (relative to the center) maps to the frame point
+ *   center + pan + R(angle) * (scale * p).
  *
  * Kept DOM-free so the math is unit-testable.
  */
-import type { CropRect } from "./crop";
+import type { CropView } from "./crop";
 
-export interface ViewState {
-  /** Natural image size in pixels. */
-  natW: number;
-  natH: number;
-  /** Crop frame size in pixels, on screen. */
-  frameW: number;
-  frameH: number;
-  /** Absolute display scale applied to the natural image. */
-  scale: number;
-  /** Image top-left offset within the frame's coordinate space (<= 0). */
-  offsetX: number;
-  offsetY: number;
-}
-
-/** The smallest scale at which the image still covers the whole frame. */
-export function coverBaseScale(
+/**
+ * The smallest scale at which the rotated image still covers the whole frame.
+ *
+ * Rotating the frame by -angle into the image axes, its half-extents grow to
+ * Ux = (fw/2)|cos| + (fh/2)|sin| and Uy = (fw/2)|sin| + (fh/2)|cos|. The scaled
+ * image half-size must reach each, so scale >= 2*Ux/natW and >= 2*Uy/natH.
+ */
+export function coverScale(
   natW: number,
   natH: number,
   frameW: number,
-  frameH: number
+  frameH: number,
+  angleDeg: number
 ): number {
   if (natW <= 0 || natH <= 0) return 1;
-  return Math.max(frameW / natW, frameH / natH);
+  const r = (angleDeg * Math.PI) / 180;
+  const c = Math.abs(Math.cos(r));
+  const s = Math.abs(Math.sin(r));
+  const needX = (frameW * c + frameH * s) / natW;
+  const needY = (frameW * s + frameH * c) / natH;
+  return Math.max(needX, needY);
 }
 
-/** Clamp one offset axis so the scaled image never uncovers the frame. */
-export function clampOffset(
-  offset: number,
-  dispSize: number,
-  frameSize: number
-): number {
-  // The image left/top edge can sit at 0 (flush) down to frameSize - dispSize
-  // (its right/bottom edge flush). When the image is not larger than the frame
-  // both bounds collapse to a centered position.
-  const min = Math.min(0, frameSize - dispSize);
-  if (offset > 0) return 0;
-  if (offset < min) return min;
-  return offset;
-}
+/**
+ * Clamp the pan so the rotated, scaled image still covers the frame. Returns
+ * the corrected pan; an already-valid pan is returned unchanged.
+ */
+export function clampPan(view: CropView): { panX: number; panY: number } {
+  const { natW, natH, frameW, frameH, scale, angleDeg } = view;
+  const r = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(r);
+  const sin = Math.sin(r);
+  const c = Math.abs(cos);
+  const s = Math.abs(sin);
 
-/** Convert the current view into a normalized crop rectangle. */
-export function rectFromView(v: ViewState): CropRect {
-  const dispW = v.natW * v.scale;
-  const dispH = v.natH * v.scale;
-  const ox = clampOffset(v.offsetX, dispW, v.frameW);
-  const oy = clampOffset(v.offsetY, dispH, v.frameH);
+  const ux = (frameW / 2) * c + (frameH / 2) * s;
+  const uy = (frameW / 2) * s + (frameH / 2) * c;
+  const maxDx = Math.max(0, (scale * natW) / 2 - ux);
+  const maxDy = Math.max(0, (scale * natH) / 2 - uy);
 
-  const w = clamp01(v.frameW / dispW);
-  const h = clamp01(v.frameH / dispH);
-  const x = clamp01(-ox / dispW, 1 - w);
-  const y = clamp01(-oy / dispH, 1 - h);
-  return { x, y, w, h };
-}
+  // Rotate the pan into image axes, clamp there, then rotate back.
+  const dx = cos * view.panX + sin * view.panY;
+  const dy = -sin * view.panX + cos * view.panY;
+  const cdx = Math.min(maxDx, Math.max(-maxDx, dx));
+  const cdy = Math.min(maxDy, Math.max(-maxDy, dy));
 
-function clamp01(n: number, max = 1): number {
-  if (!Number.isFinite(n) || n <= 0) return 0;
-  return n > max ? max : n;
+  return {
+    panX: cos * cdx - sin * cdy,
+    panY: sin * cdx + cos * cdy,
+  };
 }

--- a/frontend/src/lib/crop-geometry.ts
+++ b/frontend/src/lib/crop-geometry.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure geometry for the image cropper. The cropper shows the image behind a
+ * fixed crop frame; the user pans and zooms the image. These helpers convert
+ * that view state into a normalized {@link CropRect} and keep the image large
+ * enough to always cover the frame.
+ *
+ * Kept DOM-free so the math is unit-testable.
+ */
+import type { CropRect } from "./crop";
+
+export interface ViewState {
+  /** Natural image size in pixels. */
+  natW: number;
+  natH: number;
+  /** Crop frame size in pixels, on screen. */
+  frameW: number;
+  frameH: number;
+  /** Absolute display scale applied to the natural image. */
+  scale: number;
+  /** Image top-left offset within the frame's coordinate space (<= 0). */
+  offsetX: number;
+  offsetY: number;
+}
+
+/** The smallest scale at which the image still covers the whole frame. */
+export function coverBaseScale(
+  natW: number,
+  natH: number,
+  frameW: number,
+  frameH: number
+): number {
+  if (natW <= 0 || natH <= 0) return 1;
+  return Math.max(frameW / natW, frameH / natH);
+}
+
+/** Clamp one offset axis so the scaled image never uncovers the frame. */
+export function clampOffset(
+  offset: number,
+  dispSize: number,
+  frameSize: number
+): number {
+  // The image left/top edge can sit at 0 (flush) down to frameSize - dispSize
+  // (its right/bottom edge flush). When the image is not larger than the frame
+  // both bounds collapse to a centered position.
+  const min = Math.min(0, frameSize - dispSize);
+  if (offset > 0) return 0;
+  if (offset < min) return min;
+  return offset;
+}
+
+/** Convert the current view into a normalized crop rectangle. */
+export function rectFromView(v: ViewState): CropRect {
+  const dispW = v.natW * v.scale;
+  const dispH = v.natH * v.scale;
+  const ox = clampOffset(v.offsetX, dispW, v.frameW);
+  const oy = clampOffset(v.offsetY, dispH, v.frameH);
+
+  const w = clamp01(v.frameW / dispW);
+  const h = clamp01(v.frameH / dispH);
+  const x = clamp01(-ox / dispW, 1 - w);
+  const y = clamp01(-oy / dispH, 1 - h);
+  return { x, y, w, h };
+}
+
+function clamp01(n: number, max = 1): number {
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return n > max ? max : n;
+}

--- a/frontend/src/lib/crop.ts
+++ b/frontend/src/lib/crop.ts
@@ -1,0 +1,244 @@
+/**
+ * Crop an image or an animated GIF to a fixed output size.
+ *
+ * A static image is drawn once onto a canvas and exported as WebP. An animated
+ * GIF is decoded frame by frame, each full frame is composited (GIF frames are
+ * patches with disposal rules), cropped, and the sequence is re-encoded as a
+ * new GIF so the animation survives the crop.
+ *
+ * The crop rectangle is normalized to the natural image size, so the caller
+ * (the cropper UI) never needs the real pixel dimensions.
+ */
+import { parseGIF, decompressFrames, type ParsedFrame } from "gifuct-js";
+import { GIFEncoder, quantize, applyPalette } from "gifenc";
+
+/** A crop region in [0,1] coordinates, relative to the natural image size. */
+export interface CropRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface CropTarget {
+  /** Output width in pixels. */
+  outWidth: number;
+  /** Output height in pixels. */
+  outHeight: number;
+  /**
+   * Byte budget for the encoded result. A GIF that exceeds it is re-encoded at
+   * a smaller size. A static WebP is small enough that it never trips this.
+   */
+  maxBytes: number;
+}
+
+/** The full crop region - the identity crop that selects the whole image. */
+export const FULL_CROP: CropRect = { x: 0, y: 0, w: 1, h: 1 };
+
+function isGifBytes(b: Uint8Array): boolean {
+  // "GIF87a" or "GIF89a"
+  return (
+    b.length >= 6 &&
+    b[0] === 0x47 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x38 &&
+    (b[4] === 0x37 || b[4] === 0x39) &&
+    b[5] === 0x61
+  );
+}
+
+async function fetchBytes(
+  src: string
+): Promise<{ bytes: Uint8Array; type: string }> {
+  // A remote host without CORS headers rejects here; the caller turns the
+  // rejection into a message that points the user at the upload tab.
+  const res = await fetch(src);
+  if (!res.ok) throw new Error(`Could not load the image (HTTP ${res.status}).`);
+  const type = (res.headers.get("content-type") ?? "").split(";")[0].trim();
+  const buf = await res.arrayBuffer();
+  return { bytes: new Uint8Array(buf), type };
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(
+      ...(bytes.subarray(i, i + chunk) as unknown as number[])
+    );
+  }
+  return btoa(binary);
+}
+
+function get2d(
+  canvas: HTMLCanvasElement,
+  willReadFrequently = false
+): CanvasRenderingContext2D {
+  const ctx = canvas.getContext("2d", { willReadFrequently });
+  if (!ctx) throw new Error("Canvas 2D context is unavailable.");
+  return ctx;
+}
+
+async function cropStatic(
+  bytes: Uint8Array,
+  type: string,
+  rect: CropRect,
+  target: CropTarget
+): Promise<string> {
+  // Decode through a same-origin blob URL. Drawing a cross-origin <img>
+  // straight from its remote URL would taint the canvas and block the export.
+  const blob = new Blob([bytes as unknown as BlobPart], {
+    type: type || "image/png",
+  });
+  const url = URL.createObjectURL(blob);
+  try {
+    const img = new Image();
+    img.src = url;
+    await img.decode();
+
+    const canvas = document.createElement("canvas");
+    canvas.width = target.outWidth;
+    canvas.height = target.outHeight;
+    const ctx = get2d(canvas);
+    ctx.drawImage(
+      img,
+      rect.x * img.naturalWidth,
+      rect.y * img.naturalHeight,
+      rect.w * img.naturalWidth,
+      rect.h * img.naturalHeight,
+      0,
+      0,
+      target.outWidth,
+      target.outHeight
+    );
+
+    const webp = canvas.toDataURL("image/webp", 0.92);
+    // A browser without WebP encode returns a PNG data URL from the WebP call.
+    return webp.startsWith("data:image/webp") ? webp : canvas.toDataURL("image/png");
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function encodeGif(
+  frames: ParsedFrame[],
+  fullW: number,
+  fullH: number,
+  rect: CropRect,
+  outW: number,
+  outH: number
+): Uint8Array {
+  const full = document.createElement("canvas");
+  full.width = fullW;
+  full.height = fullH;
+  const fctx = get2d(full, true);
+
+  const patchCanvas = document.createElement("canvas");
+  const pctx = get2d(patchCanvas);
+
+  const out = document.createElement("canvas");
+  out.width = outW;
+  out.height = outH;
+  const octx = get2d(out, true);
+
+  const sx = rect.x * fullW;
+  const sy = rect.y * fullH;
+  const sw = rect.w * fullW;
+  const sh = rect.h * fullH;
+
+  const enc = GIFEncoder();
+  let prev: ParsedFrame | null = null;
+  let restore: ImageData | null = null;
+
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i];
+    const { dims, patch, disposalType, delay } = frame;
+
+    // Apply the previous frame's disposal before drawing this one.
+    if (prev) {
+      if (prev.disposalType === 2) {
+        fctx.clearRect(
+          prev.dims.left,
+          prev.dims.top,
+          prev.dims.width,
+          prev.dims.height
+        );
+      } else if (prev.disposalType === 3 && restore) {
+        fctx.putImageData(restore, 0, 0);
+      }
+    }
+    // Disposal 3 means "revert to the state before this frame", so snapshot now.
+    if (disposalType === 3) restore = fctx.getImageData(0, 0, fullW, fullH);
+
+    patchCanvas.width = dims.width;
+    patchCanvas.height = dims.height;
+    pctx.putImageData(
+      new ImageData(new Uint8ClampedArray(patch), dims.width, dims.height),
+      0,
+      0
+    );
+    fctx.drawImage(patchCanvas, dims.left, dims.top);
+
+    // Every output frame is a complete cropped image, so encode it whole and
+    // restore to a transparent background between frames.
+    octx.clearRect(0, 0, outW, outH);
+    octx.drawImage(full, sx, sy, sw, sh, 0, 0, outW, outH);
+    const rgba = octx.getImageData(0, 0, outW, outH).data;
+
+    const palette = quantize(rgba, 256, { format: "rgba4444" });
+    const index = applyPalette(rgba, palette, "rgba4444");
+    enc.writeFrame(index, outW, outH, {
+      palette,
+      transparent: true,
+      dispose: 2,
+      delay: delay || 100,
+      ...(i === 0 ? { first: true, repeat: 0 } : {}),
+    });
+
+    prev = frame;
+  }
+
+  enc.finish();
+  return enc.bytes();
+}
+
+async function cropGif(
+  bytes: Uint8Array,
+  rect: CropRect,
+  target: CropTarget
+): Promise<string> {
+  const parsed = parseGIF(bytes.buffer as ArrayBuffer);
+  const frames = decompressFrames(parsed, true);
+  if (frames.length === 0) throw new Error("The GIF has no frames.");
+
+  const fullW = parsed.lsd.width;
+  const fullH = parsed.lsd.height;
+
+  // Re-encoding can grow a GIF. If the result blows the byte budget, shrink the
+  // output and try again, keeping the smallest attempt as the floor.
+  const scales = [1, 0.8, 0.6, 0.45];
+  let encoded: Uint8Array | null = null;
+  for (const scale of scales) {
+    const outW = Math.max(2, Math.round(target.outWidth * scale));
+    const outH = Math.max(2, Math.round(target.outHeight * scale));
+    encoded = encodeGif(frames, fullW, fullH, rect, outW, outH);
+    if (encoded.length <= target.maxBytes) break;
+  }
+  return "data:image/gif;base64," + toBase64(encoded!);
+}
+
+/**
+ * Crop `src` (a data URL, blob URL, or CORS-reachable URL) to `target` and
+ * return a data URL. An animated GIF stays animated; anything else becomes a
+ * static WebP. Rejects when the source cannot be fetched or decoded.
+ */
+export async function cropImageToDataUrl(
+  src: string,
+  rect: CropRect,
+  target: CropTarget
+): Promise<string> {
+  const { bytes, type } = await fetchBytes(src);
+  if (isGifBytes(bytes)) return cropGif(bytes, rect, target);
+  return cropStatic(bytes, type, rect, target);
+}

--- a/frontend/src/lib/crop.ts
+++ b/frontend/src/lib/crop.ts
@@ -1,23 +1,37 @@
 /**
  * Crop an image or an animated GIF to a fixed output size.
  *
- * A static image is drawn once onto a canvas and exported as WebP. An animated
- * GIF is decoded frame by frame, each full frame is composited (GIF frames are
- * patches with disposal rules), cropped, and the sequence is re-encoded as a
- * new GIF so the animation survives the crop.
+ * The cropper shows the image behind a fixed frame; the user pans, zooms, and
+ * rotates it. That view is described by a {@link CropView} - an absolute scale,
+ * a pan of the image center, and a rotation angle. The pipeline reproduces the
+ * exact same transform on a canvas, so what the user frames is what they get.
  *
- * The crop rectangle is normalized to the natural image size, so the caller
- * (the cropper UI) never needs the real pixel dimensions.
+ * A static image is rendered once and exported as WebP. An animated GIF is
+ * decoded frame by frame, each full frame is composited (GIF frames are patches
+ * with disposal rules), rendered through the same transform, and the sequence
+ * is re-encoded, so the animation survives the crop.
  */
 import { parseGIF, decompressFrames, type ParsedFrame } from "gifuct-js";
 import { GIFEncoder, quantize, applyPalette } from "gifenc";
 
-/** A crop region in [0,1] coordinates, relative to the natural image size. */
-export interface CropRect {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
+/**
+ * The cropper view. Pan and angle place the image inside the crop frame; the
+ * frame maps onto the output. The transform is applied about the image center.
+ */
+export interface CropView {
+  /** Natural image size in pixels. */
+  natW: number;
+  natH: number;
+  /** Crop frame size in pixels, as shown on screen. Same aspect as the output. */
+  frameW: number;
+  frameH: number;
+  /** Absolute display scale applied to the natural image. */
+  scale: number;
+  /** Image center offset from the frame center, in frame pixels. */
+  panX: number;
+  panY: number;
+  /** Rotation in degrees, clockwise. */
+  angleDeg: number;
 }
 
 export interface CropTarget {
@@ -31,9 +45,6 @@ export interface CropTarget {
    */
   maxBytes: number;
 }
-
-/** The full crop region - the identity crop that selects the whole image. */
-export const FULL_CROP: CropRect = { x: 0, y: 0, w: 1, h: 1 };
 
 function isGifBytes(b: Uint8Array): boolean {
   // "GIF87a" or "GIF89a"
@@ -80,10 +91,33 @@ function get2d(
   return ctx;
 }
 
+/**
+ * Draw `source` into the output canvas with the cropper's transform. The output
+ * canvas is the crop frame scaled to the output size; inside it the image is
+ * translated, rotated, and scaled about its center - the same as the CSS
+ * transform the cropper shows.
+ */
+function renderView(
+  ctx: CanvasRenderingContext2D,
+  source: CanvasImageSource & { width: number; height: number },
+  view: CropView,
+  outW: number,
+  outH: number
+): void {
+  ctx.clearRect(0, 0, outW, outH);
+  ctx.save();
+  ctx.scale(outW / view.frameW, outH / view.frameH);
+  ctx.translate(view.frameW / 2 + view.panX, view.frameH / 2 + view.panY);
+  ctx.rotate((view.angleDeg * Math.PI) / 180);
+  ctx.scale(view.scale, view.scale);
+  ctx.drawImage(source, -source.width / 2, -source.height / 2);
+  ctx.restore();
+}
+
 async function cropStatic(
   bytes: Uint8Array,
   type: string,
-  rect: CropRect,
+  view: CropView,
   target: CropTarget
 ): Promise<string> {
   // Decode through a same-origin blob URL. Drawing a cross-origin <img>
@@ -101,17 +135,7 @@ async function cropStatic(
     canvas.width = target.outWidth;
     canvas.height = target.outHeight;
     const ctx = get2d(canvas);
-    ctx.drawImage(
-      img,
-      rect.x * img.naturalWidth,
-      rect.y * img.naturalHeight,
-      rect.w * img.naturalWidth,
-      rect.h * img.naturalHeight,
-      0,
-      0,
-      target.outWidth,
-      target.outHeight
-    );
+    renderView(ctx, img, view, target.outWidth, target.outHeight);
 
     const webp = canvas.toDataURL("image/webp", 0.92);
     // A browser without WebP encode returns a PNG data URL from the WebP call.
@@ -125,7 +149,7 @@ function encodeGif(
   frames: ParsedFrame[],
   fullW: number,
   fullH: number,
-  rect: CropRect,
+  view: CropView,
   outW: number,
   outH: number
 ): Uint8Array {
@@ -141,11 +165,6 @@ function encodeGif(
   out.width = outW;
   out.height = outH;
   const octx = get2d(out, true);
-
-  const sx = rect.x * fullW;
-  const sy = rect.y * fullH;
-  const sw = rect.w * fullW;
-  const sh = rect.h * fullH;
 
   const enc = GIFEncoder();
   let prev: ParsedFrame | null = null;
@@ -180,10 +199,9 @@ function encodeGif(
     );
     fctx.drawImage(patchCanvas, dims.left, dims.top);
 
-    // Every output frame is a complete cropped image, so encode it whole and
-    // restore to a transparent background between frames.
-    octx.clearRect(0, 0, outW, outH);
-    octx.drawImage(full, sx, sy, sw, sh, 0, 0, outW, outH);
+    // Every output frame is a complete transformed image, so encode it whole
+    // and restore to a transparent background between frames.
+    renderView(octx, full, view, outW, outH);
     const rgba = octx.getImageData(0, 0, outW, outH).data;
 
     const palette = quantize(rgba, 256, { format: "rgba4444" });
@@ -205,7 +223,7 @@ function encodeGif(
 
 async function cropGif(
   bytes: Uint8Array,
-  rect: CropRect,
+  view: CropView,
   target: CropTarget
 ): Promise<string> {
   const parsed = parseGIF(bytes.buffer as ArrayBuffer);
@@ -219,26 +237,26 @@ async function cropGif(
   // output and try again, keeping the smallest attempt as the floor.
   const scales = [1, 0.8, 0.6, 0.45];
   let encoded: Uint8Array | null = null;
-  for (const scale of scales) {
-    const outW = Math.max(2, Math.round(target.outWidth * scale));
-    const outH = Math.max(2, Math.round(target.outHeight * scale));
-    encoded = encodeGif(frames, fullW, fullH, rect, outW, outH);
+  for (const s of scales) {
+    const outW = Math.max(2, Math.round(target.outWidth * s));
+    const outH = Math.max(2, Math.round(target.outHeight * s));
+    encoded = encodeGif(frames, fullW, fullH, view, outW, outH);
     if (encoded.length <= target.maxBytes) break;
   }
   return "data:image/gif;base64," + toBase64(encoded!);
 }
 
 /**
- * Crop `src` (a data URL, blob URL, or CORS-reachable URL) to `target` and
+ * Crop `src` (a data URL, blob URL, or CORS-reachable URL) with `view` and
  * return a data URL. An animated GIF stays animated; anything else becomes a
  * static WebP. Rejects when the source cannot be fetched or decoded.
  */
 export async function cropImageToDataUrl(
   src: string,
-  rect: CropRect,
+  view: CropView,
   target: CropTarget
 ): Promise<string> {
   const { bytes, type } = await fetchBytes(src);
-  if (isGifBytes(bytes)) return cropGif(bytes, rect, target);
-  return cropStatic(bytes, type, rect, target);
+  if (isGifBytes(bytes)) return cropGif(bytes, view, target);
+  return cropStatic(bytes, type, view, target);
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -24,6 +24,51 @@ declare module "virtual:pwa-register" {
   }): () => void;
 }
 
+// gifenc ships no type declarations. Only the entry points the crop
+// pipeline uses are declared here.
+declare module "gifenc" {
+  export type GifencFormat = "rgb565" | "rgb444" | "rgba4444";
+  export function quantize(
+    rgba: Uint8Array | Uint8ClampedArray,
+    maxColors: number,
+    options?: {
+      format?: GifencFormat;
+      oneBitAlpha?: boolean | number;
+      clearAlpha?: boolean;
+      clearAlphaThreshold?: number;
+    }
+  ): number[][];
+  export function applyPalette(
+    rgba: Uint8Array | Uint8ClampedArray,
+    palette: number[][],
+    format?: GifencFormat
+  ): Uint8Array;
+  export interface GIFEncoderInstance {
+    writeFrame(
+      index: Uint8Array,
+      width: number,
+      height: number,
+      options?: {
+        palette?: number[][];
+        first?: boolean;
+        transparent?: boolean;
+        transparentIndex?: number;
+        delay?: number;
+        repeat?: number;
+        dispose?: number;
+      }
+    ): void;
+    finish(): void;
+    bytes(): Uint8Array;
+    bytesView(): Uint8Array;
+    reset(): void;
+  }
+  export function GIFEncoder(options?: {
+    auto?: boolean;
+    initialCapacity?: number;
+  }): GIFEncoderInstance;
+}
+
 // PWA install prompt event
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];


### PR DESCRIPTION
## What

The avatar and banner picker gains a crop editor. The user **drags to pan**, **zooms**, and **rotates** the image behind a fixed frame: a circle for the avatar (1:1), a 3:1 frame for the banner. Both destinations share one picker (`AvatarPickerDialog`, `target="avatar" | "banner"`), so the editor serves both.

The crop carries a full view transform - scale, pan, and rotation - and the pipeline reproduces that exact transform on a canvas, so what the user frames is what they get. It works for both a static image and an animated GIF:
- A static image becomes a WebP.
- An animated GIF is decoded frame by frame (honoring GIF disposal rules), each full frame is composited and rendered through the transform, then the sequence is re-encoded, so **the animation survives the crop**. A GIF that exceeds the byte budget is re-encoded at a smaller size.
- The cover scale and the pan clamp both account for the angle, so the frame stays covered at any rotation.
- A cross-origin source is drawn through a same-origin blob URL, so the canvas stays readable. An un-fetchable host surfaces a clear message that points the user at the Upload tab.

## Screenshots

Avatar crop - circular 1:1 frame, drag to pan, zoom and rotate sliders (the animated GIF plays while you frame it):

![Avatar cropper](https://raw.githubusercontent.com/awful-org/awful.chat/assets/crop-images/pr/crop-images/avatar-crop.png)

Banner crop - wide 3:1 frame, same editor, opened from Settings -> Profile:

![Banner cropper](https://raw.githubusercontent.com/awful-org/awful.chat/assets/crop-images/pr/crop-images/banner-crop.png)

## Changes

- `src/lib/crop.ts` - the crop pipeline. Renders a source (static image or composited GIF frame) through the view transform onto the output canvas.
- `src/lib/crop-geometry.ts` - DOM-free geometry: rotation-aware cover scale and pan clamp (unit-tested).
- `src/lib/components/ImageCropper.svelte` - the pan / zoom / rotate editor. The GIF keeps playing while it is framed.
- `src/lib/components/AvatarPickerDialog.svelte` - a "Crop" button appears once an image is chosen; it swaps the dialog into the editor and writes the cropped result back before Save.
- `src/vite-env.d.ts` - ambient types for `gifenc`.
- Add `gifuct-js` and `gifenc`. `third-party-notices.txt` regenerated by the build.

## Verification

- `pnpm test`: 268/268 pass (adds `crop-geometry.test.ts`, incl. rotation cover-scale and pan-clamp cases).
- `svelte-check`: 0 errors. `pnpm build`: succeeds.
- Browser, end to end: opened the editor on a GIF, dragged to pan (transform translate changed), moved the rotate slider (angle applied, cover scale auto-grew), and saved. The result was an animated GIF.
- Pipeline checks: rotated avatar crop -> `GIF89a` 64x64, 4 frames; animated banner crop -> 720x240 GIF; static crop -> WebP.
