### PR TITLE
fix: the Rooms switch carries an unread counter, and the counter can be trusted

### DIFF
--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -1023,6 +1023,13 @@
     if (messages.length > 0) markSeen().catch(() => {});
   });
 
+  // markSeen refuses to run while the page is hidden, so the room the user was
+  // parked on keeps its unread count in a background tab. Catch it up the
+  // moment they look again.
+  function markSeenOnReturn(): void {
+    if (document.visibilityState === "visible") markSeen().catch(() => {});
+  }
+
   function shouldShowHeader(current: Message, previous?: Message): boolean {
     if (!previous) return true;
     const a = senderDid(current.senderId) || current.senderId;
@@ -1280,6 +1287,8 @@
     }
   }}
 />
+
+<svelte:document onvisibilitychange={markSeenOnReturn} />
 
 <div
   use:viewportHeight

--- a/frontend/src/lib/components/RoomSidebar.svelte
+++ b/frontend/src/lib/components/RoomSidebar.svelte
@@ -99,6 +99,19 @@
     y: number;
   } | null>(null);
 
+  // The Rooms switch had no counter while the DMs switch did, so unread room
+  // traffic was invisible from the DMs tab. Same rule as the per-room badges:
+  // the room on screen is being read, so it does not count.
+  const roomUnreadTotal = $derived(
+    rooms.reduce(
+      (sum, room) =>
+        room.roomCode === activeRoomCode
+          ? sum
+          : sum + (unreadCounts.get(room.roomCode) ?? 0),
+      0
+    )
+  );
+
   // Same clamp the other context menus use, so a right-click near the edge
   // does not render the menu offscreen.
   function clampMenu(x: number, y: number) {
@@ -291,12 +304,19 @@
             type="button"
             onclick={() => onChangeTab("rooms")}
             aria-label="Rooms"
-            class="inline-flex size-9 items-center justify-center rounded-md transition-colors cursor-pointer {activeTab ===
+            class="relative inline-flex size-9 items-center justify-center rounded-md transition-colors cursor-pointer {activeTab ===
             'rooms'
               ? 'bg-accent text-accent-foreground'
               : 'text-muted-foreground hover:bg-accent/50'}"
           >
             <Hash class="size-4" />
+            {#if roomUnreadTotal > 0}
+              <span
+                class="absolute -top-1 -right-1 inline-flex min-w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] font-bold items-center justify-center px-1 tabular-nums"
+              >
+                {Math.min(roomUnreadTotal, 99)}
+              </span>
+            {/if}
           </button>
         {/snippet}
       </Tip>
@@ -364,6 +384,13 @@
       onclick={() => onChangeTab("rooms")}
     >
       Rooms
+      {#if roomUnreadTotal > 0}
+        <span
+          class="ml-1 inline-flex min-w-4.5 h-4.5 rounded-full bg-primary text-primary-foreground text-[10px] font-bold items-center justify-center px-1 tabular-nums"
+        >
+          {Math.min(roomUnreadTotal, 99)}
+        </span>
+      {/if}
     </button>
     <button
       type="button"

--- a/frontend/src/lib/rooms.svelte.ts
+++ b/frontend/src/lib/rooms.svelte.ts
@@ -97,7 +97,13 @@ export async function refreshDmRooms(): Promise<void> {
 }
 
 export async function refreshUnreadCount(roomCode: string): Promise<void> {
-  const room = roomsStore.rooms.find((r) => r.roomCode === roomCode);
+  // Fall back to the database when the mirror has not caught up: a message can
+  // arrive for a room whose record exists but whose sidebar entry is still in
+  // flight (a deep-link join), and dropping the count there left the badge
+  // dark until the next full sweep.
+  const room =
+    roomsStore.rooms.find((r) => r.roomCode === roomCode) ??
+    (await getRoom(roomCode));
   if (!room) return;
   const count = await getUnreadCount(
     roomCode,
@@ -106,9 +112,10 @@ export async function refreshUnreadCount(roomCode: string): Promise<void> {
   );
   // If markSeen advanced the watermark while the count was in flight, this
   // result is stale - writing it would relight the badge on a room the user
-  // is reading. Drop it; the next event recomputes.
+  // is reading. Drop it; the next event recomputes. A room still absent from
+  // the mirror cannot have been read through it, so it keeps its count.
   const now = roomsStore.rooms.find((r) => r.roomCode === roomCode);
-  if (!now || now.lastSeenLamport !== room.lastSeenLamport) return;
+  if (now && now.lastSeenLamport !== room.lastSeenLamport) return;
   const next = new Map(roomsStore.unreadCounts);
   next.set(roomCode, count);
   roomsStore.unreadCounts = next;
@@ -130,23 +137,27 @@ async function _refreshAllActivity(): Promise<void> {
   roomsStore.lastActivity = merged;
 }
 
+/**
+ * Recount every room. Authoritative, not seed-only: it counts from each room's
+ * persisted watermark, which is the same source markSeen writes, so a room the
+ * user has just read counts zero anyway. Skipping rooms already in the map
+ * meant a second sweep silently kept stale counts.
+ */
 async function _refreshAllUnread(): Promise<void> {
-  const entries = await Promise.all(
-    roomsStore.rooms.map(async (r) => {
-      const count = await getUnreadCount(
-        r.roomCode,
-        r.lastSeenLamport,
-        selfSenderId()
-      );
-      return [r.roomCode, count] as [string, number];
-    })
+  const before = roomsStore.rooms.map((r) => r.lastSeenLamport);
+  const counts = await Promise.all(
+    roomsStore.rooms.map((r) =>
+      getUnreadCount(r.roomCode, r.lastSeenLamport, selfSenderId())
+    )
   );
   const merged = new Map(roomsStore.unreadCounts);
-  for (const [roomCode, count] of entries) {
-    if (!merged.has(roomCode)) {
-      merged.set(roomCode, count);
-    }
-  }
+  roomsStore.rooms.forEach((room, i) => {
+    // Same staleness rule as refreshUnreadCount: if markSeen moved the
+    // watermark while the sweep was in flight, this count would relight the
+    // badge on a room being read.
+    if (room.lastSeenLamport !== before[i]) return;
+    merged.set(room.roomCode, counts[i]);
+  });
   roomsStore.unreadCounts = merged;
 }
 

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -3031,7 +3031,18 @@ export async function loadMoreMessages(
   return older.length === PAGE_SIZE;
 }
 
+/**
+ * Mark everything loaded in the open conversation as read.
+ *
+ * Only while the page is actually visible. A backgrounded tab parked on a room
+ * kept marking arriving messages read, so that room accrued no unread count and
+ * the tab title and app icon under-counted by exactly its traffic - the whole
+ * point of a counter is to survive not looking. Callers re-run this when the
+ * page comes back.
+ */
 export async function markSeen(): Promise<void> {
+  if (typeof document !== "undefined" && document.visibilityState !== "visible")
+    return;
   const roomCode = transportState.roomCode;
   if (!roomCode) return;
   // Only this room's messages: a sync batch for another room can share the


### PR DESCRIPTION
Stack 2/4 — base `fix/room-message-sounds` (#13).

## The bug

The **DMs** switch showed an unread total. The **Rooms** switch showed nothing. So from the DMs tab, unread room traffic was invisible — the room list holding the per-room badges was not even on screen.

Rooms gets the same total, in the expanded tab and in the icon rail. It excludes the room on screen, for the same reason the per-room badges do: it is being read.

## The counter it reports had three ways to be wrong

- **`markSeen` marked the open room read while the tab was hidden.** A background tab parked on a room therefore accrued no unread count at all, and the tab title and app icon under-counted by exactly that room's traffic. Surviving not looking is the entire job of a counter. It now refuses while the page is hidden, and `ChatView` catches the room up when the page comes back.
- **`refreshUnreadCount` dropped the count for any room missing from the sidebar mirror.** A message arriving during a deep-link join hit that, and the full sweep runs once, so the badge stayed dark until a reload. It falls back to the database, the way `saveRoom` already does.
- **The full sweep only filled rooms it had no entry for**, so a second sweep would keep every stale count. It is authoritative now, with the same in-flight staleness check `refreshUnreadCount` uses.

## Not changed

`selfSenderId()` returning `undefined` before the DID loads looks like a fourth defect, but every path that reaches it runs post-unlock, where the DID is set. Fixing it would need a dependency inversion — `rooms.svelte.ts` cannot import the transport — for a case that does not occur.

## Verification

Driven in a real browser: two rooms, three messages seeded from another sender into the room **not** on screen.

- Rooms switch reads `Rooms 3`
- The Dogs row carries its own `3`
- Tab title reads `(3) Awful.chat`

Visibility guard, against the live modules:

| | unread on `dogs` |
|---|---|
| after 3 more arrive | 6 |
| `markSeen()` while `visibilityState === "hidden"` | **6 — held** |
| `markSeen()` after returning to visible | 0 |

Catch-up wiring, through the real `visibilitychange` event with `ChatView` mounted: the stored watermark held while hidden and advanced to the arriving message's lamport on return.

Full suite green.

---

## Before / after

Two rooms. Three unread messages from somebody else in **Dogs**, which is not the room on screen.

|  | Before | After |
|---|---|---|
| **Rooms tab** | ![Rooms switch with no counter, Dogs carrying its own badge of 3](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/rooms-badge-before.png) | ![Rooms switch reading 3, Dogs still carrying its own badge](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/rooms-badge-after.png) |
| **DMs tab** — the actual complaint | ![DMs tab: the DMs switch shows 3, the Rooms switch shows nothing, and the room list is off screen](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/rooms-badge-dmstab-before.png) | ![DMs tab: the Rooms switch now reads 3 alongside the DMs switch](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/rooms-badge-dmstab-after.png) |

The second row is the point. From the DMs tab the room list is not on screen at all, so before this change there was nothing anywhere to say three messages were waiting in Dogs.
