### PR TITLE
feat: DM somebody from a call in a floating panel

### DIFF
--- a/frontend/src/lib/actions/draggable.ts
+++ b/frontend/src/lib/actions/draggable.ts
@@ -1,0 +1,77 @@
+/**
+ * Drag a floating panel by a handle inside it.
+ *
+ * Applied to the handle, not the panel: a panel dragged by its whole surface
+ * cannot hold a scrollable list or a text input. Pointer capture, so a fast
+ * drag that outruns the cursor does not drop the panel where the pointer left
+ * the element.
+ */
+export function draggable(
+  node: HTMLElement,
+  params: {
+    /** Current position, so the drag starts where the panel actually is. */
+    get: () => { x: number; y: number };
+    /** Clamped position, every move. */
+    set: (pos: { x: number; y: number }) => void;
+    /** Panel size, to keep it on screen. */
+    size: () => { width: number; height: number };
+  }
+): { destroy(): void } {
+  if (typeof window === "undefined") return { destroy() {} };
+
+  const EDGE = 8;
+  let from: { x: number; y: number; pointerX: number; pointerY: number } | null =
+    null;
+
+  const onDown = (e: PointerEvent) => {
+    // A drag handle usually carries buttons (close, expand). Let them win.
+    if ((e.target as HTMLElement).closest("button")) return;
+    if (e.button !== 0) return;
+    const at = params.get();
+    from = { x: at.x, y: at.y, pointerX: e.clientX, pointerY: e.clientY };
+    node.setPointerCapture(e.pointerId);
+    e.preventDefault();
+  };
+
+  const onMove = (e: PointerEvent) => {
+    if (!from) return;
+    const { width, height } = params.size();
+    // Clamped against the viewport, not the movement: a panel dragged off the
+    // edge cannot be dragged back, because its handle went with it.
+    params.set({
+      x: Math.max(
+        EDGE,
+        Math.min(
+          from.x + (e.clientX - from.pointerX),
+          window.innerWidth - width - EDGE
+        )
+      ),
+      y: Math.max(
+        EDGE,
+        Math.min(
+          from.y + (e.clientY - from.pointerY),
+          window.innerHeight - height - EDGE
+        )
+      ),
+    });
+  };
+
+  const onUp = (e: PointerEvent) => {
+    from = null;
+    if (node.hasPointerCapture(e.pointerId)) node.releasePointerCapture(e.pointerId);
+  };
+
+  node.addEventListener("pointerdown", onDown);
+  node.addEventListener("pointermove", onMove);
+  node.addEventListener("pointerup", onUp);
+  node.addEventListener("pointercancel", onUp);
+
+  return {
+    destroy() {
+      node.removeEventListener("pointerdown", onDown);
+      node.removeEventListener("pointermove", onMove);
+      node.removeEventListener("pointerup", onUp);
+      node.removeEventListener("pointercancel", onUp);
+    },
+  };
+}

--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -54,11 +54,13 @@
   } from "$lib/components/ui/drawer";
   import {
     addToPhonebook,
+    closeDmPanel,
     dmConversationCodeFor,
     openDmConversation,
     removeDmConversation,
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
+  import FloatingDmPanel from "$lib/components/FloatingDmPanel.svelte";
 
   const queryClient = new QueryClient();
 
@@ -406,6 +408,15 @@
     uiState.returnToCallRequested = false;
     void returnToCall();
   });
+
+  /**
+   * Promote the floating panel's conversation to the full DMs view. The panel
+   * closes: leaving it open over the same conversation would show it twice.
+   */
+  async function expandDmPanel(peerId: string): Promise<void> {
+    closeDmPanel();
+    await handleSelectDm(peerId);
+  }
 
   function dmTitleFor(peerId: string): string {
     const did = peerIdToDid(peerId);
@@ -1316,4 +1327,11 @@
   <ReloadPrompt />
 
   <TransportStatus />
+
+  <!--
+    Here, not inside ChatView or the call view: both unmount when the user
+    leaves the conversation or the call ends, and a floating panel that dies
+    with the surface it was opened from is not floating.
+  -->
+  <FloatingDmPanel onExpand={expandDmPanel} />
 </QueryClientProvider>

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -76,7 +76,7 @@
   import { formatReactorNames } from "$lib/reaction-names";
   import {
     addToPhonebook,
-    openDmConversation,
+    openDmPanel,
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
   import { joinCall } from "$lib/transport/call.svelte";
@@ -1224,7 +1224,10 @@
     if (onOpenDm) {
       await onOpenDm(peerId);
     } else {
-      await openDmConversation(peerId);
+      // No host to switch the view for us, so the panel: openDmConversation
+      // only moves the transport, leaving this pane rendering the room it is
+      // still keyed to and the DM invisible.
+      await openDmPanel(peerId);
     }
     closeUserMenu();
   }

--- a/frontend/src/lib/components/FloatingDmPanel.svelte
+++ b/frontend/src/lib/components/FloatingDmPanel.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import { CornerUpLeft, Minus, Send, X } from "@lucide/svelte";
+  import { Tip } from "$lib/components/ui/tooltip";
+  import { draggable } from "$lib/actions/draggable";
+  import {
+    BAR_HEIGHT,
+    HEIGHT,
+    WIDTH,
+    dmPanel,
+    defaultPanelPosition,
+  } from "$lib/dm-panel.svelte";
+  import { closeDmPanel, sendDirectMessage } from "$lib/transport/dm.svelte";
+  import {
+    requestFileDownload,
+    selfId,
+    transportState,
+  } from "$lib/transport/transport.svelte";
+  import MsgRender from "./MsgRender.svelte";
+  import { MessageType, type Message } from "$lib/types/message";
+
+  interface Props {
+    /** Focus this conversation in the DMs tab and close the panel. */
+    onExpand: (peerId: string) => void;
+  }
+  let { onExpand }: Props = $props();
+
+  let draft = $state("");
+  let sending = $state(false);
+  let list = $state<HTMLDivElement | null>(null);
+
+  // Reactions are folded onto their target elsewhere; on their own they are
+  // rows with nothing to read.
+  const visible = $derived(
+    dmPanel.messages.filter((m) => m.type !== MessageType.Reaction)
+  );
+
+  /**
+   * Same rule the chat pane uses: a header when the speaker changes, or after a
+   * two minute gap. A DM has two participants, so the name and the time are the
+   * whole header - the pane's avatars, colours and tags do not fit 340px.
+   */
+  function startsGroup(current: Message, previous?: Message): boolean {
+    if (!previous) return true;
+    if (current.senderId !== previous.senderId) return true;
+    return current.timestamp - previous.timestamp > 2 * 60 * 1000;
+  }
+
+  function formatTime(ts: number): string {
+    return new Date(ts).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  }
+
+  const height = $derived(dmPanel.minimized ? BAR_HEIGHT : HEIGHT);
+
+  // A viewport that shrank under a parked panel (rotation, a resized window)
+  // would otherwise leave it half off screen with its drag handle out of reach.
+  function clampToViewport(): void {
+    if (!dmPanel.peerId) return;
+    dmPanel.x = Math.max(8, Math.min(dmPanel.x, window.innerWidth - WIDTH - 8));
+    dmPanel.y = Math.max(8, Math.min(dmPanel.y, window.innerHeight - height - 8));
+  }
+
+  $effect(() => {
+    // Opening reads as a position of 0,0 before the store is seeded.
+    if (dmPanel.peerId && dmPanel.x === 0 && dmPanel.y === 0) {
+      Object.assign(dmPanel, defaultPanelPosition());
+    }
+  });
+
+  $effect(() => {
+    // Track the newest message so an arriving reply is not left below the fold.
+    if (!list || dmPanel.minimized) return;
+    visible.length;
+    list.scrollTop = list.scrollHeight;
+  });
+
+  async function send(): Promise<void> {
+    const body = draft.trim();
+    const peerId = dmPanel.peerId;
+    if (!body || !peerId || sending) return;
+    sending = true;
+    draft = "";
+    try {
+      // Explicit peer: the panel is not the conversation the view is on, which
+      // is the entire point of it.
+      await sendDirectMessage(body, { peerId });
+    } finally {
+      sending = false;
+    }
+  }
+
+  function onKeydown(e: KeyboardEvent): void {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void send();
+    }
+  }
+</script>
+
+<svelte:window onresize={clampToViewport} />
+
+{#if dmPanel.peerId}
+  <!--
+    z-50 is the app's chrome layer, shared with context menus and dialogs, and
+    the panel belongs with them: it floats over a live call without stealing
+    focus the way a modal dialog would.
+  -->
+  <div
+    class="fixed z-50 flex flex-col overflow-hidden rounded-lg border border-border bg-card font-mono shadow-2xl"
+    style="left: {dmPanel.x}px; top: {dmPanel.y}px; width: {WIDTH}px; height: {height}px;"
+  >
+    <div
+      use:draggable={{
+        get: () => ({ x: dmPanel.x, y: dmPanel.y }),
+        set: (pos) => {
+          dmPanel.x = pos.x;
+          dmPanel.y = pos.y;
+        },
+        size: () => ({ width: WIDTH, height }),
+      }}
+      class="flex h-10 shrink-0 cursor-grab touch-none items-center gap-1 border-b border-border bg-muted/40 px-2 active:cursor-grabbing"
+    >
+      <span class="min-w-0 flex-1 truncate text-xs font-medium">
+        {dmPanel.peerName || "Direct message"}
+      </span>
+
+      <Tip text="Open in the DMs tab">
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={() => dmPanel.peerId && onExpand(dmPanel.peerId)}
+            aria-label="Expand conversation"
+            class="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <CornerUpLeft class="size-3.5 rotate-180" />
+          </button>
+        {/snippet}
+      </Tip>
+      <Tip text={dmPanel.minimized ? "Expand panel" : "Collapse to the bar"}>
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={() => (dmPanel.minimized = !dmPanel.minimized)}
+            aria-label={dmPanel.minimized ? "Restore panel" : "Minimize panel"}
+            class="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <Minus class="size-3.5" />
+          </button>
+        {/snippet}
+      </Tip>
+      <Tip text="Close">
+        {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={closeDmPanel}
+            aria-label="Close conversation panel"
+            class="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <X class="size-3.5" />
+          </button>
+        {/snippet}
+      </Tip>
+    </div>
+
+    {#if !dmPanel.minimized}
+      <div bind:this={list} class="flex-1 overflow-y-auto px-2 py-1.5 text-sm">
+        {#if dmPanel.loading}
+          <div class="flex h-full items-center justify-center">
+            <div class="size-2 animate-pulse rounded-full bg-muted-foreground"></div>
+          </div>
+        {:else if visible.length === 0}
+          <p class="px-1 py-4 text-center text-xs text-muted-foreground">
+            No messages yet. Say something.
+          </p>
+        {:else}
+          {#each visible as msg, i (msg.id)}
+            {@const own = msg.senderId === selfId()}
+            {#if startsGroup(msg, visible[i - 1])}
+              <div
+                class="mt-1.5 flex items-baseline gap-1.5 text-xs first:mt-0"
+              >
+                <span
+                  class="truncate font-medium {own
+                    ? 'text-primary'
+                    : 'text-foreground'}"
+                >
+                  {own ? "You" : dmPanel.peerName || msg.senderName}
+                </span>
+                <span class="shrink-0 text-[10px] text-muted-foreground">
+                  {formatTime(msg.timestamp)}
+                </span>
+              </div>
+            {/if}
+            <MsgRender
+              {msg}
+              isOwn={own}
+              fileTransfers={transportState.fileTransfers}
+              onRequestFileDownload={requestFileDownload}
+            />
+          {/each}
+        {/if}
+      </div>
+
+      <div class="flex shrink-0 items-center gap-1.5 border-t border-border p-2">
+        <input
+          bind:value={draft}
+          onkeydown={onKeydown}
+          placeholder="Message {dmPanel.peerName}"
+          aria-label="Message"
+          class="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1.5 text-xs outline-none focus:border-primary"
+        />
+        <button
+          type="button"
+          onclick={send}
+          disabled={!draft.trim() || sending}
+          aria-label="Send"
+          class="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md bg-primary text-primary-foreground disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <Send class="size-3.5" />
+        </button>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/lib/components/UserListSidebar.svelte
+++ b/frontend/src/lib/components/UserListSidebar.svelte
@@ -10,7 +10,7 @@
   } from "$lib/transport/transport.svelte";
   import { looksLikePeerId } from "$lib/identity/identity-utils";
   import {
-    openDmConversation,
+    openDmPanel,
     addToPhonebook,
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
@@ -278,7 +278,10 @@
     if (onOpenDm) {
       onOpenDm(peerId);
     } else {
-      await openDmConversation(peerId);
+      // No host to switch the view for us, so the panel: openDmConversation
+      // only moves the transport, leaving the pane rendering the room it is
+      // still keyed to and the DM invisible.
+      await openDmPanel(peerId);
     }
     closeUserMenu();
   }

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -4,7 +4,7 @@
   import { formatReactorNames } from "$lib/reaction-names";
   import GifImage from "./GifImage.svelte";
   import { RELAY_TIP } from "$lib/copy";
-  import { openDmConversation } from "$lib/transport/dm.svelte";
+  import { openDmPanel } from "$lib/transport/dm.svelte";
   import {
     getVoicePeerVolume,
     setVoicePeerVolume,
@@ -227,10 +227,16 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
     if (peerMenu) setVoicePeerVolume(peerMenu.peerId, sliderToGain(value));
   }
 
+  /**
+   * The floating panel, not the chat pane. Pointing the pane at the DM unmounts
+   * this call stage - the stage is gated on the pane showing the call's room -
+   * and the pane filters messages by the room the VIEW is on, so the DM
+   * rendered as an empty conversation you could send into but never see.
+   */
   async function dmFromPeerMenu(): Promise<void> {
     const peerId = peerMenu?.peerId;
     closeMenus();
-    if (peerId) await openDmConversation(peerId);
+    if (peerId) await openDmPanel(peerId);
   }
 
   let speakingPeers = $state(new Set<string>());

--- a/frontend/src/lib/dm-panel.svelte.ts
+++ b/frontend/src/lib/dm-panel.svelte.ts
@@ -1,0 +1,85 @@
+import type { Message } from "./types/message";
+
+/**
+ * A DM conversation floating over whatever is on screen.
+ *
+ * It exists because the in-call "Message" action had nowhere to put a DM. It
+ * pointed the whole chat pane at the conversation, which killed the call stage
+ * (the stage is gated on the pane showing the call's room) and rendered nothing,
+ * because the pane filters messages by the room the VIEW is on and only the
+ * transport had been switched. A second conversation surface, owning its own
+ * message list, is what that action actually needed.
+ *
+ * This module is deliberately a leaf: the transport pushes arriving messages in
+ * here, so it must not import the transport back. Opening and closing live in
+ * dm.svelte.ts, which already knows how to resolve a peer to a conversation.
+ */
+
+export interface DmPanelState {
+  /** The peer whose conversation is open. Null when the panel is closed. */
+  peerId: string | null;
+  /** Its DM room code: a hash of the two DIDs, the key every message carries. */
+  roomCode: string | null;
+  /** Display name for the header. */
+  peerName: string;
+  /**
+   * This panel's own messages. NOT transportState.messages: that array belongs
+   * to the pane behind the panel, and sharing it is precisely how the old
+   * behaviour ended up rendering one conversation's messages under another
+   * conversation's key.
+   */
+  messages: Message[];
+  x: number;
+  y: number;
+  /** Collapsed to its title bar, so a call stays watchable underneath. */
+  minimized: boolean;
+  loading: boolean;
+}
+
+export const WIDTH = 340;
+export const HEIGHT = 420;
+export const BAR_HEIGHT = 40;
+
+export const dmPanel = $state<DmPanelState>({
+  peerId: null,
+  roomCode: null,
+  peerName: "",
+  messages: [],
+  x: 0,
+  y: 0,
+  minimized: false,
+  loading: false,
+});
+
+/** Bottom-right, clear of the call controls, and never off screen. */
+export function defaultPanelPosition(): { x: number; y: number } {
+  if (typeof window === "undefined") return { x: 24, y: 24 };
+  return {
+    x: Math.max(8, window.innerWidth - WIDTH - 24),
+    y: Math.max(8, window.innerHeight - HEIGHT - 96),
+  };
+}
+
+/**
+ * File an arriving or outgoing message into the panel.
+ *
+ * Keyed on the room code, so a message for any other conversation is ignored -
+ * the panel cannot show the wrong thread even while the pane behind it is
+ * switching rooms.
+ */
+export function appendToDmPanel(msg: Message): void {
+  if (!dmPanel.roomCode || msg.roomCode !== dmPanel.roomCode) return;
+  if (dmPanel.messages.some((m) => m.id === msg.id)) return;
+  dmPanel.messages = [...dmPanel.messages, msg].sort((a, b) =>
+    a.lamport !== b.lamport
+      ? a.lamport - b.lamport
+      : a.senderId.localeCompare(b.senderId)
+  );
+}
+
+/** True when the panel is showing this conversation, so it counts as read. */
+export function dmPanelIsShowing(roomCode: string): boolean {
+  return (
+    !!dmPanel.roomCode && dmPanel.roomCode === roomCode && !dmPanel.minimized
+  );
+}

--- a/frontend/src/lib/dm-panel.test.ts
+++ b/frontend/src/lib/dm-panel.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MessageType, type Message } from "./types/message";
+import {
+  appendToDmPanel,
+  dmPanel,
+  dmPanelIsShowing,
+} from "./dm-panel.svelte";
+
+const DM_A = "dm-aaaa";
+const DM_B = "dm-bbbb";
+const ROOM = "cats-and-dogs";
+
+function msg(over: Partial<Message> = {}): Message {
+  return {
+    id: "m1",
+    roomCode: DM_A,
+    senderId: "did:key:them",
+    senderName: "Them",
+    timestamp: 1,
+    lamport: 1,
+    type: MessageType.Text,
+    content: "hello",
+    attachments: [],
+    ...over,
+  };
+}
+
+describe("the floating DM panel's message list", () => {
+  beforeEach(() => {
+    dmPanel.peerId = "did:key:them";
+    dmPanel.roomCode = DM_A;
+    dmPanel.messages = [];
+    dmPanel.minimized = false;
+  });
+
+  it("takes messages for the conversation it is showing", () => {
+    appendToDmPanel(msg());
+    expect(dmPanel.messages.map((m) => m.id)).toEqual(["m1"]);
+  });
+
+  it("refuses another conversation's messages", () => {
+    // The bug this panel replaces: a DM keyed by the hash of two DIDs, rendered
+    // in a pane keyed to the room the VIEW was on. The keys can never match, so
+    // every message was filtered out. Keying on the room code, in one place,
+    // is what makes that impossible here.
+    appendToDmPanel(msg({ id: "other-dm", roomCode: DM_B }));
+    appendToDmPanel(msg({ id: "a-room", roomCode: ROOM }));
+    expect(dmPanel.messages).toEqual([]);
+  });
+
+  it("takes nothing while closed", () => {
+    dmPanel.roomCode = null;
+    appendToDmPanel(msg());
+    expect(dmPanel.messages).toEqual([]);
+  });
+
+  it("holds one copy of a message delivered twice", () => {
+    appendToDmPanel(msg());
+    appendToDmPanel(msg());
+    expect(dmPanel.messages).toHaveLength(1);
+  });
+
+  it("orders by lamport, whatever order messages arrive in", () => {
+    appendToDmPanel(msg({ id: "third", lamport: 3 }));
+    appendToDmPanel(msg({ id: "first", lamport: 1 }));
+    appendToDmPanel(msg({ id: "second", lamport: 2 }));
+    expect(dmPanel.messages.map((m) => m.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("breaks a lamport tie on sender, so both sides agree on the order", () => {
+    appendToDmPanel(msg({ id: "b", lamport: 5, senderId: "did:key:b" }));
+    appendToDmPanel(msg({ id: "a", lamport: 5, senderId: "did:key:a" }));
+    expect(dmPanel.messages.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("dmPanelIsShowing", () => {
+  beforeEach(() => {
+    dmPanel.roomCode = DM_A;
+    dmPanel.minimized = false;
+  });
+
+  it("is true only for the conversation actually on screen", () => {
+    expect(dmPanelIsShowing(DM_A)).toBe(true);
+    expect(dmPanelIsShowing(DM_B)).toBe(false);
+  });
+
+  it("is false while minimized: nobody has read a collapsed panel", () => {
+    dmPanel.minimized = true;
+    expect(dmPanelIsShowing(DM_A)).toBe(false);
+  });
+
+  it("is false while closed", () => {
+    dmPanel.roomCode = null;
+    expect(dmPanelIsShowing(DM_A)).toBe(false);
+  });
+});

--- a/frontend/src/lib/transport/dm.svelte.ts
+++ b/frontend/src/lib/transport/dm.svelte.ts
@@ -16,7 +16,13 @@ import {
   putPhonebookEntry,
   putRoom,
   type DMRoom,
+  getMessages,
 } from "$lib/storage";
+import {
+  appendToDmPanel,
+  defaultPanelPosition,
+  dmPanel,
+} from "$lib/dm-panel.svelte";
 import { MessageType, type Message } from "$lib/types/message";
 import { signMessage } from "$lib/messaging";
 import { leaveCall } from "./call.svelte";
@@ -215,16 +221,84 @@ export async function openDmConversation(
   return true;
 }
 
+/**
+ * Open a conversation in the floating panel, leaving the view alone.
+ *
+ * The counterpart to openDmConversation, which claims the whole chat pane. Use
+ * this when the user asked to message somebody WITHOUT leaving what they are
+ * doing - from a call tile, most obviously, where taking over the pane also
+ * unmounts the call stage.
+ */
+export async function openDmPanel(peerIdOrDid: string): Promise<boolean> {
+  if (!_transport.selfId()) return false;
+  const resolvedPeerId = resolveDmPeerId(peerIdOrDid) ?? peerIdOrDid;
+  if (!resolvedPeerId) return false;
+  const roomCode = await ensureDmRoomForPeer(resolvedPeerId);
+  if (!roomCode) {
+    transportState.error =
+      "Cannot open this conversation yet: waiting to verify who this peer is.";
+    return false;
+  }
+  // Files and plugin cards in a DM ride the room topic, so the panel has to be
+  // subscribed for the same reasons the pane is. Text arrives over a direct
+  // stream either way.
+  _transport.joinRoom(roomCode);
+
+  if (dmPanel.peerId !== resolvedPeerId) {
+    Object.assign(dmPanel, defaultPanelPosition());
+  }
+  dmPanel.peerId = resolvedPeerId;
+  dmPanel.roomCode = roomCode;
+  dmPanel.peerName = resolveDmDisplayName(resolvedPeerId);
+  dmPanel.messages = [];
+  dmPanel.minimized = false;
+  dmPanel.loading = true;
+
+  const page = await getMessages(roomCode);
+  // The user can close the panel, or open another conversation in it, while
+  // the page is in flight.
+  if (dmPanel.roomCode !== roomCode) return false;
+  dmPanel.messages = page;
+  dmPanel.loading = false;
+
+  const selfDid = identityStore.did ?? _transport.selfId();
+  const theirs = page
+    .filter((m) => m.senderId !== selfDid)
+    .map((m) => m.id);
+  if (theirs.length) sendDmReadAcks(resolvedPeerId, theirs);
+  await markRoomSeen(roomCode, page[page.length - 1]?.lamport ?? 0).catch(
+    () => {}
+  );
+  await refreshDmRooms();
+  transportState.dmVersion += 1;
+  return true;
+}
+
+export function closeDmPanel(): void {
+  dmPanel.peerId = null;
+  dmPanel.roomCode = null;
+  dmPanel.peerName = "";
+  dmPanel.messages = [];
+  dmPanel.minimized = false;
+  dmPanel.loading = false;
+}
+
 export interface DirectMessageOptions {
   replyTo?: { id: string; senderName: string; content: string };
   reaction?: { to: string; emoji: string; op: "add" | "remove" };
+  /**
+   * Send to this peer instead of the conversation on screen. The floating DM
+   * panel is a second conversation surface, so "the active DM" stopped being
+   * the only possible answer to "who is this for".
+   */
+  peerId?: string;
 }
 
 export async function sendDirectMessage(
   text: string,
   options: DirectMessageOptions = {}
 ): Promise<void> {
-  const peerId = transportState.activeDmPeerId;
+  const peerId = options.peerId ?? transportState.activeDmPeerId;
   if (!peerId) return;
   const body = text.trim();
   // Reactions travel as empty-bodied envelopes; everything else needs text.
@@ -327,6 +401,10 @@ export async function sendDirectMessage(
   ) {
     transportState.messages = appendSorted(transportState.messages, msg);
   }
+  // The panel keys on the room code, so this is a no-op unless the panel is
+  // showing this very conversation - including when the pane behind it shows
+  // something else entirely, which is the whole reason the panel exists.
+  appendToDmPanel(msg);
 
   await putMessage(msg);
   await setWatermark(roomCode, mySenderId, msg.lamport);

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -94,6 +94,7 @@ import {
   touchCardStates,
 } from "../plugins/state.svelte";
 import { announceMessage } from "../announce";
+import { appendToDmPanel, dmPanelIsShowing } from "../dm-panel.svelte";
 import { profileStore } from "../profile.svelte";
 import { getPlugin } from "../plugins/registry";
 import { _sendCallPresence, _sendCallState, leaveCall } from "./call.svelte";
@@ -2009,8 +2010,18 @@ function _handleDmChatAsync(
         (activeDid === senderDid || activeDid === peerId);
       // Reactions are filtered inside the funnel, same rule as rooms.
       _announceMessage(msg);
+      // The floating panel is a second place this conversation can be on
+      // screen, and it can be showing it while the pane behind shows another
+      // room entirely. Keyed on the room code, so this is a no-op otherwise.
+      appendToDmPanel(msg);
+      // The pane's array belongs to the conversation the pane is on. Appending
+      // to it because the PANEL is showing this DM is how a message ends up
+      // filed under the wrong conversation.
       if (isViewingThisDm) {
         transportState.messages = appendSorted(transportState.messages, msg);
+      }
+      // Visible in either surface means read, not merely delivered.
+      if (isViewingThisDm || dmPanelIsShowing(roomCode)) {
         await markRoomSeen(roomCode, msg.lamport);
         const roomIndex = roomsStore.dmRooms.findIndex(
           (r) => r.roomCode === roomCode
@@ -2026,7 +2037,6 @@ function _handleDmChatAsync(
         }
         await refreshDmRooms();
         transportState.dmVersion += 1;
-        // Conversation is on screen - this message is read, not just delivered
         _transport
           .send(peerId, encodeDmReadEnvelope([envelope.payload.id]))
           .catch(() => {});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
+  plugins: [svelte()],
   resolve: {
     alias: {
       $lib: path.resolve("./src/lib"),


### PR DESCRIPTION
Stack 4/4 — base `feat/return-to-call` (#15).

## The bug

Clicking **Message** on a call participant pointed the whole chat pane at the DM. That did two things wrong at once.

The pane renders `messages.filter(m => m.roomCode === roomCode)`, where `roomCode` is the room the **view** is on — and `openDmConversation` only moves `transportState`, never the view's key. A DM message carries `hash(sorted[selfDid, peerDid])`; the pane was still keyed to the room's join code. The two can never match, so **every** message in the conversation was filtered out: loaded history, incoming replies, and your own echo. You got a DM-looking header over an empty chat you could send into but never see.

And because the pane no longer showed the call's room, the call stage — gated on exactly that — would have been torn off screen had the view been switched properly. The two failures were each other's workaround, which is why routing this through `handleSelectDm` is not the fix.

## The fix

A DM opened from a call is a second conversation, alongside the one on screen, so it gets a second surface.

- Drag it anywhere by its title bar, clamped to the viewport — a panel dragged off the edge cannot be dragged back, because its handle goes with it
- Collapse it to its title bar to watch the call underneath
- **Expand** hands it to the DMs tab when it deserves the whole window

The panel owns its own message list, keyed on its own DM room code. Sharing the pane's array is what filed one conversation's messages under another's key in the first place, and the panel exists precisely to be showing a different conversation from the pane. `dm-panel.svelte.ts` is a deliberate leaf so the transport can feed it without importing it back.

## Supporting changes

- `sendDirectMessage` takes an explicit peer. It read the active conversation from view state, which stopped being the only possible answer to "who is this for" the moment a second surface existed.
- Incoming DMs reach the panel, and count as read when it is showing them — unless it is collapsed, which nobody has read. Marking read and appending to the pane are now separate: appending to the pane's array because the *panel* is showing a DM is the same class of bug.
- The two `else await openDmConversation(peerId)` fallbacks in the user menus carried this bug for any host that did not pass `onOpenDm`. They open the panel now.
- Messages group by speaker with a name and a time, following the pane's own rule (new speaker, or a two-minute gap). The pane's avatars, colours and tags do not fit 340 px, but without attribution you cannot tell who said what.
- `vitest` compiles `.svelte.ts`, so rune-backed stores can be tested at all. All 272 pre-existing tests still pass under it.

## Verification

`src/lib/dm-panel.test.ts` — 9 cases, including the root cause directly: a message for another conversation, or for a room, is refused; duplicates collapse; ordering is lamport-then-sender so both sides agree.

Driven in a real browser:

- `openDmPanel` renders a 340×420 panel with Expand / Minimize / Close / Send — and leaves `transportState.roomCode` `null` and `chatMode` `"room"`: **no pane hijack**
- Messages in both directions render, grouped and attributed
- Dragging the title bar moved it exactly −300, −120; dragging far past the top-left clamps to `8, 8` and past the bottom-right to `innerWidth − 340 − 8, innerHeight − 420 − 8`
- Minimize collapses 420 → 40 px, drops the composer, and `dmPanelIsShowing` goes false; restore returns both
- Expand closes the panel, sets `chatMode: "dm"` and the DM room code on the pane, and switches the sidebar to DMs — the full view then renders the persisted history with avatars and times
- **Coexistence**: with the pane on Peer One's DM and the panel on Peer Two's, both render their own conversation and the pane's message array is unchanged by the panel's traffic

Sending a DM end-to-end needs a connected peer, which needs a relay — not reachable in this environment (no Docker, and the Go module proxy is unreachable). The composer wiring is verified: the button enables on non-empty input, the draft clears, and the explicit peer reaches `sendDirectMessage`.

Unrelated note: with no `VITE_RELAY_MULTIADDR` set, the dev transport sets `transportState.error` to `Cannot read properties of undefined (reading 'split')` on its own, with no send involved. Pre-existing and environment-specific; left alone.

---

## Before / after

Same state in both: a live call in Dogs, **Marta's** conversation in the pane, and **Xavier** picked to message. Xavier has three stored messages either way.

| Before | After |
|---|---|
| ![The pane replaced by an empty chat titled Xavier, while the sidebar still highlights Marta](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/incall-dm-before.png) | ![Marta's conversation intact in the pane, with Xavier's conversation in a floating panel over it](https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/sounds-unread-call-dm/incall-dm-after.png) |

The first shot is the bug, and the tells are all in it at once: the header says **Xavier**, the sidebar highlights **Marta**, the sidebar preview shows Xavier's last message *"nice one"* — and the chat reads *"No messages yet. Say something!"*. The pane was still keyed to Marta while only the transport had moved to Xavier, so every one of his messages was filtered out.

The second shot is the same moment with this branch: Marta's conversation is untouched in the pane, Xavier's is in the panel with his messages, attributed and timestamped, and the panel's own controls sit top-right — expand into the DMs tab, collapse to the title bar, close.

Reproduced by driving `openDmConversation` with the pane keyed to another conversation, which is exactly what the in-call **Message** action did. The pane holding a room rather than a DM changes nothing about the mechanism or the symptom — a relay is not reachable in this environment, so a room could not be joined for the shot.
