### PR TITLE
feat: a way back to the call you are in

### DIFF
--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -26,6 +26,7 @@
     refreshPhonebook,
     refreshDmRooms,
   } from "$lib/rooms.svelte";
+  import { uiState } from "$lib/ui-state.svelte";
   import {
     getMessages,
     getLastMessage,
@@ -380,6 +381,31 @@
     sidebarTab = "rooms";
     sidebarOpen = false;
   }
+
+  /**
+   * Take the user back to the call they are in. The call survives navigating
+   * away - only the stage unmounts, because it is gated on the conversation on
+   * screen being the call's - so getting back is pure navigation. Nothing is
+   * rejoined.
+   */
+  async function returnToCall(): Promise<void> {
+    const code = transportState.callRoomCode;
+    if (!code) return;
+    if (code.startsWith("dm-")) {
+      const peer = roomsStore.dmRooms.find(
+        (r) => r.roomCode === code
+      )?.participantDid;
+      if (peer) await handleSelectDm(peer);
+      return;
+    }
+    await handleSelectRoom(code);
+  }
+
+  $effect(() => {
+    if (!uiState.returnToCallRequested) return;
+    uiState.returnToCallRequested = false;
+    void returnToCall();
+  });
 
   function dmTitleFor(peerId: string): string {
     const did = peerIdToDid(peerId);

--- a/frontend/src/lib/components/CallStatus.svelte
+++ b/frontend/src/lib/components/CallStatus.svelte
@@ -6,12 +6,15 @@
     _voice,
   } from "$lib/transport/transport.svelte";
   import {
+    CornerUpLeft,
     Headphones,
     Signal,
     SignalHigh,
     WifiOff,
     Radio,
   } from "@lucide/svelte";
+  import { roomsStore } from "$lib/rooms.svelte";
+  import { requestReturnToCall } from "$lib/ui-state.svelte";
   import { onMount, onDestroy } from "svelte";
   import { cn } from "$lib/utils";
   import type { TransportStatus } from "$lib/transport/types";
@@ -171,57 +174,99 @@
     return quality === "connecting" ? getStatusConfig("p2p") : base;
   });
   const StatusIcon = $derived(config.icon);
+
+  // The room the CALL is in, not the one on screen. Reading transportState
+  // .roomName meant that as soon as you looked elsewhere the chip announced
+  // "Connected" under the name of a room you were not calling in.
+  const callRoomName = $derived.by(() => {
+    const code = transportState.callRoomCode;
+    if (!code) return "Voice";
+    if (code.startsWith("dm-")) {
+      const did = roomsStore.dmRooms.find(
+        (r) => r.roomCode === code
+      )?.participantDid;
+      return (did && transportState.peerNames.get(did)) || "Direct call";
+    }
+    return roomsStore.rooms.find((r) => r.roomCode === code)?.name || code;
+  });
+
+  // Away from the call the chip stops being a status line and becomes the way
+  // back: nothing else on screen leads there, and the call keeps running
+  // regardless of what the user is looking at.
+  const away = $derived(
+    transportState.inCall &&
+      !!transportState.callRoomCode &&
+      transportState.uiRoomCode !== transportState.callRoomCode
+  );
 </script>
 
 {#if transportState.inCall}
   {#if collapsed}
     <Tip
-      text={`${config.label} · ${transportState.roomName || "Voice"}${
+      text={`${away ? "Back to call · " : ""}${config.label} · ${callRoomName}${
         quality === "relayed" ? " · relayed" : ""
       }${deafened ? " · deafened" : ""}`}
       side="right"
     >
       {#snippet children(props)}
-        <div
+        <svelte:element
+          this={away ? "button" : "div"}
           {...props}
+          type={away ? "button" : undefined}
+          role={away ? "button" : undefined}
+          aria-label={away ? `Back to call in ${callRoomName}` : undefined}
+          onclick={away ? requestReturnToCall : undefined}
           class={cn(
             "mx-2 mb-2 flex items-center justify-center rounded-lg border py-2",
             config.bg,
-            config.border
+            config.border,
+            away && "cursor-pointer hover:brightness-125"
           )}
         >
-          <StatusIcon class={cn("size-5", config.color)} />
-        </div>
+          {#if away}
+            <CornerUpLeft class={cn("size-5", config.color)} />
+          {:else}
+            <StatusIcon class={cn("size-5", config.color)} />
+          {/if}
+        </svelte:element>
       {/snippet}
     </Tip>
   {:else}
-    <div
+    <svelte:element
+      this={away ? "button" : "div"}
+      type={away ? "button" : undefined}
+      role={away ? "button" : undefined}
+      aria-label={away ? `Back to call in ${callRoomName}` : undefined}
+      onclick={away ? requestReturnToCall : undefined}
       class={cn(
         "flex items-center justify-between px-3 py-2 rounded-lg border text-sm mb-2",
         config.bg,
-        config.border
+        config.border,
+        away && "w-full text-left cursor-pointer hover:brightness-125"
       )}
     >
-      <div class="flex items-center gap-2">
-        <div class={cn("relative", config.color)}>
-          <StatusIcon class="size-5" />
-          {#if quality === "failed"}
-            <div class="absolute inset-0 flex items-center justify-center">
-              <div class="w-0.5 h-3 bg-current rotate-45"></div>
-            </div>
+      <div class="flex items-center gap-2 min-w-0">
+        <div class={cn("relative shrink-0", config.color)}>
+          {#if away}
+            <CornerUpLeft class="size-5" />
+          {:else}
+            <StatusIcon class="size-5" />
+            {#if quality === "failed"}
+              <div class="absolute inset-0 flex items-center justify-center">
+                <div class="w-0.5 h-3 bg-current rotate-45"></div>
+              </div>
+            {/if}
           {/if}
         </div>
-        <div class="flex flex-col">
+        <div class="flex flex-col min-w-0">
           <span class={cn("font-medium text-xs", config.color)}
-            >{config.label}</span
+            >{away ? "Back to call" : config.label}</span
           >
-          <span class="text-[10px] text-gray-400"
-            >{transportState.roomName || "Voice"}</span
-          >
+          <span class="text-[10px] text-gray-400 truncate">{callRoomName}</span>
         </div>
       </div>
 
-      <div class="flex items-center gap-1">
+      <div class="flex items-center gap-1 shrink-0">
         {#if quality === "relayed"}
           <Tip text="Connected via TURN relay">
             {#snippet children(props)}
@@ -244,6 +289,6 @@
           </Tip>
         {/if}
       </div>
-    </div>
+    </svelte:element>
   {/if}
 {/if}

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -38,6 +38,7 @@
     Star,
     ChessQueen,
     ThumbsUp,
+    CornerUpLeft,
   } from "@lucide/svelte";
   import { Button } from "$lib/components/ui/button";
   import { Badge } from "$lib/components/ui/badge";
@@ -83,7 +84,7 @@
   import { makeHostApi } from "$lib/plugins/host";
   import PluginIcon from "$lib/plugins/PluginIcon.svelte";
   import UserProfileCard from "./UserProfileCard.svelte";
-  import { openSettings } from "$lib/ui-state.svelte";
+  import { openSettings, requestReturnToCall } from "$lib/ui-state.svelte";
   import { identityStore } from "$lib/identity/identity.svelte";
   import { getRegistry, getPlugin } from "$lib/plugins/registry";
   import { isPluginEnabled } from "$lib/plugins/prefs.svelte";
@@ -1374,6 +1375,30 @@
               >
                 <Phone class="size-4" />
               </Button>
+            {/snippet}
+          </Tip>
+        {:else if callRoomCode && callRoomCode !== roomCode}
+          <!--
+            The call is live in another conversation and its stage is not on
+            screen. The sidebar chip also leads back, but below sm the sidebar
+            is off-canvas - so the way back has to exist here too, and this slot
+            is empty in exactly this state.
+          -->
+          <Tip text="Back to the call you are in">
+            {#snippet children(props)}
+              <button
+                {...props}
+                type="button"
+                onclick={requestReturnToCall}
+                aria-label="Back to call"
+                class="flex items-center gap-1.5 rounded-full border border-green-500/20 bg-green-500/10 px-2 py-1 text-xs font-mono text-green-400 hover:brightness-125 cursor-pointer"
+              >
+                <span
+                  class="size-1.5 rounded-full bg-green-400 animate-pulse"
+                ></span>
+                <CornerUpLeft class="size-3.5" />
+                <span class="hidden sm:inline">Back to call</span>
+              </button>
             {/snippet}
           </Tip>
         {/if}

--- a/frontend/src/lib/ui-state.svelte.ts
+++ b/frontend/src/lib/ui-state.svelte.ts
@@ -6,9 +6,19 @@
 export const uiState = $state({
   settingsOpenRequested: false,
   settingsTab: null as string | null,
+  /**
+   * Somebody asked to be taken back to the call they are in. Only AppView knows
+   * how to get there - it owns the active conversation - and the button lives
+   * in the sidebar, so the request travels through here.
+   */
+  returnToCallRequested: false,
 });
 
 export function openSettings(tab: string | null = null): void {
   uiState.settingsTab = tab;
   uiState.settingsOpenRequested = true;
+}
+
+export function requestReturnToCall(): void {
+  uiState.returnToCallRequested = true;
 }


### PR DESCRIPTION
Stack 3/4 — base `fix/rooms-tab-unread-badge` (#14).

## The gap

The call survives navigating away. `joinRoom` never touches `inCall` or `callRoomCode`, and every hangup is guarded on room identity — only the *stage* unmounts, because it is gated on the conversation on screen being the call's.

So opening a DM while in a call leaves you in a live call with no route back to it.

## Two surfaces lead back

One cannot cover both layouts.

- **The sidebar call chip.** Already mounted for the whole session and already gated on being in a call rather than on looking at it, so it was in the right place — it was just a dead `div`. Away from the call it becomes the button back, in the expanded sidebar and in the icon rail.
- **A pill in the chat header**, for mobile: below `sm` the sidebar is an off-canvas slide-over, so the chip is physically off screen. The header's call slot is empty in exactly this state, because the Join-call button hides while you are in a call.

Both write to the existing `uiState` request bus rather than threading a 27th prop through `RoomSidebar`. `AppView` owns the active conversation, so it owns getting back there — dispatching on `dm-` to the DM or room handler. Nothing is rejoined; navigating the view back to `callRoomCode` re-satisfies the gate and the stage remounts unchanged.

## The chip also lied

It read the name of the room **on screen**, so navigating away left it announcing "Connected" under a room you were not calling in. It names the call's own room now, resolving a `dm-` code to the peer.

## Verification

Driven in a real browser with a live call in `dogs` while looking at `cats`:

- The chip renders as a real `<button>`, `aria-label="Back to call in Dogs"`, reading `Back to call / Dogs` — the **call's** room, not the one on screen
- Clicking it sets `returnToCallRequested`; `AppView` consumes the flag and attempts the navigation
- With `uiRoomCode === callRoomCode` it reverts to a plain status `div` reading `Waiting for others / Dogs`

The navigation itself needs a relay, which is not reachable in this environment (no Docker, and the Go module proxy is unreachable), so the join reports `Transport not connected to relay` — which is itself the proof that `returnToCall` ran and dispatched to `handleSelectRoom`. The header pill needs `ChatView` mounted on a joined room, so it is compile-verified only.

Full suite green.

---

## Before / after

A live call in **Dogs**, with Marta's DM open — the situation from the report: in a call, then you "enter" somewhere else.

|  | Before | After |
|---|---|---|
| **Sidebar chip** | ![Sidebar chip reading Waiting for others over the name Marta, not clickable](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/call-return-sidebar-before.png) | ![Sidebar chip reading Back to call over the name Dogs, now a button](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/call-return-sidebar-after.png) |
| **Chat header** | ![Chat header with no call affordance at all](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/call-return-header-before.png) | ![Chat header with a green Back to call pill beside the title](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/call-return-header-after.png) |

Look at the chip in the first shot: **"Waiting for others / Marta"**. The call is in Dogs. It was naming the conversation on screen, so the one element that knew a call was live pointed at the wrong room — and it was a plain `div`, so there was nothing to click either.

The header row is the mobile case. Below `sm` the sidebar is an off-canvas slide-over, so the chip is not on screen at all; that header slot is empty in exactly this state because the Join-call button hides while you are in a call.
