### PR TITLE
fix: room messages make a sound again

### DIFF
--- a/frontend/src/lib/announce.test.ts
+++ b/frontend/src/lib/announce.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageType, type Message } from "./types/message";
+
+const notified: Array<{
+  title: string;
+  body: string;
+  tag: string;
+  viewingConversation?: boolean;
+  data?: { roomCode: string; dmPeerDid?: string };
+}> = [];
+
+vi.mock("./notify.svelte", () => ({
+  notifyMessage: (opts: (typeof notified)[number]) => notified.push(opts),
+}));
+
+vi.mock("./plugins/registry", () => ({
+  getManifest: (id: string) => (id === "dice" ? { name: "Dice" } : undefined),
+}));
+
+vi.mock("./rooms.svelte", () => ({
+  roomsStore: {
+    rooms: [{ roomCode: "room-a", name: "The Room" }],
+    dmRooms: [],
+  },
+}));
+
+const { announceMessage, _resetAnnounced } = await import("./announce");
+
+const ME = "did:key:me";
+const THEM = "did:key:them";
+
+const ctx = {
+  selfIds: [ME, "12D3KooWme"],
+  uiRoomCode: null as string | null,
+  resolveName: (did: string) => (did === ME ? "Me" : "Them"),
+};
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: "m1",
+    roomCode: "room-a",
+    senderId: THEM,
+    senderName: "Them",
+    timestamp: 1,
+    lamport: 1,
+    type: MessageType.Text,
+    content: "hello",
+    attachments: [],
+    ...over,
+  };
+}
+
+describe("announceMessage", () => {
+  beforeEach(() => {
+    notified.length = 0;
+    ctx.uiRoomCode = null;
+    _resetAnnounced();
+  });
+
+  it("announces a new room message under the message's own room name", () => {
+    announceMessage(msg(), ctx);
+    expect(notified).toHaveLength(1);
+    expect(notified[0].title).toBe("The Room");
+    expect(notified[0].body).toBe("Them: hello");
+    expect(notified[0].tag).toBe("room:room-a");
+    expect(notified[0].data).toEqual({
+      roomCode: "room-a",
+      dmPeerDid: undefined,
+    });
+  });
+
+  it("announces the same message once, however many times it is delivered", () => {
+    // The whole point: room chat arrives over pubsub AND as a direct copy.
+    announceMessage(msg(), ctx);
+    announceMessage(msg(), ctx);
+    expect(notified).toHaveLength(1);
+  });
+
+  it("keeps announcing distinct messages after a duplicate", () => {
+    announceMessage(msg({ id: "m1" }), ctx);
+    announceMessage(msg({ id: "m1" }), ctx);
+    announceMessage(msg({ id: "m2" }), ctx);
+    expect(notified.map((n) => n.body)).toEqual(["Them: hello", "Them: hello"]);
+  });
+
+  it("stays quiet for your own message coming back through sync", () => {
+    announceMessage(msg({ senderId: ME }), ctx);
+    announceMessage(msg({ id: "m2", senderId: "12D3KooWme" }), ctx);
+    expect(notified).toHaveLength(0);
+  });
+
+  it("stays quiet for reactions and plugin updates", () => {
+    announceMessage(msg({ type: MessageType.Reaction }), ctx);
+    announceMessage(msg({ id: "m2", type: MessageType.PluginUpdate }), ctx);
+    expect(notified).toHaveLength(0);
+  });
+
+  it("titles a mention with the sender, not the room", () => {
+    announceMessage(msg({ content: `hey @[${ME}] look` }), ctx);
+    expect(notified[0].title).toBe("Them mentioned you");
+    expect(notified[0].body).toBe("Them: hey @Me look");
+  });
+
+  it("uses the DM shape for a dm- room and routes a click to the sender", () => {
+    announceMessage(msg({ roomCode: "dm-abc" }), ctx);
+    expect(notified[0].title).toBe("Them");
+    expect(notified[0].body).toBe("hello");
+    expect(notified[0].tag).toBe("dm:dm-abc");
+    expect(notified[0].data).toEqual({
+      roomCode: "dm-abc",
+      dmPeerDid: THEM,
+    });
+  });
+
+  it("names the plugin in a plugin card announcement", () => {
+    announceMessage(
+      msg({
+        type: MessageType.PluginCard,
+        content: JSON.stringify({ pluginId: "dice" }),
+      }),
+      ctx
+    );
+    expect(notified[0].body).toBe("Them: posted a Dice");
+  });
+
+  it("reports the conversation on screen so the sound rule can stay quiet", () => {
+    ctx.uiRoomCode = "room-a";
+    announceMessage(msg(), ctx);
+    expect(notified[0].viewingConversation).toBe(true);
+
+    ctx.uiRoomCode = "room-b";
+    announceMessage(msg({ id: "m2" }), ctx);
+    expect(notified[1].viewingConversation).toBe(false);
+  });
+
+  it("falls back to the room code for a room it does not know", () => {
+    announceMessage(msg({ roomCode: "room-unknown" }), ctx);
+    expect(notified[0].title).toBe("room-unknown");
+  });
+
+  it("describes a file message with no text", () => {
+    announceMessage(msg({ type: MessageType.File, content: "" }), ctx);
+    expect(notified[0].body).toBe("Them: [file]");
+  });
+});

--- a/frontend/src/lib/announce.ts
+++ b/frontend/src/lib/announce.ts
@@ -1,0 +1,133 @@
+import { MessageType, type Message } from "./types/message";
+import { notifyMessage } from "./notify.svelte";
+import { humanizeMentions, mentionsMe } from "./mentions";
+import { getManifest } from "./plugins/registry";
+import { roomsStore } from "./rooms.svelte";
+
+/**
+ * Telling the user a message arrived: the sound, and the notification when the
+ * app is out of sight.
+ *
+ * Its own module because room chat is delivered TWICE on purpose - a gossipsub
+ * publish plus a direct one-message copy per member, so a dead or still-forming
+ * mesh cannot swallow it - and BOTH delivery paths have to announce, or the
+ * message is silent whenever the arm that does not announce wins the race. Two
+ * callers announcing the same message need one place that decides, and one
+ * place that remembers what has already been said.
+ *
+ * The transport knows how a message arrived. This knows how to say so.
+ */
+
+/** Everything announceMessage needs to know that only the caller can answer. */
+export interface AnnounceContext {
+  /** Every id that means "me": the DID and the transport peer id. */
+  selfIds: string[];
+  /** The conversation on screen, so a sound is not played over the reader. */
+  uiRoomCode: string | null;
+  /** DID -> display name, for rendering @mentions in the preview text. */
+  resolveName: (did: string) => string;
+}
+
+/**
+ * Ids already announced this session. Bounded, because a long-lived tab in a
+ * busy room would otherwise grow it without limit.
+ */
+const announced = new Set<string>();
+const CAP = 1000;
+
+/** Claim an id, or report that someone already announced it. */
+function claim(id: string): boolean {
+  if (announced.has(id)) return false;
+  announced.add(id);
+  if (announced.size > CAP) {
+    // Insertion-ordered, so iteration hands back the oldest ids first.
+    let drop = announced.size - CAP / 2;
+    for (const old of announced) {
+      announced.delete(old);
+      if (--drop <= 0) break;
+    }
+  }
+  return true;
+}
+
+/** Test seam: a fresh module per case is not worth a vi.resetModules dance. */
+export function _resetAnnounced(): void {
+  announced.clear();
+}
+
+/**
+ * Announce a message the caller has established is genuinely new.
+ *
+ * Claims the id first, so the second delivery of the same message is silent
+ * even when both delivery paths read storage before either wrote. Never
+ * throws: this runs between storing a message and painting it, and an
+ * escaping error there turns "stored" into "invisible until refresh".
+ */
+export function announceMessage(msg: Message, ctx: AnnounceContext): void {
+  if (
+    msg.type === MessageType.Reaction ||
+    msg.type === MessageType.PluginUpdate
+  ) {
+    // A heart on an old message and a plugin's state update have nothing to
+    // read, so there is nothing to announce.
+    return;
+  }
+  if (ctx.selfIds.includes(msg.senderId)) {
+    // Your own message, arriving back from another device or a peer replaying
+    // history. Announcing it would beep at you for what you just wrote.
+    return;
+  }
+  if (!claim(msg.id)) return;
+
+  try {
+    let body = msg.content || "[file]";
+    if (msg.type === MessageType.PluginCard) {
+      try {
+        const payload = JSON.parse(msg.content);
+        const manifest = getManifest(payload.pluginId);
+        body = `posted a ${manifest?.name || payload.pluginId}`;
+      } catch {
+        body = "posted a plugin card";
+      }
+    } else {
+      body = humanizeMentions(body, ctx.resolveName);
+    }
+
+    // DM files and plugin cards ride the room broadcast path too, so this has
+    // to be able to speak both shapes.
+    const isDm = msg.roomCode.startsWith("dm-");
+    let title: string;
+    let preview: string;
+    if (isDm) {
+      // In a DM the sender IS the conversation; naming them twice is noise.
+      title = msg.senderName;
+      preview = body;
+    } else if (mentionsMe(msg.content ?? "", ctx.selfIds)) {
+      title = `${msg.senderName} mentioned you`;
+      preview = `${msg.senderName}: ${body}`;
+    } else {
+      // The message's OWN room, not the one on screen: titling a background
+      // room's message with the open room's name pointed the reader at the
+      // wrong conversation.
+      title =
+        roomsStore.rooms.find((r) => r.roomCode === msg.roomCode)?.name ||
+        msg.roomCode;
+      preview = `${msg.senderName}: ${body}`;
+    }
+
+    notifyMessage({
+      title,
+      body: preview,
+      tag: `${isDm ? "dm" : "room"}:${msg.roomCode}`,
+      viewingConversation: ctx.uiRoomCode === msg.roomCode,
+      data: {
+        roomCode: msg.roomCode,
+        // An inbound DM's sender IS the other side of the conversation, so a
+        // click on the notification routes straight back to it.
+        dmPeerDid: isDm ? msg.senderDid || msg.senderId : undefined,
+      },
+    });
+  } catch (err) {
+    console.warn("[chat] notification failed:", err);
+  }
+}

--- a/frontend/src/lib/sounds.ts
+++ b/frontend/src/lib/sounds.ts
@@ -12,7 +12,9 @@ function getCtx(): AudioContext {
 // Autoplay policy: resume() is IGNORED outside a user gesture, so a session
 // that never played a gesture-driven sound (joining a call, toggling mute)
 // carried a permanently suspended context - incoming-message beeps were
-// scheduled into silence. The session's first gesture unlocks it for good.
+// scheduled into silence. Every gesture re-arms it, not just the first: the
+// context can be suspended again later (mobile backgrounding, an audio-session
+// interruption), and a one-shot listener left the session mute for good.
 if (typeof window !== "undefined") {
   const unlock = () => {
     try {
@@ -20,11 +22,9 @@ if (typeof window !== "undefined") {
     } catch {
       /* no audio here */
     }
-    window.removeEventListener("pointerdown", unlock);
-    window.removeEventListener("keydown", unlock);
   };
-  window.addEventListener("pointerdown", unlock);
-  window.addEventListener("keydown", unlock);
+  window.addEventListener("pointerdown", unlock, { passive: true });
+  window.addEventListener("keydown", unlock, { passive: true });
 }
 
 function playOsc(
@@ -32,7 +32,15 @@ function playOsc(
   duration: number,
   type: OscillatorType = "sine",
   gain = 0.15,
-  attack = 0.005
+  attack = 0.005,
+  /**
+   * Seconds to wait before the note starts, measured on the AUDIO clock.
+   * setTimeout is clamped to >=1s in a background tab - exactly where an
+   * incoming-message beep matters most - which degraded a two-note chime to a
+   * single blip. Anything that has to land inside a few tens of milliseconds
+   * belongs here, not in a timer.
+   */
+  delay = 0
 ) {
   const ctx = getCtx();
   const osc = ctx.createOscillator();
@@ -41,15 +49,18 @@ function playOsc(
   osc.type = type;
   osc.frequency.value = freq;
 
-  gainNode.gain.value = 0;
-  gainNode.gain.linearRampToValueAtTime(gain, ctx.currentTime + attack);
-  gainNode.gain.linearRampToValueAtTime(0, ctx.currentTime + duration);
+  const start = ctx.currentTime + delay;
+  // A ramp with no preceding event starts from an implementation-defined
+  // time. Anchor it so the attack is the same in every browser.
+  gainNode.gain.setValueAtTime(0, start);
+  gainNode.gain.linearRampToValueAtTime(gain, start + attack);
+  gainNode.gain.linearRampToValueAtTime(0, start + duration);
 
   osc.connect(gainNode);
   gainNode.connect(ctx.destination);
 
-  osc.start();
-  osc.stop(ctx.currentTime + duration);
+  osc.start(start);
+  osc.stop(start + duration);
 }
 
 export async function playJoinSound() {
@@ -119,10 +130,14 @@ export async function playUndeafenSound() {
 /**
  * An incoming chat message. Softer and shorter than the notification triple:
  * this can fire often, so it has to be ignorable.
+ *
+ * Both notes are scheduled up front on the audio clock. This is the one cue
+ * that plays while the tab is in the background, where a 45 ms setTimeout is
+ * clamped to a second and the chime arrives as one lonely blip.
  */
 export async function playMessageSound() {
   playOsc(880, 0.05, "sine", 0.06);
-  setTimeout(() => playOsc(1175, 0.07, "sine", 0.05), 45);
+  playOsc(1175, 0.07, "sine", 0.05, 0.005, 0.045);
 }
 
 export async function playNotifySound() {

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -93,7 +93,7 @@ import {
   foldUpdate,
   touchCardStates,
 } from "../plugins/state.svelte";
-import { humanizeMentions, mentionsMe } from "../mentions";
+import { announceMessage } from "../announce";
 import { profileStore } from "../profile.svelte";
 import { getPlugin } from "../plugins/registry";
 import { _sendCallPresence, _sendCallState, leaveCall } from "./call.svelte";
@@ -127,7 +127,6 @@ import {
 } from "./files.svelte";
 import { initVoice } from "./voice.svelte";
 import { initTransmission } from "./transmission.svelte";
-import { notifyMessage } from "../notify.svelte";
 
 const MSG_ORDER = (a: Message, b: Message) =>
   a.lamport !== b.lamport
@@ -1011,7 +1010,13 @@ async function _pushMissingTo(
 async function _handleSyncBatch(
   roomCode: string,
   messages: WireChatMessage[],
-  fromPeerId?: string
+  fromPeerId?: string,
+  /**
+   * The sender marked this as the direct copy of a live send, not history
+   * repair. Only a live batch may announce: a repair would beep once per
+   * recovered message.
+   */
+  live = false
 ): Promise<void> {
   // Bind incoming history to the room named in the (signed-message-bearing)
   // batch, and only if we actually joined it - a peer cannot inject history
@@ -1085,6 +1090,19 @@ async function _handleSyncBatch(
   // path otherwise never creates.
   for (const m of fullMessages) stripAndAdoptInlineFiles(m);
 
+  // Newness has to be read BEFORE the write below, which would otherwise
+  // satisfy the lookup. Only worth the round trip for a live batch: repair
+  // never announces, so it never needs the answer.
+  const unannounced = live
+    ? await Promise.all(
+        fullMessages.map(
+          async (m) =>
+            !transportState.messages.some((x) => x.id === m.id) &&
+            !(await getMessage(m.id))
+        )
+      )
+    : [];
+
   await bulkPutMessages(fullMessages);
 
   // Backfilled plugin updates cannot be folded onto a cached state (the fold
@@ -1119,6 +1137,12 @@ async function _handleSyncBatch(
 
   refreshUnreadCount(roomCode).catch(() => {});
   for (const m of fullMessages) noteRoomActivity(m.roomCode, m.timestamp);
+
+  if (live) {
+    fullMessages.forEach((m, i) => {
+      if (unannounced[i]) _announceMessage(m);
+    });
+  }
 
   // Storage got everything; the view only takes messages for the room that is
   // actually open (the user may have switched while the batch was in flight),
@@ -1620,6 +1644,19 @@ async function _verifyIncoming(
   return verifySignature(wire.senderDid, wire.sig, canonicalFor(wire));
 }
 
+/**
+ * Bind an incoming message to this client's identity and view, then let
+ * announce.ts decide whether to make a sound about it. The caller has already
+ * established that the message is genuinely new.
+ */
+function _announceMessage(msg: Message): void {
+  announceMessage(msg, {
+    selfIds: [identityStore.did ?? "", _transport.selfId()],
+    uiRoomCode: transportState.uiRoomCode,
+    resolveName: resolveMentionDisplayName,
+  });
+}
+
 async function _handleChatMessage(
   wire: WireChatMessage,
   roomCodeOverride?: string,
@@ -1723,50 +1760,7 @@ async function _handleChatMessage(
     transportState.dmVersion += 1;
   }
 
-  // Reactions and plugin updates are noise as notifications, and a message
-  // replayed by sync is not news - only announce genuinely new chat arriving
-  // from someone else.
-  if (
-    isNewMessage &&
-    msg.type !== MessageType.Reaction &&
-    msg.type !== MessageType.PluginUpdate &&
-    !isSelfSender(msg.senderId)
-  ) {
-    // This whole block sits between putMessage and appendSorted: an
-    // uncaught throw here (a bad mention resolve, a notification quirk)
-    // turns "stored" into "invisible until refresh" for every message
-    // after it. Notifying is best-effort; painting the message is not.
-    try {
-      let body = msg.content || "[file]";
-      if (msg.type === MessageType.PluginCard) {
-        try {
-          const payload = JSON.parse(msg.content);
-          const { getManifest } = await import("../plugins/registry");
-          const manifest = getManifest(payload.pluginId);
-          body = `posted a ${manifest?.name || payload.pluginId}`;
-        } catch {
-          body = "posted a plugin card";
-        }
-      } else {
-        body = humanizeMentions(body, resolveMentionDisplayName);
-      }
-      const mentioned = mentionsMe(msg.content ?? "", [
-        identityStore.did ?? "",
-        _transport.selfId(),
-      ]);
-      notifyMessage({
-        title: mentioned
-          ? `${msg.senderName} mentioned you`
-          : transportState.roomName || msg.roomCode,
-        body: `${msg.senderName}: ${body}`,
-        tag: `room:${msg.roomCode}`,
-        viewingConversation: transportState.uiRoomCode === msg.roomCode,
-        data: { roomCode: msg.roomCode },
-      });
-    } catch (err) {
-      console.warn("[chat] notification failed:", err);
-    }
-  }
+  if (isNewMessage) _announceMessage(msg);
 
   // Match on the open room, not the mode: DM file messages arrive through
   // this path too, and the mode check kept them invisible until reopen.
@@ -2013,16 +2007,8 @@ function _handleDmChatAsync(
       const isViewingThisDm =
         transportState.chatMode === "dm" &&
         (activeDid === senderDid || activeDid === peerId);
-      // Reactions are noise as notifications, same rule as rooms.
-      if (!reaction) {
-        notifyMessage({
-          title: msg.senderName,
-          body: humanizeMentions(msg.content, resolveMentionDisplayName),
-          tag: `dm:${roomCode}`,
-          viewingConversation: transportState.uiRoomCode === roomCode,
-          data: { roomCode, dmPeerDid: senderDid },
-        });
-      }
+      // Reactions are filtered inside the funnel, same rule as rooms.
+      _announceMessage(msg);
       if (isViewingThisDm) {
         transportState.messages = appendSorted(transportState.messages, msg);
         await markRoomSeen(roomCode, msg.lamport);
@@ -2195,7 +2181,12 @@ _transport.on("message", (peerId, data, room) => {
         _handleDigest(peerId, msg.roomCode, msg.watermarks).catch(() => {});
         break;
       case MessageType.SyncBatch:
-        _handleSyncBatch(msg.roomCode, msg.messages, peerId).catch(() => {});
+        _handleSyncBatch(
+          msg.roomCode,
+          msg.messages,
+          peerId,
+          msg.live === true
+        ).catch(() => {});
         break;
       case MessageType.SyncComplete:
         _handleSyncComplete(peerId, msg.roomCode);
@@ -2556,6 +2547,10 @@ function _broadcastChatWire(wire: WireChatMessage, roomCode: string): void {
     messages: [wire],
     batchIndex: 0,
     totalBatches: 1,
+    // Not history repair: whichever copy of this message lands first is the
+    // one that has to announce it, because the publish above is dropped
+    // outright when the mesh has no topic peers for the room.
+    live: true,
   });
   // DM rooms have no roomUsers roster - the direct copy goes to the one peer
   // the conversation is with (plugin cards and files ride this path too).

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -251,6 +251,13 @@ export interface WireSyncBatch {
   messages: WireChatMessage[];
   batchIndex: number;
   totalBatches: number;
+  /**
+   * This batch is the direct copy of a live send, not history repair. The
+   * receiver announces a live batch (sound, notification) and stays quiet for
+   * repair, which would otherwise beep once per recovered message. Absent from
+   * older senders, which is why quiet is the default.
+   */
+  live?: boolean;
 }
 
 export interface WireSyncComplete {


### PR DESCRIPTION
Stack 1/4 — base `main`.

## The bug

Room chat is delivered **twice**, on purpose. `_broadcastChatWire` publishes to the room's gossipsub topic *and* hands every connected member a direct one-message `SyncBatch`, because a publish into a mesh with no topic peers for the room is silently dropped (`allowPublishToZeroTopicPeers`).

Only the pubsub arm announced the message. And it announces only what is new to storage — so whenever the direct copy landed first, the message was already stored, already painted, and completely silent. No sound, no notification.

The direct copy wins deterministically whenever the mesh has no topic peers for that room, which is exactly the case the second delivery was added to cover, plus a race the rest of the time.

DM text has no second delivery — one envelope, one receive path, always announces. That asymmetry is why DMs kept beeping and rooms did not.

## The fix

Both arms announce, and `announce.ts` keeps it to one sound per message by claiming the id before it does anything else. The sender marks its direct copy `live` so the receiver can tell a live send from history repair, which must stay quiet or a sync would beep once per recovered message.

Announcing moves out of the transport into its own module. Two callers deciding whether to make a sound need one place that decides and one place that remembers what has already been said. The transport knows how a message arrived; `announce.ts` knows how to say so.

## Also in here

- The notification titled a background room's message with the name of the room **on screen**, pointing the reader at the wrong conversation. It uses the message's own room now.
- DM files and plugin cards ride the room broadcast path, so they announced as room messages. The funnel speaks both shapes.
- The message chime scheduled its second note with a 45 ms `setTimeout`. A background tab clamps that to a second — so the one cue that exists for an unfocused window arrived as a lonely blip. Both notes go on the audio clock.
- The AudioContext unlock listeners removed themselves after the first gesture. A context suspended later (mobile backgrounding, an audio-session interruption) never recovered and the session stayed mute. Every gesture re-arms it.

## Verification

`src/lib/announce.test.ts` — 11 cases over the funnel: announce-once across two deliveries, self-authored silence, reactions and plugin updates, mention titling, the DM shape, plugin-card bodies, unknown rooms, file messages.

Driven in a real browser against the live modules, counting oscillators on the actual `AudioContext`:

| case | notes scheduled |
|---|---|
| first delivery | 2 — 880 Hz at +0 s, 1175 Hz at **+0.045 s on the audio clock** |
| second delivery of the same message | 0 |
| message in a room you are not viewing | 2 |
| your own message back through sync | 0 |
| a reaction | 0 |
| sounds switched off in settings | 0 |

`AudioContext.state` was `running`, so those are audible rather than scheduled into silence.

The focus axis cannot be driven in a headless browser (it always reports itself unfocused) — that is why `notify-rules.ts` exists and is unit-tested; it is unchanged here.

Full suite green.

---

## No before / after screenshot

Deliberately. This change is audible, not visible: the same messages arrived on screen before and after, they just made no sound. A screenshot of that is two identical images.

The evidence is the oscillator table above, taken from the real `AudioContext` in a browser — including the second note moving from a `setTimeout` a background tab clamps to a second, onto the audio clock at +0.045 s.

The one visible part is the notification title, which named the room on screen rather than the message's own room. Notifications are OS chrome and need a granted permission, so they cannot be captured headlessly; `announce.test.ts` asserts the title instead.
