### PR TITLE
feat: Cmd/Ctrl+K command palette for rooms, settings and actions

### DIFF
--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -44,6 +44,8 @@
   import { humanizeMentions } from "$lib/mentions";
   import ReloadPrompt from "./ReloadPrompt.svelte";
   import InstallPrompt from "./InstallPrompt.svelte";
+  import CommandPalette from "./palette/CommandPalette.svelte";
+  import type { PaletteHost } from "$lib/palette/host";
   import { Dialog } from "bits-ui";
   import { Notebook, Star, Trash2, Users, X } from "@lucide/svelte";
   import {
@@ -525,6 +527,34 @@
     createJoinOpen = true;
   }
 
+  let paletteOpen = $state(false);
+
+  // Anything outside this tree asks for the palette through uiState, the same
+  // way it asks for the settings dialog.
+  $effect(() => {
+    if (!uiState.paletteOpenRequested) return;
+    uiState.paletteOpenRequested = false;
+    if (identityStore.isUnlocked) paletteOpen = true;
+  });
+
+  // The palette cannot navigate on its own: this component owns activeRoomCode,
+  // the history push, and the room-name broadcast. Reproducing that inside the
+  // palette would fork the join path, so it delegates back here.
+  //
+  // activeRoomCode is a getter, not a snapshot, or the palette would read a
+  // stale room for the whole time it is mounted.
+  const paletteHost: PaletteHost = {
+    get activeRoomCode() {
+      return activeRoomCode;
+    },
+    openRoom: (code) => void handleSelectRoom(code),
+    joinRoomByCode: (code) => void handleJoin(code, ""),
+    openDm: (peerId) => void handleSelectDm(peerId),
+    leaveRoom: handleLeave,
+    removeRoom: (code) => void handleRemoveRoom(code),
+    openCreateJoin,
+  };
+
   // Manifest shortcut: long-press the installed icon > "New room".
   // The param is stripped so a later reload does not reopen the dialog.
   $effect(() => {
@@ -796,10 +826,23 @@
 <svelte:window
   onpopstate={handlePopState}
   onkeydown={(e) => {
+    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+    const key = e.key.toLowerCase();
+
+    // Cmd/Ctrl+K opens the command palette. preventDefault is required even
+    // though nothing here claims the key: Firefox maps it to the search bar.
+    // Stays enabled on mobile, unlike the sidebar shortcut, because an external
+    // keyboard is the whole point of it.
+    if (key === "k") {
+      e.preventDefault();
+      if (!identityStore.isUnlocked) return;
+      paletteOpen = !paletteOpen;
+      return;
+    }
+
     // Cmd/Ctrl+B collapses the room sidebar. The composer is a plain
     // textarea, so there is no native bold to steal.
-    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-    if (e.key.toLowerCase() !== "b") return;
+    if (key !== "b") return;
     if (isMobile) return;
     e.preventDefault();
     setSidebarCollapsed(!displayPrefs.sidebarCollapsed);
@@ -1334,4 +1377,13 @@
     with the surface it was opened from is not floating.
   -->
   <FloatingDmPanel onExpand={expandDmPanel} />
+
+  <!-- Also outside the unlocked branch, for the same reason: mounting it once
+       here means the palette survives lock/unlock and room switches, and it is
+       reachable whether or not a room is open. It is gated on isUnlocked because
+       every command needs an identity, and because openSettings' consumer only
+       exists in the unlocked tree. -->
+  {#if identityStore.isUnlocked}
+    <CommandPalette bind:open={paletteOpen} host={paletteHost} />
+  {/if}
 </QueryClientProvider>

--- a/frontend/src/lib/components/palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/palette/CommandPalette.svelte
@@ -1,0 +1,386 @@
+<script lang="ts">
+  /**
+   * The Cmd-K command palette.
+   *
+   * Composition rationale. The dialog shell is bits-ui `Dialog`, which is what
+   * every other overlay in this app uses, and which supplies the portal, focus
+   * trap, focus restore, and body scroll lock. The combobox and listbox below it
+   * are written here rather than taken from bits-ui `Command` for three reasons:
+   *
+   *   1. bits-ui inherits cmdk's scorer, which returns a bare number. Without
+   *      match positions a row cannot show WHY it matched.
+   *   2. bits-ui keys its item registry by the item's value string, so two rows
+   *      with the same label collide. Room names collide routinely.
+   *   3. bits-ui puts `role="application"` on the palette root, which turns off
+   *      screen-reader browse mode.
+   *
+   * Every ranking decision lives in plain, unit-tested modules under
+   * `$lib/palette/`. This file is markup, keyboard wiring, and scroll behaviour.
+   *
+   * ARIA follows the APG combobox pattern: DOM focus never leaves the input, and
+   * the active row is named by `aria-activedescendant`. Moving real focus onto a
+   * row would stop the user from typing.
+   */
+  import { Dialog } from "bits-ui";
+  import { ArrowLeft, CornerDownLeft, Search, TriangleAlert } from "@lucide/svelte";
+  import PaletteRow from "./PaletteRow.svelte";
+  import { PaletteState } from "$lib/palette/palette.svelte";
+  import { buildCatalog } from "$lib/palette/commands";
+  import type { PaletteHost } from "$lib/palette/host";
+  import { SIGILS } from "$lib/palette/types";
+
+  interface Props {
+    /** Visibility. The single source of truth; the palette only ever clears it. */
+    open: boolean;
+    host: PaletteHost;
+  }
+
+  let { open = $bindable(), host }: Props = $props();
+
+  // The catalog depends on app state, never on the query, so it is NOT rebuilt
+  // per keystroke. That keeps the lowercase-field cache in `rank.ts` warm.
+  const catalog = $derived(buildCatalog(host));
+
+  const palette = new PaletteState(
+    () => catalog,
+    () => {
+      open = false;
+    },
+  );
+
+  let inputEl = $state<HTMLInputElement | null>(null);
+  let listEl = $state<HTMLElement | null>(null);
+  /**
+   * Whether the pointer has genuinely moved since the palette opened. A palette
+   * that opens under the cursor otherwise selects whatever row lands beneath it,
+   * overriding the keyboard selection before the user has typed anything.
+   */
+  let pointerMoved = $state(false);
+
+  // Start every session at the root. Resetting on open rather than on close lets
+  // the exit animation finish on the page the user was actually looking at.
+  $effect(() => {
+    if (open) {
+      palette.reset();
+      pointerMoved = false;
+    }
+  });
+
+  const listId = "palette-listbox";
+  const rowId = (id: string) => `palette-row-${id.replace(/[^\w:-]/g, "_")}`;
+
+  const activeId = $derived(
+    palette.selected ? rowId(palette.selected.cmd.id) : undefined,
+  );
+  const resultCount = $derived(palette.rows.length);
+  const onConfirm = $derived(palette.page?.kind === "confirm");
+
+  /**
+   * What to say when nothing matched.
+   *
+   * A list page names its own empty case, since "no audio devices" is more
+   * useful than "no matches". Quoting the query only helps when there IS one:
+   * with a bare scope prefix the body is empty, and `No matches for “”` reads
+   * like a bug.
+   */
+  const emptyText = $derived.by(() => {
+    const page = palette.page;
+    if (page?.kind === "list" && page.emptyText) return page.emptyText;
+    const body = palette.parsed.body;
+    if (body.length > 0) return `No matches for “${body}”`;
+    if (palette.scope !== null) return `Nothing in ${SIGILS[palette.scope].toLowerCase()} yet`;
+    return "Nothing here";
+  });
+
+  /** Keep the active row visible without yanking the list around. */
+  $effect(() => {
+    const id = activeId;
+    if (!id || !listEl) return;
+    const el = listEl.querySelector(`#${CSS.escape(id)}`);
+    if (el) el.scrollIntoView({ block: "nearest" });
+  });
+
+
+  /** How many rows a PageUp/PageDown moves. Measured, not guessed. */
+  function pageSize(): number {
+    const first = listEl?.querySelector<HTMLElement>("[data-palette-row]");
+    if (!listEl || !first || first.offsetHeight === 0) return 8;
+    return Math.max(1, Math.floor(listEl.clientHeight / first.offsetHeight));
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    // An IME candidate window uses the same keys. Acting on them mid-composition
+    // commits the wrong thing. `keyCode === 229` is required on top of
+    // `isComposing`, which is unreliable for Japanese IME in Safari.
+    if (e.isComposing || e.keyCode === 229) return;
+    if (e.defaultPrevented) return;
+
+    switch (e.key) {
+      case "Escape":
+        // Own the whole decision. Escape is handled by six other listeners in
+        // this app, none of which stop propagation, so without this a single
+        // press would close the palette AND a context menu behind it.
+        e.preventDefault();
+        e.stopPropagation();
+        palette.escape();
+        return;
+
+      case "Backspace":
+        // Read the live element value: on a key repeat the state write lags a
+        // tick, which pops a page the user was still typing in.
+        if (palette.backspace((e.currentTarget as HTMLInputElement).value)) {
+          e.preventDefault();
+        }
+        return;
+
+      case "ArrowDown":
+        e.preventDefault();
+        if (e.altKey) palette.move(groupJump(1));
+        else palette.move(1);
+        return;
+
+      case "ArrowUp":
+        e.preventDefault();
+        if (e.altKey) palette.move(groupJump(-1));
+        else palette.move(-1);
+        return;
+
+      case "Home":
+        e.preventDefault();
+        palette.moveToStart();
+        return;
+
+      case "End":
+        e.preventDefault();
+        palette.moveToEnd();
+        return;
+
+      case "PageDown":
+        e.preventDefault();
+        palette.movePage(1, pageSize());
+        return;
+
+      case "PageUp":
+        e.preventDefault();
+        palette.movePage(-1, pageSize());
+        return;
+
+      case "Enter":
+        e.preventDefault();
+        void palette.accept();
+        return;
+    }
+  }
+
+  /**
+   * Distance to the first row of the next or previous group, for Alt+Arrow.
+   * Returns a plain step of 1 when there is no further group, so the key never
+   * feels dead.
+   */
+  function groupJump(direction: 1 | -1): number {
+    const rows = palette.rows;
+    const current = rows.findIndex((r) => r.cmd.id === palette.selected?.cmd.id);
+    if (current < 0) return direction;
+    const group = rows[current].cmd.group;
+    for (let i = current + direction; i >= 0 && i < rows.length; i += direction) {
+      if (rows[i].cmd.group !== group) return i - current;
+    }
+    return direction;
+  }
+
+  const showBack = $derived(palette.crumbs.length > 0);
+</script>
+
+<!-- `bind:open` is the whole state contract. bits-ui owns the portal, the focus
+     trap, focus restore, and the body scroll lock. -->
+<Dialog.Root bind:open>
+  <Dialog.Portal>
+    <Dialog.Overlay
+      class="data-[state=open]:animate-in data-[state=closed]:animate-out
+             data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
+             fixed inset-0 z-50 bg-black/60"
+    />
+    <Dialog.Content
+      escapeKeydownBehavior="ignore"
+      onOpenAutoFocus={(e) => {
+        // Focus the search field rather than the first focusable node, so the
+        // first keystroke always types instead of activating something.
+        e.preventDefault();
+        inputEl?.focus();
+      }}
+      class="data-[state=open]:animate-in data-[state=closed]:animate-out
+             data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
+             data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95
+             fixed top-[10vh] left-1/2 z-50 w-[min(38rem,calc(100vw-2rem))]
+             -translate-x-1/2 overflow-hidden rounded-lg border border-border
+             bg-popover text-popover-foreground font-mono shadow-2xl duration-150"
+      onpointermove={() => (pointerMoved = true)}
+    >
+      <Dialog.Title class="sr-only">Command palette</Dialog.Title>
+      <Dialog.Description class="sr-only">
+        Search rooms, settings and actions. Use the arrow keys to choose and Enter
+        to run.
+      </Dialog.Description>
+
+      <!-- Search field -->
+      <div class="flex items-center gap-2 border-b border-border px-3">
+        {#if showBack}
+          <button
+            type="button"
+            tabindex="-1"
+            aria-label="Go back"
+            class="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground"
+            onclick={() => palette.pop()}
+          >
+            <ArrowLeft class="size-4" />
+          </button>
+        {:else}
+          <Search class="size-4 shrink-0 text-muted-foreground" />
+        {/if}
+
+        {#each palette.crumbs as crumb (crumb)}
+          <span
+            class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+          >
+            {crumb}
+          </span>
+        {/each}
+
+        <input
+          bind:this={inputEl}
+          type="text"
+          role="combobox"
+          aria-label="Search rooms, settings and actions"
+          aria-controls={listId}
+          aria-expanded={resultCount > 0}
+          aria-activedescendant={activeId}
+          aria-autocomplete="list"
+          autocomplete="off"
+          autocorrect="off"
+          autocapitalize="off"
+          spellcheck="false"
+          placeholder={palette.placeholder}
+          value={palette.inputValue}
+          oninput={(e) => palette.setQuery(e.currentTarget.value)}
+          onkeydown={handleKeydown}
+          class="h-11 flex-1 min-w-0 bg-transparent text-sm outline-none
+                 placeholder:text-muted-foreground"
+        />
+      </div>
+
+      {#if palette.error}
+        <p
+          role="alert"
+          class="border-b border-border px-3 py-2 text-xs text-destructive"
+        >
+          {palette.error}
+        </p>
+      {/if}
+
+      {#if palette.page?.kind === "confirm"}
+        <!-- The consequence is stated in full, in normal sentence case, before
+             the two choices. Cancel is the preselected row. -->
+        <p
+          class="flex items-start gap-2 border-b border-border px-3 py-2.5 text-xs
+                 text-muted-foreground"
+        >
+          <TriangleAlert class="mt-0.5 size-3.5 shrink-0 text-destructive" />
+          {palette.page.message}
+        </p>
+      {/if}
+
+      <!--
+        Announces the result count to screen readers only. Rendering the count as
+        text means it is announced exactly when it changes, which avoids the
+        repeated announcements a manually toggled attribute causes.
+      -->
+      <div aria-live="polite" aria-atomic="true" class="sr-only">
+        {resultCount === 0 ? "No results" : `${resultCount} results`}
+      </div>
+
+      {#if palette.onPrompt}
+        <div class="px-3 py-3 text-xs text-muted-foreground">
+          Press <kbd class="rounded border border-border px-1">Enter</kbd> to
+          confirm, or <kbd class="rounded border border-border px-1">Esc</kbd> to
+          go back.
+        </div>
+      {:else}
+        <!--
+          `overscroll-contain` stops a flick at the end of the list from
+          scrolling the page behind the palette.
+        -->
+        <div
+          bind:this={listEl}
+          id={listId}
+          role="listbox"
+          aria-label="Results"
+          tabindex="-1"
+          class="max-h-[min(24rem,60vh)] overflow-y-auto overscroll-contain py-1"
+        >
+          {#if palette.loading}
+            <p class="px-3 py-6 text-center text-xs text-muted-foreground">
+              Loading…
+            </p>
+          {:else if resultCount === 0}
+            <p class="px-3 py-6 text-center text-xs text-muted-foreground">
+              {emptyText}
+            </p>
+          {:else}
+            {#each palette.groups as group (group.name)}
+              <div role="group" aria-labelledby="palette-group-{group.name}">
+                <!--
+                  Hidden from the accessibility tree because `aria-labelledby`
+                  above already exposes this text as the group's name.
+                -->
+                <div
+                  id="palette-group-{group.name}"
+                  aria-hidden="true"
+                  class="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wider
+                         text-muted-foreground uppercase"
+                >
+                  {group.name}
+                </div>
+                {#each group.items as row (row.cmd.id)}
+                  <PaletteRow
+                    {row}
+                    id={rowId(row.cmd.id)}
+                    selected={palette.selected?.cmd.id === row.cmd.id}
+                    forgettable={group.name === palette.recentGroupName}
+                    onSelect={() => void palette.run(row.cmd)}
+                    onHover={() => {
+                      if (pointerMoved) palette.hover(row.cmd.id);
+                    }}
+                    onForget={() => palette.forget(row.cmd.id)}
+                  />
+                {/each}
+              </div>
+            {/each}
+          {/if}
+        </div>
+      {/if}
+
+      <!-- Footer: keeps the keyboard model discoverable. -->
+      <div
+        class="flex items-center gap-3 border-t border-border px-3 py-1.5
+               text-[10px] text-muted-foreground"
+      >
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-border px-1">↑</kbd>
+          <kbd class="rounded border border-border px-1">↓</kbd>
+          move
+        </span>
+        <span class="flex items-center gap-1">
+          <CornerDownLeft class="size-3" />
+          {onConfirm ? "choose" : "run"}
+        </span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-border px-1">Esc</kbd>
+          {showBack ? "back" : "close"}
+        </span>
+        <span class="ml-auto hidden sm:inline">
+          <kbd class="rounded border border-border px-1">?</kbd> for prefixes
+        </span>
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/frontend/src/lib/components/palette/HighlightedText.svelte
+++ b/frontend/src/lib/components/palette/HighlightedText.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  /**
+   * Renders text with the characters the query matched picked out.
+   *
+   * Highlighting is what turns a ranked list into an explainable one: the user
+   * can see why a row matched, so a surprising order reads as informative
+   * rather than broken. It is only possible because the matcher returns
+   * positions; the cmdk-family scorers return a bare number and cannot do this.
+   */
+  import type { MatchRange } from "$lib/palette/scorer";
+
+  interface Props {
+    text: string;
+    /** Ascending, non-overlapping. `mergeRanges` guarantees both. */
+    ranges?: MatchRange[];
+  }
+
+  let { text, ranges = [] }: Props = $props();
+
+  const segments = $derived.by(() => {
+    if (ranges.length === 0) return [{ text, hit: false }];
+    const out: { text: string; hit: boolean }[] = [];
+    let at = 0;
+    for (const range of ranges) {
+      // Guard against a range that outlived the text it was measured against.
+      const start = Math.max(at, Math.min(range.start, text.length));
+      const end = Math.max(start, Math.min(range.end, text.length));
+      if (start > at) out.push({ text: text.slice(at, start), hit: false });
+      if (end > start) out.push({ text: text.slice(start, end), hit: true });
+      at = end;
+    }
+    if (at < text.length) out.push({ text: text.slice(at), hit: false });
+    return out;
+  });
+</script>
+
+{#each segments as segment, i (i)}{#if segment.hit}<mark
+      class="bg-transparent text-primary font-semibold">{segment.text}</mark
+    >{:else}{segment.text}{/if}{/each}

--- a/frontend/src/lib/components/palette/PaletteRow.svelte
+++ b/frontend/src/lib/components/palette/PaletteRow.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  /**
+   * One palette row.
+   *
+   * Rendered as a `role="option"` inside the list's `role="listbox"`. It never
+   * takes DOM focus: focus stays in the input and the active row is named by
+   * `aria-activedescendant`, which is the only arrangement that lets a user keep
+   * typing while moving the selection.
+   */
+  import { ChevronRight, CornerDownLeft, X } from "@lucide/svelte";
+  import HighlightedText from "./HighlightedText.svelte";
+  import type { RankedCmd } from "$lib/palette/types";
+
+  interface Props {
+    row: RankedCmd;
+    /** DOM id, referenced by the input's `aria-activedescendant`. */
+    id: string;
+    selected: boolean;
+    /** Show the "forget" control. Only for rows in the recents group. */
+    forgettable?: boolean;
+    onSelect: () => void;
+    onHover: () => void;
+    onForget?: () => void;
+  }
+
+  let {
+    row,
+    id,
+    selected,
+    forgettable = false,
+    onSelect,
+    onHover,
+    onForget,
+  }: Props = $props();
+
+  const opensPage = $derived(row.cmd.action.kind === "page");
+</script>
+
+<!--
+  A div, not a button. A button inside a listbox is invalid ARIA, and a real
+  button would also be reachable by Tab, which the combobox pattern forbids for
+  popup descendants. `tabindex="-1"` keeps it out of that sequence while still
+  allowing programmatic focus.
+
+  The keyboard-handler warning is suppressed deliberately. In the APG combobox
+  pattern every key is handled once, on the input, and the active row is named by
+  `aria-activedescendant`. A keydown handler per option would need DOM focus to
+  fire, and moving focus onto a row is exactly what stops the user typing.
+-->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div
+  {id}
+  role="option"
+  tabindex="-1"
+  aria-selected={selected}
+  data-selected={selected ? "" : undefined}
+  data-palette-row
+  class="group/row flex items-center gap-2.5 mx-1 px-2.5 py-2 rounded-md cursor-pointer
+         text-sm scroll-my-2 data-selected:bg-muted
+         {row.cmd.danger ? 'text-destructive' : 'text-foreground'}"
+  onclick={onSelect}
+  onpointermove={onHover}
+>
+  {#if row.cmd.icon}
+    <row.cmd.icon
+      class="size-4 shrink-0 {row.cmd.danger
+        ? 'text-destructive'
+        : 'text-muted-foreground'}"
+    />
+  {:else}
+    <!-- Keep the text column aligned whether or not a row has an icon. -->
+    <span class="size-4 shrink-0" aria-hidden="true"></span>
+  {/if}
+
+  <span class="flex-1 min-w-0 flex items-baseline gap-2">
+    <span class="truncate">
+      <HighlightedText text={row.cmd.title} ranges={row.titleRanges} />
+    </span>
+    {#if row.cmd.subtitle}
+      <span class="truncate text-xs text-muted-foreground shrink-[2]">
+        <HighlightedText text={row.cmd.subtitle} ranges={row.subtitleRanges} />
+      </span>
+    {/if}
+  </span>
+
+  {#if row.cmd.badge}
+    <span class="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+      {row.cmd.badge}
+    </span>
+  {/if}
+
+  {#if row.cmd.shortcut}
+    <span class="shrink-0 flex items-center gap-0.5">
+      {#each row.cmd.shortcut as key (key)}
+        <kbd
+          class="rounded border border-border bg-background px-1 text-[10px] leading-4
+                 text-muted-foreground"
+        >
+          {key}
+        </kbd>
+      {/each}
+    </span>
+  {/if}
+
+  {#if forgettable && onForget}
+    <!--
+      Stop the click from reaching the row, or forgetting a command would also
+      run it. `tabindex="-1"` keeps it out of the Tab sequence, which the
+      combobox pattern requires for popup descendants.
+    -->
+    <button
+      type="button"
+      tabindex="-1"
+      aria-label="Forget {row.cmd.title}"
+      class="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity
+             hover:text-foreground group-hover/row:opacity-100
+             group-data-[selected]/row:opacity-100"
+      onclick={(e) => {
+        e.stopPropagation();
+        onForget();
+      }}
+    >
+      <X class="size-3.5" />
+    </button>
+  {/if}
+
+  {#if opensPage}
+    <ChevronRight class="size-3.5 shrink-0 text-muted-foreground" />
+  {:else if selected}
+    <CornerDownLeft class="size-3.5 shrink-0 text-muted-foreground" />
+  {/if}
+</div>

--- a/frontend/src/lib/palette/commands/actions.ts
+++ b/frontend/src/lib/palette/commands/actions.ts
@@ -1,0 +1,198 @@
+import {
+  Camera,
+  CameraOff,
+  Download,
+  HardDrive,
+  Headphones,
+  HeadphoneOff,
+  Lock,
+  Mic,
+  MicOff,
+  Monitor,
+  MonitorOff,
+  Phone,
+  PhoneOff,
+  RefreshCw,
+  Trash2,
+} from "@lucide/svelte";
+import { transportState, connect } from "$lib/transport/transport.svelte";
+import {
+  joinCall,
+  leaveCall,
+  startScreenShare,
+  stopScreenShare,
+  toggleCamera,
+  toggleDeafen,
+  toggleMute,
+} from "$lib/transport/call.svelte";
+import { lock } from "$lib/identity/identity.svelte";
+import { requestPersistentStorage, wipeLocalDatabase } from "$lib/storage";
+import { downloadBackup } from "$lib/transport/sync.svelte";
+import type { Cmd } from "../types";
+import type { CmdSource } from "../host";
+
+/**
+ * Call controls plus app-wide actions (reconnect, lock, storage, backup,
+ * and the destructive data wipe).
+ *
+ * The in-call rows (mute, deafen, camera, screen share) only make sense
+ * once a call exists, so they are omitted entirely outside a call rather
+ * than shown disabled.
+ */
+export const actionCommands: CmdSource = () => {
+  const cmds: Cmd[] = [];
+
+  cmds.push({
+    id: "actions.call.toggle",
+    title: transportState.inCall ? "Leave call" : "Join call",
+    group: "Call",
+    icon: transportState.inCall ? PhoneOff : Phone,
+    action: {
+      kind: "act",
+      perform: transportState.inCall
+        ? () => leaveCall()
+        : () => {
+            joinCall().catch((err) => console.warn("join call failed", err));
+          },
+    },
+  });
+
+  if (transportState.inCall) {
+    cmds.push({
+      id: "actions.call.mute",
+      title: transportState.muted ? "Unmute microphone" : "Mute microphone",
+      group: "Call",
+      icon: transportState.muted ? MicOff : Mic,
+      badge: transportState.muted ? "Muted" : "Live",
+      action: { kind: "act", keepOpen: true, perform: () => toggleMute() },
+    });
+
+    cmds.push({
+      id: "actions.call.deafen",
+      title: transportState.deafened ? "Undeafen" : "Deafen",
+      group: "Call",
+      icon: transportState.deafened ? HeadphoneOff : Headphones,
+      badge: transportState.deafened ? "On" : "Off",
+      action: { kind: "act", keepOpen: true, perform: () => toggleDeafen() },
+    });
+
+    cmds.push({
+      id: "actions.call.camera",
+      title: transportState.cameraOff ? "Turn on camera" : "Turn off camera",
+      group: "Call",
+      icon: transportState.cameraOff ? CameraOff : Camera,
+      badge: transportState.cameraOff ? "Off" : "On",
+      action: {
+        kind: "act",
+        keepOpen: true,
+        perform: () => {
+          toggleCamera().catch((err) =>
+            console.warn("toggle camera failed", err)
+          );
+        },
+      },
+    });
+
+    cmds.push({
+      id: "actions.call.screenShare",
+      title: transportState.screenSharing
+        ? "Stop screen share"
+        : "Start screen share",
+      group: "Call",
+      icon: transportState.screenSharing ? MonitorOff : Monitor,
+      badge: transportState.screenSharing ? "Sharing" : "Off",
+      action: {
+        kind: "act",
+        keepOpen: true,
+        perform: transportState.screenSharing
+          ? () => stopScreenShare()
+          : () => {
+              startScreenShare().catch((err) =>
+                console.warn("start screen share failed", err)
+              );
+            },
+      },
+    });
+  }
+
+  cmds.push({
+    id: "actions.app.reconnect",
+    title: "Reconnect",
+    group: "App",
+    icon: RefreshCw,
+    action: {
+      kind: "act",
+      perform: () => {
+        connect().catch((err) => console.warn("reconnect failed", err));
+      },
+    },
+  });
+
+  cmds.push({
+    id: "actions.app.lock",
+    title: "Lock the app",
+    group: "App",
+    icon: Lock,
+    action: { kind: "act", perform: () => lock() },
+  });
+
+  cmds.push({
+    id: "actions.app.persistentStorage",
+    title: "Request persistent storage",
+    group: "App",
+    icon: HardDrive,
+    action: {
+      kind: "act",
+      perform: () => {
+        requestPersistentStorage().catch((err) =>
+          console.warn("request persistent storage failed", err)
+        );
+      },
+    },
+  });
+
+  cmds.push({
+    id: "actions.app.downloadData",
+    title: "Download my data",
+    group: "App",
+    icon: Download,
+    action: {
+      kind: "act",
+      perform: () => {
+        downloadBackup().catch((err) =>
+          console.warn("download backup failed", err)
+        );
+      },
+    },
+  });
+
+  cmds.push({
+    id: "actions.app.eraseData",
+    title: "Erase all local data",
+    group: "App",
+    icon: Trash2,
+    danger: true,
+    action: {
+      kind: "page",
+      open: () => ({
+        kind: "confirm",
+        id: "actions.app.eraseData",
+        title: "Erase all local data",
+        message:
+          "This deletes your identity, messages, and every room on this device. This cannot be undone.",
+        confirmLabel: "Erase everything",
+        confirm: async () => {
+          try {
+            await wipeLocalDatabase();
+          } catch (err) {
+            console.warn("wipe local database failed", err);
+            return;
+          }
+          window.location.reload();
+        },
+      }),
+    },
+  });
+
+  return cmds;
+};

--- a/frontend/src/lib/palette/commands/index.ts
+++ b/frontend/src/lib/palette/commands/index.ts
@@ -1,0 +1,16 @@
+import type { Cmd } from "../types";
+import type { CmdSource, PaletteHost } from "../host";
+import { roomCommands } from "./rooms";
+import { settingsCommands } from "./settings";
+import { actionCommands } from "./actions";
+
+export const allSources: CmdSource[] = [
+  roomCommands,
+  settingsCommands,
+  actionCommands,
+];
+
+/** Concatenate every command source into the full catalog for one host. */
+export function buildCatalog(host: PaletteHost): Cmd[] {
+  return allSources.flatMap((source) => source(host));
+}

--- a/frontend/src/lib/palette/commands/rooms.ts
+++ b/frontend/src/lib/palette/commands/rooms.ts
@@ -1,0 +1,164 @@
+import { DoorOpen, LogIn, LogOut, Link, Pencil, Plus, Trash2, Users } from "@lucide/svelte";
+import { roomsStore, renameRoom } from "$lib/rooms.svelte";
+import { setRoomName } from "$lib/transport/transport.svelte";
+import type { Cmd } from "../types";
+import type { CmdSource } from "../host";
+import { parseRoomCode } from "../query";
+
+/**
+ * Room navigation, joining, and the destructive room-management actions.
+ *
+ * Rebuilt on every catalog refresh, so every row below reads `roomsStore`
+ * and `host` directly rather than caching anything module-scoped.
+ */
+export const roomCommands: CmdSource = (host) => {
+  const cmds: Cmd[] = [];
+  const activeCode = host.activeRoomCode;
+
+  // Rooms are ordered by most recent activity so the room you probably want
+  // is close to the top even before you type anything.
+  const rooms = roomsStore.rooms
+    .filter((room) => room.roomCode !== activeCode)
+    .slice()
+    .sort(
+      (a, b) =>
+        (roomsStore.lastActivity.get(b.roomCode) ?? 0) -
+        (roomsStore.lastActivity.get(a.roomCode) ?? 0)
+    );
+
+  for (const room of rooms) {
+    const unread = roomsStore.unreadCounts.get(room.roomCode) ?? 0;
+    cmds.push({
+      id: `room.open:${room.roomCode}`,
+      title: room.name || room.roomCode,
+      // The room code is shown unconditionally: two rooms can share a name,
+      // and the code is the only thing that still tells them apart.
+      subtitle: room.roomCode,
+      group: "Rooms",
+      icon: DoorOpen,
+      badge: unread > 0 ? String(unread) : undefined,
+      action: { kind: "act", perform: () => host.openRoom(room.roomCode) },
+    });
+  }
+
+  for (const entry of roomsStore.phonebook) {
+    cmds.push({
+      id: `room.dm:${entry.peerId}`,
+      title: entry.nickname,
+      group: "People",
+      icon: Users,
+      action: { kind: "act", perform: () => host.openDm(entry.peerId) },
+    });
+  }
+
+  cmds.push({
+    id: "room.join",
+    title: "Join room by code",
+    group: "Rooms",
+    icon: LogIn,
+    action: {
+      kind: "page",
+      open: () => ({
+        kind: "prompt",
+        id: "room.join",
+        title: "Join room by code",
+        placeholder: "Room code or invite link…",
+        validate: (value) =>
+          parseRoomCode(value) === null
+            ? "Not a room code, invite link, or web+awfl:// link"
+            : null,
+        submit: (value) => {
+          const code = parseRoomCode(value);
+          if (code) host.joinRoomByCode(code);
+        },
+        submitLabel: "Join",
+      }),
+    },
+  });
+
+  cmds.push({
+    id: "room.create",
+    title: "Create or join a room",
+    group: "Rooms",
+    icon: Plus,
+    action: { kind: "act", perform: () => host.openCreateJoin() },
+  });
+
+  if (activeCode) {
+    cmds.push({
+      id: "room.copyLink",
+      title: "Copy room link",
+      group: "Rooms",
+      icon: Link,
+      action: {
+        kind: "act",
+        perform: () => {
+          const url = `${window.location.origin}/r/${activeCode}`;
+          navigator.clipboard
+            .writeText(url)
+            .catch((err) => console.warn("copy room link failed", err));
+        },
+      },
+    });
+
+    const current = roomsStore.rooms.find((r) => r.roomCode === activeCode);
+    const currentTitle = current ? current.name || activeCode : activeCode;
+    cmds.push({
+      id: "room.rename",
+      title: "Rename room",
+      group: "Rooms",
+      icon: Pencil,
+      action: {
+        kind: "page",
+        open: () => ({
+          kind: "prompt",
+          id: "room.rename",
+          title: "Rename room",
+          initial: currentTitle,
+          // Without this an empty submit would blank the room name for every
+          // participant, since `setRoomName` broadcasts whatever it is given.
+          validate: (value) =>
+            value.trim().length === 0 ? "Room name cannot be empty" : null,
+          submit: async (value) => {
+            try {
+              await renameRoom(activeCode, value);
+              setRoomName(value);
+            } catch (err) {
+              console.warn("rename room failed", err);
+            }
+          },
+          submitLabel: "Rename",
+        }),
+      },
+    });
+
+    cmds.push({
+      id: "room.leave",
+      title: "Leave room",
+      group: "Rooms",
+      icon: LogOut,
+      action: { kind: "act", perform: () => host.leaveRoom() },
+    });
+
+    cmds.push({
+      id: "room.remove",
+      title: "Remove room",
+      group: "Rooms",
+      icon: Trash2,
+      danger: true,
+      action: {
+        kind: "page",
+        open: () => ({
+          kind: "confirm",
+          id: "room.remove",
+          title: "Remove room",
+          message: `Remove "${currentTitle}" and its history? This cannot be undone.`,
+          confirmLabel: "Remove",
+          confirm: () => host.removeRoom(activeCode),
+        }),
+      },
+    });
+  }
+
+  return cmds;
+};

--- a/frontend/src/lib/palette/commands/settings.ts
+++ b/frontend/src/lib/palette/commands/settings.ts
@@ -1,0 +1,360 @@
+import {
+  ChartPie,
+  Heart,
+  Info,
+  Mic,
+  Puzzle,
+  RefreshCw,
+  SlidersHorizontal,
+  User,
+  Volume2,
+} from "@lucide/svelte";
+import {
+  displayPrefs,
+  setCallChatBeside,
+  setItalicOwnName,
+  setShowPeerNicknameColors,
+  setSidebarCollapsed,
+} from "$lib/display-prefs.svelte";
+import { mediaPrefs, setGifAutoplay } from "$lib/media-prefs.svelte";
+import {
+  notifyState,
+  setMessageSoundsEnabled,
+  setNotificationsEnabled,
+} from "$lib/notify.svelte";
+import { mailboxPrefs, setMailboxEnabled } from "$lib/transport/mailbox.svelte";
+import {
+  getVoiceActiveInputDevice,
+  getVoiceActiveOutputDevice,
+  getVoiceDtlnEnabled,
+  getVoiceInputDevices,
+  getVoiceOutputDevices,
+  setVoiceDtlnEnabled,
+  setVoiceInputDevice,
+  setVoiceOutputDevice,
+} from "$lib/transport/voice.svelte";
+import { profileStore, saveName, saveNameEffect } from "$lib/profile.svelte";
+import { openSettings } from "$lib/ui-state.svelte";
+import { getRegistry } from "$lib/plugins/registry";
+import { isPluginEnabled, togglePlugin } from "$lib/plugins/prefs.svelte";
+import type { Cmd } from "../types";
+import type { CmdSource } from "../host";
+
+/** Settings-dialog tabs, copied verbatim from SettingsDialog.svelte so the
+ *  palette's shortcuts stay visually identical to the dialog's own tab bar. */
+const SETTINGS_TABS = [
+  { id: "profile", label: "Profile", icon: User },
+  { id: "audio", label: "Audio", icon: Volume2 },
+  { id: "app", label: "App", icon: SlidersHorizontal },
+  { id: "session", label: "Session/Sync", icon: RefreshCw },
+  { id: "data", label: "Data", icon: ChartPie },
+  { id: "plugins", label: "Plugins", icon: Puzzle },
+  { id: "quirks", label: "Quirks", icon: Info },
+  { id: "oss", label: "OSS", icon: Heart },
+] as const;
+
+const NAME_EFFECTS = [
+  { value: "none", label: "None" },
+  { value: "gradient", label: "Gradient" },
+  { value: "shimmer", label: "Shimmer" },
+  { value: "glow", label: "Glow" },
+  { value: "rainbow", label: "Rainbow" },
+] as const;
+
+/**
+ * Preference toggles, plugin toggles, settings-tab shortcuts, and the
+ * device/name-effect/nickname pickers.
+ *
+ * Every toggle re-reads its `$state` object here, at build time, so the
+ * badge always reflects the value on screen right now.
+ */
+export const settingsCommands: CmdSource = () => {
+  const cmds: Cmd[] = [];
+
+  cmds.push({
+    id: "settings.toggle:italicOwnName",
+    title: "Italic own name",
+    keywords: ["toggle", "enable", "disable", "italicize", "font style"],
+    group: "Settings",
+    badge: displayPrefs.italicOwnName ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => setItalicOwnName(!displayPrefs.italicOwnName),
+    },
+  });
+
+  cmds.push({
+    id: "settings.toggle:peerNicknameColors",
+    title: "Peer nickname colors",
+    keywords: ["toggle", "enable", "disable", "colours"],
+    group: "Settings",
+    badge: displayPrefs.showPeerNicknameColors ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () =>
+        setShowPeerNicknameColors(!displayPrefs.showPeerNicknameColors),
+    },
+  });
+
+  cmds.push({
+    id: "settings.toggle:sidebarCollapsed",
+    title: "Collapsed sidebar",
+    keywords: ["toggle", "enable", "disable", "icon rail"],
+    group: "Settings",
+    shortcut: ["⌘", "B"],
+    badge: displayPrefs.sidebarCollapsed ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => setSidebarCollapsed(!displayPrefs.sidebarCollapsed),
+    },
+  });
+
+  cmds.push({
+    id: "settings.toggle:callChatBeside",
+    title: "Chat beside call",
+    keywords: ["toggle", "enable", "disable", "layout"],
+    group: "Settings",
+    badge: displayPrefs.callChatBeside ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => setCallChatBeside(!displayPrefs.callChatBeside),
+    },
+  });
+
+  cmds.push({
+    id: "settings.toggle:gifAutoplay",
+    title: "GIF autoplay",
+    keywords: ["toggle", "enable", "disable"],
+    group: "Settings",
+    badge: mediaPrefs.gifAutoplay ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => setGifAutoplay(!mediaPrefs.gifAutoplay),
+    },
+  });
+
+  cmds.push({
+    id: "settings.toggle:messageSounds",
+    title: "Message sounds",
+    keywords: ["toggle", "enable", "disable", "mute"],
+    group: "Settings",
+    badge: notifyState.soundsEnabled ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => setMessageSoundsEnabled(!notifyState.soundsEnabled),
+    },
+  });
+
+  if (notifyState.supported) {
+    cmds.push({
+      id: "settings.toggle:notifications",
+      title: "Notifications",
+      keywords: ["toggle", "enable", "disable"],
+      group: "Settings",
+      badge: notifyState.enabled ? "On" : "Off",
+      action: {
+        kind: "act",
+        keepOpen: true,
+        perform: () => {
+          setNotificationsEnabled(!notifyState.enabled).catch((err) =>
+            console.warn("toggle notifications failed", err)
+          );
+        },
+      },
+    });
+  }
+
+  cmds.push({
+    id: "settings.toggle:offlineInbox",
+    title: "Offline inbox",
+    keywords: ["toggle", "enable", "disable", "mailbox"],
+    group: "Settings",
+    badge: mailboxPrefs.enabled ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => setMailboxEnabled(!mailboxPrefs.enabled),
+    },
+  });
+
+  cmds.push({
+    id: "settings.toggle:noiseSuppression",
+    title: "Noise suppression",
+    keywords: ["toggle", "enable", "disable", "dtln"],
+    group: "Settings",
+    badge: getVoiceDtlnEnabled() ? "On" : "Off",
+    action: {
+      kind: "act",
+      keepOpen: true,
+      perform: () => {
+        setVoiceDtlnEnabled(!getVoiceDtlnEnabled()).catch((err) =>
+          console.warn("toggle noise suppression failed", err)
+        );
+      },
+    },
+  });
+
+  for (const [pluginId, entry] of getRegistry()) {
+    const enabled = isPluginEnabled(pluginId);
+    cmds.push({
+      id: `settings.plugin:${pluginId}`,
+      title: entry.manifest.name,
+      subtitle: entry.manifest.description,
+      group: "Plugins",
+      icon: Puzzle,
+      badge: enabled ? "On" : "Off",
+      action: {
+        kind: "act",
+        keepOpen: true,
+        perform: () => togglePlugin(pluginId, !enabled),
+      },
+    });
+  }
+
+  for (const tab of SETTINGS_TABS) {
+    cmds.push({
+      id: `settings.open:${tab.id}`,
+      // The tab label alone is not searchable or self-describing: a row reading
+      // just "App" means nothing out of context, and typing "settings" found
+      // none of these at all.
+      title: `Open ${tab.label} settings`,
+      keywords: ["preferences", "options", "configure"],
+      group: "Settings",
+      icon: tab.icon,
+      action: { kind: "act", perform: () => openSettings(tab.id) },
+    });
+  }
+
+  cmds.push({
+    id: "settings.audioInput",
+    title: "Audio input device",
+    group: "Settings",
+    icon: Mic,
+    action: {
+      kind: "page",
+      open: () => ({
+        kind: "list",
+        id: "settings.audioInput",
+        title: "Audio input device",
+        placeholder: "Search devices…",
+        emptyText: "No input devices found",
+        items: async () => {
+          const devices = await getVoiceInputDevices();
+          const active = getVoiceActiveInputDevice();
+          return devices.map((device, index): Cmd => ({
+            id: `settings.audioInput:${device.deviceId}`,
+            title: device.label || `Microphone ${index + 1}`,
+            group: "Devices",
+            badge: device.deviceId === active ? "Active" : undefined,
+            action: {
+              kind: "act",
+              perform: () => {
+                setVoiceInputDevice(device.deviceId).catch((err) =>
+                  console.warn("set audio input device failed", err)
+                );
+              },
+            },
+          }));
+        },
+      }),
+    },
+  });
+
+  cmds.push({
+    id: "settings.audioOutput",
+    title: "Audio output device",
+    group: "Settings",
+    icon: Volume2,
+    action: {
+      kind: "page",
+      open: () => ({
+        kind: "list",
+        id: "settings.audioOutput",
+        title: "Audio output device",
+        placeholder: "Search devices…",
+        emptyText: "No output devices found",
+        items: async () => {
+          const devices = await getVoiceOutputDevices();
+          const active = getVoiceActiveOutputDevice();
+          return devices.map((device, index): Cmd => ({
+            id: `settings.audioOutput:${device.deviceId}`,
+            title: device.label || `Speaker ${index + 1}`,
+            group: "Devices",
+            badge: device.deviceId === active ? "Active" : undefined,
+            action: {
+              kind: "act",
+              perform: () => {
+                setVoiceOutputDevice(device.deviceId).catch((err) =>
+                  console.warn("set audio output device failed", err)
+                );
+              },
+            },
+          }));
+        },
+      }),
+    },
+  });
+
+  cmds.push({
+    id: "settings.nameEffect",
+    title: "Name effect",
+    group: "Settings",
+    action: {
+      kind: "page",
+      open: () => ({
+        kind: "list",
+        id: "settings.nameEffect",
+        title: "Name effect",
+        items: () =>
+          NAME_EFFECTS.map((effect): Cmd => ({
+            id: `settings.nameEffect:${effect.value}`,
+            title: effect.label,
+            group: "Name effect",
+            badge:
+              (profileStore.nameEffect ?? "none") === effect.value
+                ? "Active"
+                : undefined,
+            action: {
+              kind: "act",
+              perform: () => {
+                saveNameEffect(effect.value).catch((err) =>
+                  console.warn("set name effect failed", err)
+                );
+              },
+            },
+          })),
+      }),
+    },
+  });
+
+  cmds.push({
+    id: "settings.nickname",
+    title: "Nickname",
+    group: "Settings",
+    action: {
+      kind: "page",
+      open: () => ({
+        kind: "prompt",
+        id: "settings.nickname",
+        title: "Change nickname",
+        initial: profileStore.nickname,
+        validate: (value) =>
+          value.trim().length === 0 ? "Nickname cannot be empty" : null,
+        submit: (value) => {
+          saveName(value.trim()).catch((err) =>
+            console.warn("save nickname failed", err)
+          );
+        },
+        submitLabel: "Save",
+      }),
+    },
+  });
+
+  return cmds;
+};

--- a/frontend/src/lib/palette/host.ts
+++ b/frontend/src/lib/palette/host.ts
@@ -1,0 +1,46 @@
+import type { Cmd } from "./types";
+
+/**
+ * The slice of app behaviour the palette cannot reach on its own.
+ *
+ * Room navigation lives in `AppView`: it owns `activeRoomCode`, pushes history,
+ * persists the room, and broadcasts the room name. Reproducing that in the
+ * palette would fork the join path, so the palette asks its host instead.
+ *
+ * Read-only fields are declared as getters by the implementor so that reads stay
+ * reactive across the boundary.
+ */
+export interface PaletteHost {
+  /** The room on screen, or `null` when none is open. */
+  readonly activeRoomCode: string | null;
+
+  /** Switch to an already-known room. A view change, not a rejoin. */
+  openRoom(roomCode: string): void;
+
+  /**
+   * Join a room by code, adding it to the room list.
+   * Rejects codes that are not six lowercase hex characters.
+   */
+  joinRoomByCode(roomCode: string): void;
+
+  /** Open a direct-message conversation with a phonebook peer. */
+  openDm(peerId: string): void;
+
+  /** Close the room on screen. Keeps it in the room list. */
+  leaveRoom(): void;
+
+  /** Remove a room and its history. Destructive. */
+  removeRoom(roomCode: string): void;
+
+  /** Open the existing create-or-join dialog. */
+  openCreateJoin(): void;
+}
+
+/**
+ * A group of commands contributed by one area of the app.
+ *
+ * Called on every catalog rebuild, so it must read reactive state directly and
+ * must not cache. It is *not* called per keystroke: the catalog depends on app
+ * state, not on the query.
+ */
+export type CmdSource = (host: PaletteHost) => Cmd[];

--- a/frontend/src/lib/palette/mru.test.ts
+++ b/frontend/src/lib/palette/mru.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { Mru, MRU_LIMIT } from "./mru";
+
+describe("mru", () => {
+  describe("rank", () => {
+    it("returns undefined for an id that was never touched", () => {
+      const mru = new Mru();
+      expect(mru.rank("never-seen")).toBeUndefined();
+    });
+  });
+
+  describe("touch", () => {
+    it("makes a touched id outrank one touched earlier", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      expect(mru.rank("b")).toBeGreaterThan(mru.rank("a")!);
+    });
+
+    it("moves a re-touched id back to the front", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      mru.touch("a");
+      expect(mru.rank("a")).toBeGreaterThan(mru.rank("b")!);
+    });
+  });
+
+  describe("recent", () => {
+    it("returns ids from most to least recent", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      mru.touch("c");
+      expect(mru.recent()).toEqual(["c", "b", "a"]);
+    });
+
+    it("honours its limit", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      mru.touch("c");
+      expect(mru.recent(2)).toEqual(["c", "b"]);
+    });
+  });
+
+  describe("forget", () => {
+    it("removes exactly one id and reports that it did", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      expect(mru.forget("a")).toBe(true);
+      expect(mru.rank("a")).toBeUndefined();
+      expect(mru.rank("b")).toBeDefined();
+    });
+
+    it("reports false when the id was never tracked", () => {
+      const mru = new Mru();
+      expect(mru.forget("ghost")).toBe(false);
+    });
+  });
+
+  describe("size", () => {
+    it("tracks insertions", () => {
+      const mru = new Mru();
+      expect(mru.size).toBe(0);
+      mru.touch("a");
+      mru.touch("b");
+      expect(mru.size).toBe(2);
+    });
+
+    it("does not grow when re-touching an existing id", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("a");
+      expect(mru.size).toBe(1);
+    });
+  });
+
+  describe("bound", () => {
+    it("keeps size at MRU_LIMIT and evicts the least recent id once exceeded", () => {
+      const mru = new Mru();
+      for (let i = 0; i < MRU_LIMIT + 5; i++) mru.touch(`id${i}`);
+
+      expect(mru.size).toBe(MRU_LIMIT);
+      // The first five touches were the least recent, so they are gone.
+      expect(mru.rank("id0")).toBeUndefined();
+      expect(mru.rank("id4")).toBeUndefined();
+      // The most recent touch survives.
+      expect(mru.rank(`id${MRU_LIMIT + 4}`)).toBeDefined();
+    });
+  });
+
+  describe("round trip", () => {
+    it("preserves ordering through toJSON/fromJSON", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      mru.touch("c");
+
+      const restored = Mru.fromJSON(mru.toJSON());
+      expect(restored.recent()).toEqual(mru.recent());
+    });
+
+    it("resumes the counter above every restored rank, so a new touch still outranks them all", () => {
+      const mru = new Mru();
+      mru.touch("a");
+      mru.touch("b");
+      mru.touch("c");
+
+      const restored = Mru.fromJSON(mru.toJSON());
+      restored.touch("fresh");
+
+      expect(restored.recent()[0]).toBe("fresh");
+      expect(restored.rank("fresh")!).toBeGreaterThan(restored.rank("c")!);
+    });
+  });
+
+  describe("fromJSON malformed input", () => {
+    it("returns a usable empty Mru for null", () => {
+      expect(Mru.fromJSON(null).size).toBe(0);
+    });
+
+    it("returns a usable empty Mru for a non-object", () => {
+      expect(Mru.fromJSON("not an object").size).toBe(0);
+    });
+
+    it("returns a usable empty Mru when entries is missing", () => {
+      expect(Mru.fromJSON({ counter: 5 }).size).toBe(0);
+    });
+
+    it("returns a usable empty Mru when entries is not an array", () => {
+      expect(Mru.fromJSON({ counter: 5, entries: "nope" }).size).toBe(0);
+    });
+
+    it("drops entries whose id is not a string", () => {
+      const mru = Mru.fromJSON({ counter: 1, entries: [[42, 1]] });
+      expect(mru.size).toBe(0);
+    });
+
+    it("drops entries whose rank is not a finite number", () => {
+      const mru = Mru.fromJSON({
+        counter: 1,
+        entries: [
+          ["a", "notanumber"],
+          ["b", Number.POSITIVE_INFINITY],
+          ["c", 3],
+        ],
+      });
+      expect(mru.size).toBe(1);
+      expect(mru.rank("c")).toBeDefined();
+    });
+
+    it("filters malformed entries but keeps the well-formed ones, without throwing", () => {
+      expect(() =>
+        Mru.fromJSON({
+          counter: 1,
+          entries: [
+            ["a", 1],
+            "not-an-entry",
+            ["b"],
+            ["c", 2],
+          ],
+        }),
+      ).not.toThrow();
+
+      const mru = Mru.fromJSON({
+        counter: 1,
+        entries: [
+          ["a", 1],
+          "not-an-entry",
+          ["b"],
+          ["c", 2],
+        ],
+      });
+      expect(mru.size).toBe(2);
+      expect(mru.rank("a")).toBeDefined();
+      expect(mru.rank("c")).toBeDefined();
+    });
+
+    it("derives a usable counter when counter itself is missing", () => {
+      const mru = Mru.fromJSON({ entries: [["a", 7]] });
+      mru.touch("fresh");
+      expect(mru.rank("fresh")!).toBeGreaterThan(7);
+    });
+  });
+});

--- a/frontend/src/lib/palette/mru.ts
+++ b/frontend/src/lib/palette/mru.ts
@@ -1,0 +1,136 @@
+/**
+ * Recency for palette commands.
+ *
+ * Pure recency, not frequency. VS Code's palette does the same, and it is the
+ * right call: frequency makes a command you used heavily last month outrank the
+ * one you used a minute ago, which reads as the palette ignoring you.
+ *
+ * A monotonic counter, bounded to the most recent entries. The counter is the
+ * rank; the value never resets, so ordering stays total.
+ *
+ * Recency is applied by `rank.ts` as a sort tier inside a relevance class, never
+ * as a score bonus. A recently used command must not jump above a better text
+ * match, only above equally-relevant ones.
+ */
+
+/** How many commands to remember. VS Code uses the same bound. */
+export const MRU_LIMIT = 50;
+
+const STORAGE_KEY = "awful:palette-mru:v1";
+
+interface Persisted {
+  counter: number;
+  entries: [string, number][];
+}
+
+export class Mru {
+  #ranks = new Map<string, number>();
+  #counter = 1;
+
+  constructor(entries?: Iterable<[string, number]>, counter?: number) {
+    if (entries) this.#ranks = new Map(entries);
+    if (counter !== undefined) this.#counter = counter;
+  }
+
+  /** Higher means more recent. `undefined` means never used. */
+  rank(id: string): number | undefined {
+    return this.#ranks.get(id);
+  }
+
+  /** Ids from most to least recent. */
+  recent(limit = MRU_LIMIT): string[] {
+    return [...this.#ranks.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([id]) => id);
+  }
+
+  /** Record a use. Evicts the least recent entry once the bound is reached. */
+  touch(id: string): void {
+    this.#ranks.set(id, this.#counter++);
+    if (this.#ranks.size > MRU_LIMIT) this.#evictOldest();
+  }
+
+  /** Drop one command's history, for the per-row "forget" affordance. */
+  forget(id: string): boolean {
+    return this.#ranks.delete(id);
+  }
+
+  get size(): number {
+    return this.#ranks.size;
+  }
+
+  #evictOldest(): void {
+    let oldestId: string | undefined;
+    let oldestRank = Number.POSITIVE_INFINITY;
+    for (const [id, rank] of this.#ranks) {
+      if (rank < oldestRank) {
+        oldestRank = rank;
+        oldestId = id;
+      }
+    }
+    if (oldestId !== undefined) this.#ranks.delete(oldestId);
+  }
+
+  toJSON(): Persisted {
+    return { counter: this.#counter, entries: [...this.#ranks.entries()] };
+  }
+
+  /**
+   * Rebuild from persisted state, discarding anything malformed.
+   *
+   * This reads `localStorage`, which can hold whatever a previous version or a
+   * different tab wrote, so every field is validated rather than trusted.
+   */
+  static fromJSON(value: unknown): Mru {
+    if (typeof value !== "object" || value === null) return new Mru();
+    const raw = value as Partial<Persisted>;
+    if (!Array.isArray(raw.entries)) return new Mru();
+
+    const entries: [string, number][] = [];
+    for (const entry of raw.entries) {
+      if (!Array.isArray(entry) || entry.length !== 2) continue;
+      const [id, rank] = entry;
+      if (typeof id !== "string" || id.length === 0) continue;
+      if (typeof rank !== "number" || !Number.isFinite(rank)) continue;
+      entries.push([id, rank]);
+    }
+
+    // Keep the counter above every rank, or a restored session would hand out
+    // ranks that collide with existing ones and break the ordering.
+    const highest = entries.reduce((max, [, rank]) => Math.max(max, rank), 0);
+    const counter =
+      typeof raw.counter === "number" && Number.isFinite(raw.counter)
+        ? Math.max(raw.counter, highest + 1)
+        : highest + 1;
+
+    const trimmed = entries.sort((a, b) => b[1] - a[1]).slice(0, MRU_LIMIT);
+    return new Mru(trimmed, counter);
+  }
+}
+
+/**
+ * Read the persisted history.
+ *
+ * Never throws: `localStorage` is unavailable in private-mode Safari and can be
+ * blocked outright, and a palette that cannot open is worse than one that
+ * forgets. Matches how `display-prefs.svelte.ts` guards its own reads.
+ */
+export function loadMru(): Mru {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === null) return new Mru();
+    return Mru.fromJSON(JSON.parse(stored));
+  } catch {
+    return new Mru();
+  }
+}
+
+/** Persist the history. Silently gives up when storage is unavailable. */
+export function saveMru(mru: Mru): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mru.toJSON()));
+  } catch {
+    // Nothing useful to do. Recency is a convenience, not state we own.
+  }
+}

--- a/frontend/src/lib/palette/palette.svelte.ts
+++ b/frontend/src/lib/palette/palette.svelte.ts
@@ -1,0 +1,421 @@
+import { loadMru, saveMru, type Mru } from "./mru";
+import { parseQuery } from "./query";
+import { RECENT_GROUP, flatten, rank } from "./rank";
+import { SIGILS, type Cmd, type Page, type RankedCmd, type Sigil } from "./types";
+
+/**
+ * Which command groups each scope prefix admits.
+ *
+ * `?` maps to no group because it renders synthetic help rows instead of
+ * filtering the catalog.
+ */
+const SIGIL_GROUPS: Record<Sigil, readonly string[] | null> = {
+  "#": ["Rooms"],
+  "@": ["People"],
+  ">": ["Settings", "Plugins"],
+  "?": null,
+};
+
+/** Rows to jump per PageUp/PageDown when the viewport has not been measured. */
+const DEFAULT_PAGE_SIZE = 8;
+
+/**
+ * The palette's state machine.
+ *
+ * Every transition is an explicit method. There is deliberately no `$effect`
+ * here: an effect that resets the selection would run a tick after the query
+ * changed, which is long enough for `Enter` to fire against the row the user
+ * was already looking away from. Writing the reset into `setQuery` makes the
+ * ordering impossible to get wrong.
+ *
+ * All ranking decisions live in plain, tested modules (`scorer`, `rank`,
+ * `query`, `mru`). This class only sequences them, matching the codebase's own
+ * note that runes are not testable here.
+ */
+export class PaletteState {
+  readonly #catalog: () => Cmd[];
+  /**
+   * Asks the owner to close the palette.
+   *
+   * Visibility is deliberately NOT held here. The dialog above this class owns
+   * it, and mirroring a boolean in both places means two effects writing each
+   * other's dependency. One direction, one owner.
+   */
+  readonly #requestClose: () => void;
+
+  query = $state("");
+  /** Empty means the root page. */
+  stack = $state<Page[]>([]);
+  /**
+   * The active row, tracked by id rather than index. An index goes stale the
+   * moment ranking reorders the list, which is how palettes end up running the
+   * wrong command.
+   */
+  selectedId = $state<string | null>(null);
+  /** Rows supplied by the current list page. */
+  pageRows = $state<Cmd[]>([]);
+  loading = $state(false);
+  /** Load failure, or a prompt's validation message. */
+  error = $state<string | null>(null);
+  /** An action is running. Keeps the row from being fired twice. */
+  busy = $state(false);
+  /** Text typed into a prompt page, kept apart from the search query. */
+  promptValue = $state("");
+
+  #mru: Mru = loadMru();
+  /**
+   * Bumped on every recency write. `#mru` is a plain class, so results would not
+   * recompute without an explicit reactive read.
+   */
+  #mruVersion = $state(0);
+  /** Cancels a stale async page load. */
+  #loadToken = 0;
+
+  constructor(catalog: () => Cmd[], requestClose: () => void) {
+    this.#catalog = catalog;
+    this.#requestClose = requestClose;
+  }
+
+  readonly page = $derived<Page | null>(this.stack.at(-1) ?? null);
+
+  readonly crumbs = $derived(this.stack.map((page) => page.title));
+
+  readonly onPrompt = $derived(this.page?.kind === "prompt");
+
+  /** A prompt page captures free text, so it must not be parsed as a search. */
+  readonly parsed = $derived(parseQuery(this.onPrompt ? "" : this.query));
+
+  readonly scope = $derived<Sigil | null>(
+    this.stack.length === 0 ? this.parsed.sigil : null,
+  );
+
+  /** The commands the current page and scope expose, before ranking. */
+  readonly source = $derived.by<Cmd[]>(() => {
+    const page = this.page;
+    if (page?.kind === "list") return this.pageRows;
+    if (page?.kind === "confirm") return confirmRows(page, () => this.pop());
+    if (page?.kind === "prompt") return [];
+
+    if (this.scope === "?") return helpRows((sigil) => this.setQuery(sigil));
+    const catalog = this.#catalog();
+    if (this.scope === null) return catalog;
+
+    const groups = SIGIL_GROUPS[this.scope];
+    if (groups === null) return catalog;
+    return catalog.filter((cmd) => groups.includes(cmd.group));
+  });
+
+  readonly groups = $derived.by(() => {
+    // Read the version so a recency write recomputes the ordering.
+    void this.#mruVersion;
+    return rank(this.source, this.parsed, this.#mru);
+  });
+
+  readonly rows = $derived(flatten(this.groups));
+
+  /**
+   * The active row. Falls back to the first row so there is always a target for
+   * `Enter`, and so an empty `selectedId` never leaves the list inert.
+   */
+  readonly selected = $derived<RankedCmd | null>(
+    this.rows.find((row) => row.cmd.id === this.selectedId) ?? this.rows[0] ?? null,
+  );
+
+  readonly placeholder = $derived.by(() => {
+    const page = this.page;
+    if (page?.kind === "prompt") return page.placeholder ?? "";
+    if (page?.kind === "list") return page.placeholder ?? `Search ${page.title}…`;
+    if (page?.kind === "confirm") return "";
+    if (this.scope !== null) return `Search ${SIGILS[this.scope].toLowerCase()}…`;
+    return "Search rooms, settings and actions… try # @ > or ?";
+  });
+
+  readonly recentGroupName = RECENT_GROUP;
+
+  // ---------------------------------------------------------------- lifecycle
+
+  /**
+   * Return to the root page with an empty query.
+   *
+   * Called when the palette opens, not when it closes. Resetting on close would
+   * swap the visible page back to the root during the exit animation, so the
+   * user watches the palette change its mind on the way out.
+   */
+  reset(): void {
+    this.stack = [];
+    this.query = "";
+    this.promptValue = "";
+    this.selectedId = null;
+    this.pageRows = [];
+    this.loading = false;
+    this.error = null;
+    // Abandon any in-flight page load, so it cannot land into the new session.
+    this.#loadToken++;
+  }
+
+  /** Dismiss the palette. The owner drops the dialog. */
+  close(): void {
+    this.#requestClose();
+  }
+
+  // ------------------------------------------------------------------ typing
+
+  setQuery(value: string): void {
+    if (this.onPrompt) {
+      this.promptValue = value;
+      // Clear a stale validation message as soon as the user edits.
+      this.error = null;
+      return;
+    }
+    this.query = value;
+    // Never leave the selection on a row that ranking is about to move. The
+    // user is not tracking a moving row, so the first result is the only
+    // defensible target.
+    this.selectedId = null;
+  }
+
+  /** The text the input element should display. */
+  readonly inputValue = $derived(this.onPrompt ? this.promptValue : this.query);
+
+  // ------------------------------------------------------------------- pages
+
+  push(page: Page): void {
+    this.stack = [...this.stack, page];
+    this.query = "";
+    this.selectedId = null;
+    this.error = null;
+    this.promptValue = page.kind === "prompt" ? (page.initial ?? "") : "";
+    if (page.kind === "list") void this.#loadPage(page);
+    else this.pageRows = [];
+  }
+
+  pop(): void {
+    if (this.stack.length === 0) return;
+    this.stack = this.stack.slice(0, -1);
+    this.query = "";
+    this.selectedId = null;
+    this.error = null;
+    this.#loadToken++;
+    const page = this.page;
+    this.promptValue = page?.kind === "prompt" ? (page.initial ?? "") : "";
+    if (page?.kind === "list") void this.#loadPage(page);
+    else this.pageRows = [];
+  }
+
+  /**
+   * Load a list page's rows.
+   *
+   * A newer load invalidates an older one by token rather than by debouncing:
+   * cancelling is correct, whereas delaying only makes a slow enumeration feel
+   * slower.
+   */
+  async #loadPage(page: Extract<Page, { kind: "list" }>): Promise<void> {
+    const token = ++this.#loadToken;
+    this.loading = true;
+    this.error = null;
+    try {
+      const items = await page.items();
+      if (token !== this.#loadToken) return;
+      this.pageRows = items;
+    } catch (err) {
+      if (token !== this.#loadToken) return;
+      this.pageRows = [];
+      this.error = err instanceof Error ? err.message : "Could not load that list.";
+    } finally {
+      if (token === this.#loadToken) this.loading = false;
+    }
+  }
+
+  // -------------------------------------------------------------- navigation
+
+  /** Move the selection by `delta`, clamped. Short lists make wrapping disorienting. */
+  move(delta: number): void {
+    const rows = this.rows;
+    if (rows.length === 0) return;
+    const current = rows.findIndex((row) => row.cmd.id === this.selected?.cmd.id);
+    const next = Math.min(Math.max(current + delta, 0), rows.length - 1);
+    this.selectedId = rows[next].cmd.id;
+  }
+
+  moveToStart(): void {
+    this.selectedId = this.rows[0]?.cmd.id ?? null;
+  }
+
+  moveToEnd(): void {
+    this.selectedId = this.rows.at(-1)?.cmd.id ?? null;
+  }
+
+  movePage(direction: 1 | -1, pageSize = DEFAULT_PAGE_SIZE): void {
+    this.move(direction * Math.max(1, pageSize));
+  }
+
+  /** Select via the pointer. The caller MUST have confirmed real pointer movement. */
+  hover(id: string): void {
+    if (this.selectedId === id) return;
+    this.selectedId = id;
+  }
+
+  // ---------------------------------------------------------------- accepting
+
+  /**
+   * Run the active row, or submit the prompt.
+   *
+   * Recency is recorded before the action runs, so a command that closes the
+   * palette or navigates away still counts as used.
+   */
+  async accept(): Promise<void> {
+    if (this.busy) return;
+
+    const page = this.page;
+    if (page?.kind === "prompt") {
+      await this.#submitPrompt(page);
+      return;
+    }
+
+    const row = this.selected;
+    if (!row) return;
+    await this.run(row.cmd);
+  }
+
+  async run(cmd: Cmd): Promise<void> {
+    // A destructive command never earns recency. Recording it would float it
+    // into the recents group, which is the first thing the palette shows and
+    // where Enter already rests. "Erase all local data" MUST NOT be one
+    // keystroke from an empty query, and merely opening its confirm page and
+    // backing out MUST NOT promote it either.
+    if (!cmd.danger) this.#touch(cmd.id);
+
+    if (cmd.action.kind === "page") {
+      this.push(cmd.action.open());
+      return;
+    }
+
+    const keepOpen = cmd.action.keepOpen === true;
+    if (!keepOpen) this.close();
+
+    this.busy = true;
+    try {
+      await cmd.action.perform();
+    } catch (err) {
+      console.warn(`[palette] "${cmd.title}" failed`, err);
+      if (keepOpen) {
+        this.error = err instanceof Error ? err.message : "That did not work.";
+      }
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  async #submitPrompt(page: Extract<Page, { kind: "prompt" }>): Promise<void> {
+    const value = this.promptValue.trim();
+    const message = page.validate ? page.validate(value) : null;
+    if (message !== null) {
+      this.error = message;
+      return;
+    }
+
+    this.close();
+    this.busy = true;
+    try {
+      await page.submit(value);
+    } catch (err) {
+      console.warn(`[palette] "${page.title}" failed`, err);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  // ------------------------------------------------------------------ dismiss
+
+  /**
+   * One decision for `Escape`, made here so the dialog cannot also act on it.
+   * Two independent Escape listeners is why palettes close everything at once.
+   * The dialog is configured with `escapeKeydownBehavior="ignore"` so that this
+   * really is the only handler.
+   *
+   * Clears the query first, then steps back a page, and only then closes. Each
+   * press undoes exactly one thing.
+   */
+  escape(): void {
+    if (this.inputValue.length > 0) {
+      this.setQuery("");
+      return;
+    }
+    if (this.stack.length > 0) {
+      this.pop();
+      return;
+    }
+    this.close();
+  }
+
+  /**
+   * `Backspace` on an empty input steps back a page.
+   *
+   * @param liveValue The input element's current value. Read it from the event
+   *   target, never from state: on a key repeat the state write lags a tick,
+   *   which pops a page the user was still typing in.
+   * @returns `true` when the palette handled it.
+   */
+  backspace(liveValue: string): boolean {
+    if (liveValue.length > 0) return false;
+    if (this.stack.length === 0) return false;
+    this.pop();
+    return true;
+  }
+
+  // --------------------------------------------------------------------- mru
+
+  #touch(id: string): void {
+    this.#mru.touch(id);
+    this.#mruVersion++;
+    saveMru(this.#mru);
+  }
+
+  /** Drop a row from the recency list without running it. */
+  forget(id: string): void {
+    if (!this.#mru.forget(id)) return;
+    this.#mruVersion++;
+    saveMru(this.#mru);
+  }
+}
+
+/**
+ * Turn a confirm page into two rows so it reuses the same keyboard, selection,
+ * and ARIA machinery as every other page. Cancel comes first, and is therefore
+ * selected by default: a destructive action must cost a deliberate keystroke.
+ */
+function confirmRows(
+  page: Extract<Page, { kind: "confirm" }>,
+  cancel: () => void,
+): Cmd[] {
+  // The warning text is NOT the group name. Group names render as short
+  // uppercase headings, and a full sentence set in caps is the last thing a
+  // destructive prompt needs. The palette renders `page.message` itself.
+  return [
+    {
+      id: `${page.id}:cancel`,
+      title: "Cancel",
+      group: "Confirm",
+      action: { kind: "act", perform: cancel, keepOpen: true },
+    },
+    {
+      id: `${page.id}:confirm`,
+      title: page.confirmLabel,
+      group: "Confirm",
+      danger: true,
+      action: { kind: "act", perform: page.confirm },
+    },
+  ];
+}
+
+/** Rows for the `?` scope, so the prefixes are discoverable rather than folklore. */
+function helpRows(apply: (sigil: Sigil) => void): Cmd[] {
+  return (Object.keys(SIGILS) as Sigil[]).map((sigil) => ({
+    id: `help:${sigil}`,
+    title: `${sigil}  ${SIGILS[sigil]}`,
+    subtitle: `Search only ${SIGILS[sigil].toLowerCase()}`,
+    group: "Prefixes",
+    // Accepting a help row types the prefix, so the user learns it by using it.
+    action: { kind: "act", perform: () => apply(sigil), keepOpen: true },
+  }));
+}

--- a/frontend/src/lib/palette/query.test.ts
+++ b/frontend/src/lib/palette/query.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { parseQuery, parseRoomCode } from "./query";
+
+describe("query", () => {
+  describe("parseQuery", () => {
+    it("has no sigil and one term per word when nothing scopes the search", () => {
+      const parsed = parseQuery("hello world");
+      expect(parsed.sigil).toBeNull();
+      expect(parsed.body).toBe("hello world");
+      expect(parsed.terms).toEqual([
+        { text: "hello", exact: false },
+        { text: "world", exact: false },
+      ]);
+    });
+
+    it("strips the # sigil out of the body", () => {
+      const parsed = parseQuery("#room");
+      expect(parsed.sigil).toBe("#");
+      expect(parsed.body).toBe("room");
+      expect(parsed.terms).toEqual([{ text: "room", exact: false }]);
+    });
+
+    it("strips the @ sigil out of the body", () => {
+      const parsed = parseQuery("@alice");
+      expect(parsed.sigil).toBe("@");
+      expect(parsed.body).toBe("alice");
+      expect(parsed.terms).toEqual([{ text: "alice", exact: false }]);
+    });
+
+    it("strips the > sigil out of the body", () => {
+      const parsed = parseQuery(">audio");
+      expect(parsed.sigil).toBe(">");
+      expect(parsed.body).toBe("audio");
+      expect(parsed.terms).toEqual([{ text: "audio", exact: false }]);
+    });
+
+    it("strips the ? sigil out of the body", () => {
+      const parsed = parseQuery("?shortcuts");
+      expect(parsed.sigil).toBe("?");
+      expect(parsed.body).toBe("shortcuts");
+      expect(parsed.terms).toEqual([{ text: "shortcuts", exact: false }]);
+    });
+
+    it("yields zero terms for a sigil typed alone", () => {
+      const parsed = parseQuery("#");
+      expect(parsed.sigil).toBe("#");
+      expect(parsed.body).toBe("");
+      expect(parsed.terms).toEqual([]);
+    });
+
+    it("splits on whitespace into several terms", () => {
+      expect(parseQuery("join room").terms).toEqual([
+        { text: "join", exact: false },
+        { text: "room", exact: false },
+      ]);
+    });
+
+    it("collapses repeated inner whitespace between terms", () => {
+      const parsed = parseQuery("  hello   world  ");
+      expect(parsed.body).toBe("hello   world");
+      expect(parsed.terms).toEqual([
+        { text: "hello", exact: false },
+        { text: "world", exact: false },
+      ]);
+    });
+
+    it("turns a quoted segment into one exact term", () => {
+      expect(parseQuery('"settings"').terms).toEqual([
+        { text: "settings", exact: true },
+      ]);
+    });
+
+    it("keeps a quoted segment containing a space as one term", () => {
+      expect(parseQuery('"join room"').terms).toEqual([
+        { text: "join room", exact: true },
+      ]);
+    });
+
+    it("still parses usefully when a quote is never closed", () => {
+      expect(parseQuery('"unterminated').terms).toEqual([
+        { text: "unterminated", exact: true },
+      ]);
+    });
+
+    it("mixes quoted and bare terms in one query", () => {
+      expect(parseQuery('"exact" bare').terms).toEqual([
+        { text: "exact", exact: true },
+        { text: "bare", exact: false },
+      ]);
+    });
+
+    it("lowercases term text but preserves raw verbatim", () => {
+      const parsed = parseQuery("MixedCase Query");
+      expect(parsed.raw).toBe("MixedCase Query");
+      expect(parsed.terms).toEqual([
+        { text: "mixedcase", exact: false },
+        { text: "query", exact: false },
+      ]);
+    });
+
+    it("returns zero terms for empty input", () => {
+      expect(parseQuery("").terms).toEqual([]);
+    });
+
+    it("returns zero terms for whitespace-only input", () => {
+      expect(parseQuery("   ").terms).toEqual([]);
+    });
+  });
+
+  describe("parseRoomCode", () => {
+    it("accepts a bare valid 6-hex code", () => {
+      expect(parseRoomCode("a1b2c3")).toBe("a1b2c3");
+    });
+
+    it("normalises an uppercase code to lowercase", () => {
+      expect(parseRoomCode("A1B2C3")).toBe("a1b2c3");
+    });
+
+    it("pulls the code out of a full invite URL", () => {
+      expect(parseRoomCode("https://awful.chat/r/a1b2c3")).toBe("a1b2c3");
+    });
+
+    it("pulls the code out of a web+awfl:// link", () => {
+      expect(parseRoomCode("web+awfl://a1b2c3")).toBe("a1b2c3");
+    });
+
+    it("drops a trailing slash left on a pasted URL", () => {
+      expect(parseRoomCode("https://awful.chat/r/a1b2c3/")).toBe("a1b2c3");
+    });
+
+    it("drops a trailing query string left on a pasted URL", () => {
+      expect(parseRoomCode("https://awful.chat/r/a1b2c3?ref=x")).toBe("a1b2c3");
+    });
+
+    it("drops a trailing fragment left on a pasted URL", () => {
+      expect(parseRoomCode("https://awful.chat/r/a1b2c3#frag")).toBe("a1b2c3");
+    });
+
+    it("rejects a 5-character code", () => {
+      expect(parseRoomCode("a1b2c")).toBeNull();
+    });
+
+    it("rejects a 7-character code", () => {
+      expect(parseRoomCode("a1b2c3d")).toBeNull();
+    });
+
+    it("rejects a 6-character string that is not hex", () => {
+      expect(parseRoomCode("gggggg")).toBeNull();
+    });
+
+    it("rejects empty input", () => {
+      expect(parseRoomCode("")).toBeNull();
+    });
+
+    it("rejects whitespace-only input", () => {
+      expect(parseRoomCode("   ")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/lib/palette/query.ts
+++ b/frontend/src/lib/palette/query.ts
@@ -1,0 +1,90 @@
+import { SIGILS, type ParsedQuery, type QueryTerm, type Sigil } from "./types";
+
+/**
+ * Parse what the user typed into a scope and a list of terms.
+ *
+ * Rules, all borrowed from VS Code's quick access:
+ *   - A leading sigil scopes the search and is stripped from the terms.
+ *   - Whitespace splits the rest into terms, and every term must match. Typing
+ *     more words narrows; it never widens.
+ *   - A quoted segment must match contiguously, which is the escape hatch when
+ *     fuzzy matching is too eager.
+ */
+export function parseQuery(raw: string): ParsedQuery {
+  let sigil: Sigil | null = null;
+  let rest = raw;
+
+  const head = raw[0];
+  if (head !== undefined && head in SIGILS) {
+    sigil = head as Sigil;
+    rest = raw.slice(1);
+  }
+
+  const body = rest.trim();
+  return { raw, sigil, body, terms: splitTerms(body) };
+}
+
+/**
+ * Split a query body into terms, honouring double quotes.
+ *
+ * An unclosed quote is treated as if it closed at the end of the string, so the
+ * query stays usable while the user is still typing it.
+ */
+function splitTerms(body: string): QueryTerm[] {
+  const terms: QueryTerm[] = [];
+  let i = 0;
+
+  while (i < body.length) {
+    if (/\s/.test(body[i])) {
+      i++;
+      continue;
+    }
+
+    if (body[i] === '"') {
+      const close = body.indexOf('"', i + 1);
+      const end = close < 0 ? body.length : close;
+      const text = body.slice(i + 1, end).trim().toLowerCase();
+      if (text.length > 0) terms.push({ text, exact: true });
+      i = close < 0 ? body.length : close + 1;
+      continue;
+    }
+
+    let end = i;
+    while (end < body.length && !/\s/.test(body[end]) && body[end] !== '"') end++;
+    const text = body.slice(i, end).toLowerCase();
+    if (text.length > 0) terms.push({ text, exact: false });
+    i = end;
+  }
+
+  return terms;
+}
+
+/** A room code is three random bytes rendered as lowercase hex. */
+const ROOM_CODE = /^[0-9a-f]{6}$/;
+
+/**
+ * Pull a room code out of whatever the user pasted.
+ *
+ * Accepts a bare code, a full invite URL, or a `web+awfl://` link, because all
+ * three are things a user will paste into the palette. Mirrors the split that
+ * `RoomCreateJoin` already does on its paste handler.
+ *
+ * @returns The lowercase room code, or `null` when the text is not one.
+ */
+export function parseRoomCode(text: string): string | null {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+
+  const candidates = [trimmed];
+  const afterPath = trimmed.split("/r/")[1];
+  if (afterPath !== undefined) candidates.push(afterPath);
+  const afterProtocol = trimmed.split("web+awfl://")[1];
+  if (afterProtocol !== undefined) candidates.push(afterProtocol);
+
+  for (const candidate of candidates) {
+    // Drop any trailing path, query, or fragment left on a pasted URL.
+    const code = candidate.split(/[/?#]/)[0].trim().toLowerCase();
+    if (ROOM_CODE.test(code)) return code;
+  }
+  return null;
+}

--- a/frontend/src/lib/palette/rank.test.ts
+++ b/frontend/src/lib/palette/rank.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+import { compareRanked, flatten, rank, scoreCmd, RECENT_GROUP } from "./rank";
+import { parseQuery } from "./query";
+import { Mru } from "./mru";
+import type { Cmd, RankedCmd, RankedGroup } from "./types";
+
+/** A minimal, uniquely-idd command. Fills in the boring bits every fixture needs. */
+function cmd(partial: Partial<Cmd> & { title: string; id?: string }): Cmd {
+  return {
+    group: "Test",
+    action: { kind: "act", perform() {} },
+    ...partial,
+    id: partial.id ?? partial.title,
+  };
+}
+
+const emptyMru = new Mru();
+const emptySeq = new Map<string, number>();
+
+describe("rank", () => {
+  describe("scoreCmd", () => {
+    it("accepts every command when there are zero terms", () => {
+      const c = cmd({ title: "Anything at all" });
+      expect(scoreCmd(c, [])).not.toBeNull();
+    });
+
+    it("returns null when any term fails, even if another term matched strongly", () => {
+      // "settings" is a whole-title hit; "zzzzzzz" matches nothing on the
+      // command at all. One failing term must veto the whole row.
+      const c = cmd({ title: "Settings" });
+      const terms = parseQuery("settings zzzzzzz").terms;
+      expect(scoreCmd(c, terms)).toBeNull();
+    });
+
+    it("keeps a leading-phrase match ahead of a scattered one across terms", () => {
+      // Regression, caught by driving the real palette. Both rows land in
+      // TIER_TITLE because their second term only fuzzy-matches, so the raw
+      // character score decides. The prefix term used to contribute a flat
+      // length boost instead of a real score, which let the scattered title
+      // win on points.
+      const leading = cmd({ title: "Join room by code" });
+      const scattered = cmd({ title: "Create or join a room" });
+      const terms = parseQuery("join room").terms;
+
+      const a = scoreCmd(leading, terms)!;
+      const b = scoreCmd(scattered, terms)!;
+      expect(a.score).toBeGreaterThan(b.score);
+      expect(compareRanked(a, b, emptyMru, emptySeq)).toBeLessThan(0);
+    });
+
+    it("takes a command's weakest term's tier, not its strongest", () => {
+      // "settings" hits the title exactly (the strongest possible tier);
+      // "audio" only hits the subtitle. The row must carry the subtitle tier.
+      const c = cmd({ title: "Settings", subtitle: "audio device" });
+      const terms = parseQuery("settings audio").terms;
+      const scored = scoreCmd(c, terms);
+      expect(scored).not.toBeNull();
+
+      const titleOnly = scoreCmd(cmd({ title: "Settings" }), parseQuery("settings").terms);
+      // The combined score's tier is strictly weaker than the title-only tier.
+      expect(scored!.tier).toBeLessThan(titleOnly!.tier);
+    });
+
+    describe("tier ordering is absolute", () => {
+      // Tiers are spaced so far apart that no amount of character score can
+      // cross one. These four checks defend that "tiers, not blending" design.
+      const prefixCmd = cmd({ title: "Room settings" });
+      const titleFuzzyCmd = cmd({ title: "Warehouse chatroom exploration hub" });
+      const keywordCmd = cmd({ title: "Random Panel", keywords: ["zephyr"] });
+      const subtitleCmd = cmd({ title: "Random Panel Two", subtitle: "wisteria lane" });
+
+      const prefixRow = scoreCmd(prefixCmd, parseQuery("room").terms)!;
+      const titleFuzzyRow = scoreCmd(titleFuzzyCmd, parseQuery("room").terms)!;
+      const keywordRow = scoreCmd(keywordCmd, parseQuery("zephyr").terms)!;
+      const subtitleRow = scoreCmd(subtitleCmd, parseQuery("wisteria").terms)!;
+
+      it("resolved every fixture to a real row", () => {
+        expect(prefixRow).not.toBeNull();
+        expect(titleFuzzyRow).not.toBeNull();
+        expect(keywordRow).not.toBeNull();
+        expect(subtitleRow).not.toBeNull();
+      });
+
+      it("ranks a title prefix match above a much longer, better-scoring title fuzzy hit", () => {
+        expect(prefixRow.tier).toBeGreaterThan(titleFuzzyRow.tier);
+        expect(compareRanked(prefixRow, titleFuzzyRow, emptyMru, emptySeq)).toBeLessThan(0);
+      });
+
+      it("ranks a title fuzzy hit above a keyword hit", () => {
+        expect(titleFuzzyRow.tier).toBeGreaterThan(keywordRow.tier);
+        expect(compareRanked(titleFuzzyRow, keywordRow, emptyMru, emptySeq)).toBeLessThan(0);
+      });
+
+      it("ranks a keyword hit above a subtitle-only hit", () => {
+        expect(keywordRow.tier).toBeGreaterThan(subtitleRow.tier);
+        expect(compareRanked(keywordRow, subtitleRow, emptyMru, emptySeq)).toBeLessThan(0);
+      });
+    });
+
+    it("lets a shorter title win a prefix tie (\"Room\" before \"Room settings\")", () => {
+      const terms = parseQuery("room").terms;
+      const room = scoreCmd(cmd({ title: "Room" }), terms)!;
+      const roomSettings = scoreCmd(cmd({ title: "Room settings" }), terms)!;
+      expect(compareRanked(room, roomSettings, emptyMru, emptySeq)).toBeLessThan(0);
+    });
+
+    it("marks the matched characters in titleRanges, merging a multi-term query into one ascending non-overlapping list", () => {
+      const c = cmd({ title: "Room Settings Panel" });
+      const terms = parseQuery("room panel").terms;
+      const scored = scoreCmd(c, terms)!;
+
+      expect(scored.titleRanges.length).toBeGreaterThan(1);
+      for (let i = 1; i < scored.titleRanges.length; i++) {
+        expect(scored.titleRanges[i].start).toBeGreaterThanOrEqual(scored.titleRanges[i - 1].end);
+      }
+      // The prefix hit on "room" covers the first four characters.
+      expect(scored.titleRanges[0]).toEqual({ start: 0, end: 4 });
+    });
+
+    it("produces no titleRanges for a keyword-only match, because keywords are not on screen", () => {
+      const c = cmd({ title: "Random Panel", keywords: ["zephyr"] });
+      const scored = scoreCmd(c, parseQuery("zephyr").terms)!;
+      expect(scored.titleRanges).toEqual([]);
+    });
+
+    it("rejects a quoted term that only fuzzy-matches non-contiguously", () => {
+      const c = cmd({ title: "Settings" });
+      expect(scoreCmd(c, parseQuery('"stg"').terms)).toBeNull();
+      // The same characters, unquoted, are a legitimate fuzzy hit.
+      expect(scoreCmd(c, parseQuery("stg").terms)).not.toBeNull();
+    });
+  });
+
+  describe("compareRanked", () => {
+    it("never returns 0 for two different commands", () => {
+      const fixtures = [
+        cmd({ title: "Room settings" }),
+        cmd({ title: "Warehouse chatroom exploration hub" }),
+        cmd({ title: "Random Panel", keywords: ["zephyr"] }),
+        cmd({ title: "Random Panel Two", subtitle: "wisteria lane" }),
+        cmd({ title: "Room" }),
+      ];
+      const queries = ["room", "room", "zephyr", "wisteria", "room"];
+      const rows = fixtures.map((c, i) => scoreCmd(c, parseQuery(queries[i]).terms)!);
+
+      for (let i = 0; i < rows.length; i++) {
+        for (let j = 0; j < rows.length; j++) {
+          if (i === j) continue;
+          expect(compareRanked(rows[i], rows[j], emptyMru, emptySeq)).not.toBe(0);
+        }
+      }
+    });
+
+    it("sorts the same way regardless of starting order (a stable total order)", () => {
+      const fixtures = [
+        cmd({ id: "a", title: "Room" }),
+        cmd({ id: "b", title: "A room mention buried deep inside" }),
+        cmd({ id: "c", title: "Another chatroom reference somewhere in here" }),
+      ];
+      const terms = parseQuery("room").terms;
+      const rows = fixtures.map((c) => scoreCmd(c, terms)!);
+
+      const forward = [...rows].sort((a, b) => compareRanked(a, b, emptyMru, emptySeq));
+      const backward = [...rows]
+        .reverse()
+        .sort((a, b) => compareRanked(a, b, emptyMru, emptySeq));
+
+      expect(backward.map((r) => r.cmd.id)).toEqual(forward.map((r) => r.cmd.id));
+    });
+
+    it("lets recency break a tie within a tier", () => {
+      const untouched = cmd({ id: "untouched", title: "A room mention buried deep inside" });
+      const touched = cmd({ id: "touched", title: "Another chatroom reference in here too" });
+      const terms = parseQuery("room").terms;
+
+      const rowUntouched = scoreCmd(untouched, terms)!;
+      const rowTouched = scoreCmd(touched, terms)!;
+      expect(rowUntouched.tier).toBe(rowTouched.tier);
+
+      const mru = new Mru();
+      mru.touch("touched");
+      expect(compareRanked(rowTouched, rowUntouched, mru, emptySeq)).toBeLessThan(0);
+    });
+
+    it("never lets recency cross into a stronger tier", () => {
+      const strong = cmd({ id: "strong", title: "Room" });
+      const weakTouched = cmd({ id: "weak", title: "A room mention buried deep inside" });
+      const terms = parseQuery("room").terms;
+
+      const rowStrong = scoreCmd(strong, terms)!;
+      const rowWeak = scoreCmd(weakTouched, terms)!;
+      expect(rowStrong.tier).toBeGreaterThan(rowWeak.tier);
+
+      const mru = new Mru();
+      mru.touch("weak");
+      // Touching the weaker row cannot make it outrank the untouched, stronger one.
+      expect(compareRanked(rowWeak, rowStrong, mru, emptySeq)).toBeGreaterThan(0);
+    });
+  });
+
+  describe("rank", () => {
+    it("puts RECENT_GROUP first when history exists", () => {
+      const cmds = [cmd({ id: "a", title: "Alpha" }), cmd({ id: "b", title: "Beta" })];
+      const mru = new Mru();
+      mru.touch("b");
+      const groups = rank(cmds, parseQuery(""), mru);
+      expect(groups[0].name).toBe(RECENT_GROUP);
+      expect(groups[0].items.map((r) => r.cmd.id)).toEqual(["b"]);
+    });
+
+    it("omits RECENT_GROUP when history is empty", () => {
+      const cmds = [cmd({ id: "a", title: "Alpha" })];
+      const groups = rank(cmds, parseQuery(""), new Mru());
+      expect(groups.some((g) => g.name === RECENT_GROUP)).toBe(false);
+    });
+
+    it("never lists the same command id twice", () => {
+      const cmds = [
+        cmd({ id: "a", title: "Alpha", group: "G1" }),
+        cmd({ id: "b", title: "Beta", group: "G1" }),
+      ];
+      const mru = new Mru();
+      mru.touch("a");
+      const groups = rank(cmds, parseQuery(""), mru);
+      const ids = groups.flatMap((g) => g.items.map((r) => r.cmd.id));
+      expect(ids).toEqual(["a", "b"]);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("orders groups by their best member's score", () => {
+      // A prefix hit ("Room One") outscores a weak fuzzy hit buried in
+      // another group's title, so that group must sort first.
+      const strongGroup = cmd({ id: "g1", title: "Room One", group: "Rooms" });
+      const weakGroup = cmd({ id: "g2", title: "Zeta thing room-ish", group: "Other" });
+      const groups = rank([weakGroup, strongGroup], parseQuery("room"), new Mru());
+      expect(groups.map((g) => g.name)).toEqual(["Rooms", "Other"]);
+    });
+
+    it("honours its limit argument", () => {
+      const cmds = [
+        cmd({ id: "a", title: "Alpha", group: "G1" }),
+        cmd({ id: "b", title: "Beta", group: "G1" }),
+        cmd({ id: "c", title: "Gamma", group: "G2" }),
+      ];
+      const groups = rank(cmds, parseQuery(""), new Mru(), 2);
+      const ids = groups.flatMap((g) => g.items.map((r) => r.cmd.id));
+      expect(ids).toEqual(["a", "b"]);
+    });
+
+    it("gives two commands sharing a title a distinguishing subtitle", () => {
+      const cmds = [cmd({ id: "dupA", title: "Room" }), cmd({ id: "dupB", title: "Room" })];
+      const groups = rank(cmds, parseQuery("room"), new Mru());
+      const rows = groups.flatMap((g) => g.items);
+      expect(rows.find((r) => r.cmd.id === "dupA")!.cmd.subtitle).toBe("dupA");
+      expect(rows.find((r) => r.cmd.id === "dupB")!.cmd.subtitle).toBe("dupB");
+    });
+
+    it("leaves a command that already has a subtitle alone", () => {
+      const cmds = [
+        cmd({ id: "dupA", title: "Room" }),
+        cmd({ id: "dupB", title: "Room", subtitle: "already set" }),
+      ];
+      const groups = rank(cmds, parseQuery("room"), new Mru());
+      const rows = groups.flatMap((g) => g.items);
+      expect(rows.find((r) => r.cmd.id === "dupB")!.cmd.subtitle).toBe("already set");
+    });
+  });
+
+  describe("flatten", () => {
+    it("returns rows in group order", () => {
+      const rowA: RankedCmd = { ...scoreCmd(cmd({ id: "a", title: "A" }), [])! };
+      const rowB: RankedCmd = { ...scoreCmd(cmd({ id: "b", title: "B" }), [])! };
+      const rowC: RankedCmd = { ...scoreCmd(cmd({ id: "c", title: "C" }), [])! };
+      const groups: RankedGroup[] = [
+        { name: "G1", items: [rowA, rowB] },
+        { name: "G2", items: [rowC] },
+      ];
+      expect(flatten(groups).map((r) => r.cmd.id)).toEqual(["a", "b", "c"]);
+    });
+  });
+});

--- a/frontend/src/lib/palette/rank.ts
+++ b/frontend/src/lib/palette/rank.ts
@@ -1,0 +1,371 @@
+import {
+  match,
+  matchExact,
+  mergeRanges,
+  span,
+  type MatchRange,
+  type MatchResult,
+} from "./scorer";
+import type { Mru } from "./mru";
+import {
+  TIER_EXACT,
+  TIER_KEYWORD,
+  TIER_PREFIX,
+  TIER_SUBTITLE,
+  TIER_TITLE,
+  type Cmd,
+  type ParsedQuery,
+  type QueryTerm,
+  type RankedCmd,
+  type RankedGroup,
+} from "./types";
+
+/**
+ * How many rows to render at most.
+ *
+ * Below a few hundred rows a virtualizer buys nothing and makes scroll-into-view,
+ * Home/End, paging, and `aria-activedescendant` all harder to get right. Capping
+ * the output is the cheaper correct answer.
+ */
+export const MAX_ROWS = 200;
+
+/** How many recently used commands to surface when the query is empty. */
+export const RECENT_ROWS = 5;
+
+export const RECENT_GROUP = "Recently used";
+
+/** Lowercased fields, cached so a multi-term query lowercases each command once. */
+interface Lowered {
+  title: string;
+  subtitle: string | null;
+  keywords: string[];
+}
+
+const loweredCache = new WeakMap<Cmd, Lowered>();
+
+function lowered(cmd: Cmd): Lowered {
+  const cached = loweredCache.get(cmd);
+  if (cached) return cached;
+  const value: Lowered = {
+    title: cmd.title.toLowerCase(),
+    subtitle: cmd.subtitle ? cmd.subtitle.toLowerCase() : null,
+    keywords: cmd.keywords ? cmd.keywords.map((k) => k.toLowerCase()) : [],
+  };
+  loweredCache.set(cmd, value);
+  return value;
+}
+
+/** Where a term matched. Decides which text gets highlighted. */
+type Field = "title" | "keyword" | "subtitle";
+
+interface TermHit {
+  tier: number;
+  score: number;
+  field: Field;
+  result: MatchResult;
+}
+
+/**
+ * Match one term against one command, taking the strongest tier available.
+ *
+ * The order here is the ranking policy: title beats keyword beats subtitle, and
+ * an exact or prefix hit on the title beats any fuzzy hit anywhere. Because
+ * tiers are spaced `1<<2` apart in score terms, this ordering is absolute.
+ */
+function matchTerm(low: Lowered, term: QueryTerm): TermHit | null {
+  const run = term.exact ? matchExact : match;
+
+  if (!term.exact) {
+    // Exact and prefix hits are scored by the same matcher as every other tier,
+    // not with a flat number. A multi-term query sums the per-term scores, so a
+    // term scored on a different scale would distort the total: "join room"
+    // once ranked "Create or join a room" above "Join room by code", because
+    // the prefix term contributed a bare length boost while the loser earned a
+    // full character score for both of its terms.
+    if (low.title === term.text) {
+      const hit = match(low.title, term.text);
+      if (hit) {
+        return { tier: TIER_EXACT, score: hit.score, field: "title", result: hit };
+      }
+    }
+
+    if (low.title.startsWith(term.text)) {
+      const hit = match(low.title, term.text);
+      if (hit) {
+        // Shorter titles win a prefix tie: given "Room" and "Room settings" for
+        // the query "room", the bare "Room" is what was meant.
+        const boost = Math.round((term.text.length / low.title.length) * 100);
+        const score = hit.score + boost;
+        return {
+          tier: TIER_PREFIX,
+          score,
+          field: "title",
+          result: { score, positions: hit.positions },
+        };
+      }
+    }
+  }
+
+  const onTitle = run(low.title, term.text);
+  if (onTitle) {
+    return {
+      tier: TIER_TITLE,
+      score: onTitle.score,
+      field: "title",
+      result: onTitle,
+    };
+  }
+
+  // Keywords are aliases. They rank the row but are never highlighted, because
+  // they are not on screen.
+  let bestKeyword: MatchResult | null = null;
+  for (const keyword of low.keywords) {
+    const hit = run(keyword, term.text);
+    if (hit && (!bestKeyword || hit.score > bestKeyword.score)) bestKeyword = hit;
+  }
+  if (bestKeyword) {
+    return {
+      tier: TIER_KEYWORD,
+      score: bestKeyword.score,
+      field: "keyword",
+      result: bestKeyword,
+    };
+  }
+
+  if (low.subtitle !== null) {
+    const onSubtitle = run(low.subtitle, term.text);
+    if (onSubtitle) {
+      return {
+        tier: TIER_SUBTITLE,
+        score: onSubtitle.score,
+        field: "subtitle",
+        result: onSubtitle,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Score one command against every term.
+ *
+ * Every term must match something, so typing more words always narrows. The
+ * command takes its *weakest* term's tier, which stops one strong title hit from
+ * dragging a row up when the rest of the query only grazed its subtitle.
+ *
+ * @returns The ranked row, or `null` when any term failed to match.
+ */
+export function scoreCmd(cmd: Cmd, terms: readonly QueryTerm[]): RankedCmd | null {
+  if (terms.length === 0) {
+    return {
+      cmd,
+      score: 0,
+      tier: TIER_EXACT,
+      titleRanges: [],
+      subtitleRanges: [],
+      titleSpan: 0,
+    };
+  }
+
+  const low = lowered(cmd);
+  let weakestTier = Number.POSITIVE_INFINITY;
+  let total = 0;
+  const titleRanges: MatchRange[] = [];
+  const subtitleRanges: MatchRange[] = [];
+  const titlePositions: number[] = [];
+
+  for (const term of terms) {
+    const hit = matchTerm(low, term);
+    if (!hit) return null;
+
+    weakestTier = Math.min(weakestTier, hit.tier);
+    total += hit.score;
+
+    if (hit.field === "title") {
+      titlePositions.push(...hit.result.positions);
+      for (const p of hit.result.positions) {
+        titleRanges.push({ start: p, end: p + 1 });
+      }
+    } else if (hit.field === "subtitle") {
+      for (const p of hit.result.positions) {
+        subtitleRanges.push({ start: p, end: p + 1 });
+      }
+    }
+  }
+
+  titlePositions.sort((a, b) => a - b);
+  return {
+    cmd,
+    score: weakestTier + total,
+    tier: weakestTier,
+    titleRanges: mergeRanges(titleRanges),
+    subtitleRanges: mergeRanges(subtitleRanges),
+    titleSpan: span(titlePositions),
+  };
+}
+
+/**
+ * Order two rows.
+ *
+ * An ordered tuple, never a weighted sum, and it never returns 0 before the last
+ * rule. Every tie left unbroken shows up as rows swapping places between
+ * keystrokes, which reads as the palette being unstable.
+ *
+ * Recency sits *inside* a relevance class, not above it, so a recently used
+ * command can outrank an equally relevant one but never a better match.
+ */
+export function compareRanked(
+  a: RankedCmd,
+  b: RankedCmd,
+  mru: Mru,
+  seq: ReadonlyMap<string, number>,
+): number {
+  if (a.tier !== b.tier) return b.tier - a.tier;
+
+  const rankA = mru.rank(a.cmd.id);
+  const rankB = mru.rank(b.cmd.id);
+  if (rankA !== undefined && rankB !== undefined && rankA !== rankB) {
+    return rankB - rankA;
+  }
+  if (rankA !== undefined && rankB === undefined) return -1;
+  if (rankB !== undefined && rankA === undefined) return 1;
+
+  if (a.score !== b.score) return b.score - a.score;
+
+  // A tighter match is a better one, except under a prefix hit, where a longer
+  // match means more of the title was typed.
+  if (a.tier < TIER_PREFIX && a.titleSpan !== b.titleSpan) {
+    return a.titleSpan - b.titleSpan;
+  }
+
+  if (a.cmd.title.length !== b.cmd.title.length) {
+    return a.cmd.title.length - b.cmd.title.length;
+  }
+
+  const byTitle = a.cmd.title.localeCompare(b.cmd.title);
+  if (byTitle !== 0) return byTitle;
+
+  // Authored order, so the result is fully deterministic.
+  return (seq.get(a.cmd.id) ?? 0) - (seq.get(b.cmd.id) ?? 0);
+}
+
+/**
+ * Two rows sharing a title are indistinguishable to the user. Rooms collide by
+ * name routinely. Mark the collisions so the row can show the id alongside.
+ */
+function disambiguate(rows: RankedCmd[]): void {
+  const seen = new Map<string, RankedCmd[]>();
+  for (const row of rows) {
+    const key = row.cmd.title.toLowerCase();
+    const bucket = seen.get(key);
+    if (bucket) bucket.push(row);
+    else seen.set(key, [row]);
+  }
+  for (const bucket of seen.values()) {
+    if (bucket.length < 2) continue;
+    for (const row of bucket) {
+      if (row.cmd.subtitle) continue;
+      row.cmd = { ...row.cmd, subtitle: row.cmd.id };
+    }
+  }
+}
+
+/**
+ * Filter, order, and group commands for display.
+ *
+ * With no query the catalog is shown in authored order, led by a recently used
+ * group. With a query the rows are ranked and the groups follow their best
+ * member, which is what makes the top row feel chosen rather than stumbled on.
+ */
+export function rank(
+  cmds: readonly Cmd[],
+  query: ParsedQuery,
+  mru: Mru,
+  limit = MAX_ROWS,
+): RankedGroup[] {
+  const seq = new Map<string, number>();
+  cmds.forEach((cmd, index) => seq.set(cmd.id, index));
+
+  if (query.terms.length === 0) {
+    return groupUnfiltered(cmds, mru, limit);
+  }
+
+  const rows: RankedCmd[] = [];
+  for (const cmd of cmds) {
+    const scored = scoreCmd(cmd, query.terms);
+    if (scored) rows.push(scored);
+  }
+
+  rows.sort((a, b) => compareRanked(a, b, mru, seq));
+  const visible = rows.slice(0, limit);
+  disambiguate(visible);
+
+  // Group score is its best member's score, and members keep their global order
+  // within the group.
+  const groups = new Map<string, RankedCmd[]>();
+  for (const row of visible) {
+    const bucket = groups.get(row.cmd.group);
+    if (bucket) bucket.push(row);
+    else groups.set(row.cmd.group, [row]);
+  }
+
+  return [...groups.entries()]
+    .map(([name, items]) => ({ name, items }))
+    .sort((a, b) => b.items[0].score - a.items[0].score);
+}
+
+/** The empty-query view: recents first, then the catalog in authored order. */
+function groupUnfiltered(
+  cmds: readonly Cmd[],
+  mru: Mru,
+  limit: number,
+): RankedGroup[] {
+  const byId = new Map(cmds.map((cmd) => [cmd.id, cmd]));
+  const recentIds = mru.recent(RECENT_ROWS).filter((id) => byId.has(id));
+  const recentSet = new Set(recentIds);
+
+  const out: RankedGroup[] = [];
+  let remaining = limit;
+
+  if (recentIds.length > 0) {
+    const items = recentIds
+      .slice(0, remaining)
+      .map((id) => blankRow(byId.get(id)!));
+    remaining -= items.length;
+    out.push({ name: RECENT_GROUP, items });
+  }
+
+  const groups = new Map<string, RankedCmd[]>();
+  for (const cmd of cmds) {
+    if (remaining <= 0) break;
+    // A recent row is already on screen; showing it twice wastes a slot and
+    // breaks the "one row per id" invariant that keying depends on.
+    if (recentSet.has(cmd.id)) continue;
+    const bucket = groups.get(cmd.group);
+    if (bucket) bucket.push(blankRow(cmd));
+    else groups.set(cmd.group, [blankRow(cmd)]);
+    remaining--;
+  }
+
+  for (const [name, items] of groups) out.push({ name, items });
+  return out;
+}
+
+function blankRow(cmd: Cmd): RankedCmd {
+  return {
+    cmd,
+    score: 0,
+    tier: TIER_EXACT,
+    titleRanges: [],
+    subtitleRanges: [],
+    titleSpan: 0,
+  };
+}
+
+/** Flatten groups into the row order the keyboard walks. */
+export function flatten(groups: readonly RankedGroup[]): RankedCmd[] {
+  const out: RankedCmd[] = [];
+  for (const group of groups) out.push(...group.items);
+  return out;
+}

--- a/frontend/src/lib/palette/scorer.test.ts
+++ b/frontend/src/lib/palette/scorer.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_PATTERN,
+  MAX_TEXT,
+  match,
+  matchExact,
+  mergeRanges,
+  span,
+  toRanges,
+} from "./scorer";
+
+/** Convenience: the matcher requires pre-lowercased input. */
+function score(text: string, pattern: string) {
+  return match(text.toLowerCase(), pattern.toLowerCase());
+}
+
+describe("scorer", () => {
+  describe("match", () => {
+    // These four numbers are the reference values produced by fzf's
+    // FuzzyMatchV2 for the label "Join Room". They pin the port to the
+    // original algorithm, so a regression in the bonus table shows up here.
+    it("scores an acronym match and reports both initials", () => {
+      expect(score("Join Room", "jr")).toEqual({
+        score: 56,
+        positions: [0, 5],
+      });
+    });
+
+    it("scores a contiguous prefix run", () => {
+      expect(score("Join Room", "join")).toEqual({
+        score: 114,
+        positions: [0, 1, 2, 3],
+      });
+    });
+
+    it("scores a contiguous run at a word boundary", () => {
+      expect(score("Join Room", "room")).toEqual({
+        score: 114,
+        positions: [5, 6, 7, 8],
+      });
+    });
+
+    it("scores an initial plus a following word above either alone", () => {
+      expect(score("Join Room", "jroom")).toEqual({
+        score: 134,
+        positions: [0, 5, 6, 7, 8],
+      });
+    });
+
+    it("returns null when the characters are not present in order", () => {
+      expect(score("Join Room", "xq")).toBeNull();
+      expect(score("Join Room", "mor")).toBeNull();
+    });
+
+    it("returns null for an empty pattern", () => {
+      expect(match("join room", "")).toBeNull();
+    });
+
+    it("returns null when the pattern is longer than the text", () => {
+      expect(score("ab", "abc")).toBeNull();
+    });
+
+    it("prefers a word-boundary match over a mid-word match", () => {
+      // "Set Theme" starts a word with `t`; "Battery" buries it.
+      const boundary = score("Set Theme", "t")!;
+      const buried = score("Battery", "t")!;
+      expect(boundary.score).toBeGreaterThan(buried.score);
+    });
+
+    it("rates start-of-string and after-a-space as the same boundary", () => {
+      // Deliberate. fzf calibrates one boundary bonus, and preferring the
+      // start of a title is the tier layer's job, not the character scorer's.
+      // `rank.ts` puts a prefix match strictly above any fuzzy match, so
+      // "Room settings" still beats "Open room" for the query `r`.
+      expect(score("Room settings", "r")!.score).toBe(
+        score("Open room", "r")!.score,
+      );
+    });
+
+
+    it("credits camelCase boundaries like word boundaries", () => {
+      const camel = score("joinRoom", "jr")!;
+      expect(camel.positions).toEqual([0, 4]);
+    });
+
+    it("treats a letter-to-digit transition as a boundary", () => {
+      const withDigit = score("room2", "r2")!;
+      expect(withDigit.positions).toEqual([0, 4]);
+    });
+
+    it("prefers a tighter match over a scattered one", () => {
+      const tight = score("mic mute", "mm")!;
+      const scattered = score("maximize window frame", "mm")!;
+      expect(tight.score).toBeGreaterThan(scattered.score);
+    });
+
+    it("charges less for one long gap than for several short ones", () => {
+      // Affine gaps: opening costs -3, extending costs -1.
+      const oneGap = score("abxxxxcd", "abcd")!;
+      const manyGaps = score("axbxcxd", "abcd")!;
+      expect(oneGap.score).toBeGreaterThan(manyGaps.score);
+    });
+
+    it("matches case-insensitively", () => {
+      expect(score("PROFILE", "pro")).not.toBeNull();
+      expect(score("profile", "PRO")).not.toBeNull();
+    });
+
+    it("matches accented and non-Latin text", () => {
+      expect(score("Café Room", "caf")).not.toBeNull();
+      expect(score("Комната", "ком")).not.toBeNull();
+    });
+
+    it("returns ascending positions", () => {
+      const result = score("Toggle Screen Share", "tss")!;
+      const sorted = [...result.positions].sort((a, b) => a - b);
+      expect(result.positions).toEqual(sorted);
+    });
+
+    it("returns exactly one position per pattern character", () => {
+      const result = score("Start Screen Share", "sss")!;
+      expect(result.positions).toHaveLength(3);
+    });
+
+    it("refuses a pattern longer than the cap", () => {
+      expect(match("a".repeat(300), "a".repeat(MAX_PATTERN + 1))).toBeNull();
+    });
+
+    it("stays bounded on a pathological low-entropy label", () => {
+      // The cmdk scorer costs ~29 ms for this shape because it has no cap.
+      // Here the text is truncated to MAX_TEXT and the DP is bounded, so the
+      // call has to stay far below a frame budget.
+      const text = "a".repeat(2000);
+      const started = performance.now();
+      const result = match(text, "a".repeat(8));
+      const elapsed = performance.now() - started;
+      expect(result).not.toBeNull();
+      expect(elapsed).toBeLessThan(5);
+    });
+
+    it("only considers the first MAX_TEXT characters", () => {
+      const text = `${"b".repeat(MAX_TEXT)}z`;
+      expect(match(text, "z")).toBeNull();
+    });
+  });
+
+  describe("toRanges", () => {
+    it("collapses consecutive positions into one range", () => {
+      expect(toRanges([0, 1, 2])).toEqual([{ start: 0, end: 3 }]);
+    });
+
+    it("splits non-consecutive positions", () => {
+      expect(toRanges([0, 5, 6])).toEqual([
+        { start: 0, end: 1 },
+        { start: 5, end: 7 },
+      ]);
+    });
+
+    it("returns nothing for no positions", () => {
+      expect(toRanges([])).toEqual([]);
+    });
+  });
+
+  describe("mergeRanges", () => {
+    it("merges overlapping ranges", () => {
+      expect(
+        mergeRanges([
+          { start: 0, end: 4 },
+          { start: 2, end: 6 },
+        ]),
+      ).toEqual([{ start: 0, end: 6 }]);
+    });
+
+    it("merges touching ranges", () => {
+      expect(
+        mergeRanges([
+          { start: 0, end: 2 },
+          { start: 2, end: 4 },
+        ]),
+      ).toEqual([{ start: 0, end: 4 }]);
+    });
+
+    it("keeps disjoint ranges apart and sorts them", () => {
+      expect(
+        mergeRanges([
+          { start: 8, end: 9 },
+          { start: 0, end: 2 },
+        ]),
+      ).toEqual([
+        { start: 0, end: 2 },
+        { start: 8, end: 9 },
+      ]);
+    });
+
+    it("does not mutate its input", () => {
+      const input = [{ start: 2, end: 4 }, { start: 0, end: 3 }];
+      mergeRanges(input);
+      expect(input).toEqual([{ start: 2, end: 4 }, { start: 0, end: 3 }]);
+    });
+  });
+
+  describe("span", () => {
+    it("measures the distance the match covers", () => {
+      expect(span([0, 5])).toBe(6);
+      expect(span([0, 1, 2])).toBe(3);
+    });
+
+    it("is zero for no positions", () => {
+      expect(span([])).toBe(0);
+    });
+  });
+
+  describe("matchExact", () => {
+    it("finds a contiguous substring", () => {
+      const result = matchExact("join room", "n r")!;
+      expect(result.positions).toEqual([3, 4, 5]);
+    });
+
+    it("rejects a non-contiguous pattern that fuzzy matching would accept", () => {
+      expect(match("join room", "jr")).not.toBeNull();
+      expect(matchExact("join room", "jr")).toBeNull();
+    });
+
+    it("scores a match at the start above a match in the middle", () => {
+      const atStart = matchExact("room list", "room")!;
+      const inMiddle = matchExact("open room", "room")!;
+      expect(atStart.score).toBeGreaterThan(inMiddle.score);
+    });
+
+    it("returns null for an empty pattern", () => {
+      expect(matchExact("join room", "")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/lib/palette/scorer.ts
+++ b/frontend/src/lib/palette/scorer.ts
@@ -1,0 +1,391 @@
+/**
+ * Fuzzy matcher for the command palette.
+ *
+ * This is a port of fzf's `FuzzyMatchV2` (Smith-Waterman with affine gap
+ * penalties) from `src/algo/algo.go`. It returns a score AND the matched
+ * character positions, so rows can highlight the characters the user typed.
+ *
+ * Why not the cmdk / bits-ui scorer:
+ *   1. It returns a score only. You cannot highlight from it.
+ *   2. It has no length cap. A 300-character label costs ~29 ms per call,
+ *      which drops frames on one keystroke. This DP caps at MAX_TEXT and
+ *      prefilters, so its cost is bounded by construction.
+ *
+ * The bonus constants are fzf's, and they are calibrated rather than guessed:
+ * BONUS_BOUNDARY (8) against GAP_EXTENSION (-1) means an acronym jump pays for
+ * itself across about 8 characters, which is the average English word length.
+ * Do not tune one constant without re-reading that relationship.
+ *
+ * Case handling: matching is case-insensitive and case agreement earns no
+ * bonus. Tiering in `rank.ts` does the heavy lifting for intent, so a case
+ * bonus here would only add noise.
+ */
+
+/** Inclusive-start, exclusive-end slice of a string, for highlighting. */
+export interface MatchRange {
+  start: number;
+  end: number;
+}
+
+export interface MatchResult {
+  /** Higher is better. Only comparable between candidates for the same term. */
+  score: number;
+  /** Matched indices into the target text, ascending. */
+  positions: number[];
+}
+
+// Character classes. The numeric order matters: `cls > CLS_NONWORD` is the
+// test fzf uses for "this character starts a word".
+const CLS_WHITE = 0;
+const CLS_NONWORD = 1;
+const CLS_DELIMITER = 2;
+const CLS_LOWER = 3;
+const CLS_UPPER = 4;
+const CLS_LETTER = 5;
+const CLS_NUMBER = 6;
+
+// fzf's score table (algo.go:113-153).
+const SCORE_MATCH = 16;
+const SCORE_GAP_START = -3;
+const SCORE_GAP_EXTENSION = -1;
+const BONUS_BOUNDARY = SCORE_MATCH / 2; // 8
+const BONUS_NONWORD = SCORE_MATCH / 2; // 8
+const BONUS_CAMEL = BONUS_BOUNDARY + SCORE_GAP_EXTENSION; // 7
+const BONUS_CONSECUTIVE = -(SCORE_GAP_START + SCORE_GAP_EXTENSION); // 4
+const BONUS_FIRST_CHAR_MULTIPLIER = 2;
+const BONUS_BOUNDARY_WHITE = BONUS_BOUNDARY + 2; // 10
+const BONUS_BOUNDARY_DELIMITER = BONUS_BOUNDARY + 1; // 9
+
+/**
+ * Hard caps. These exist to make the worst case cheap, not to be generous.
+ * A palette row nobody can read is not worth scoring past 256 characters.
+ */
+export const MAX_TEXT = 256;
+export const MAX_PATTERN = 64;
+
+const CODE_0 = 48;
+const CODE_9 = 57;
+const CODE_A_UPPER = 65;
+const CODE_Z_UPPER = 90;
+const CODE_A_LOWER = 97;
+const CODE_Z_LOWER = 122;
+
+/** fzf's `delimiterChars`, plus the separators our labels actually contain. */
+const DELIMITERS = "/,:;|-_.";
+
+function classOf(code: number): number {
+  if (code >= CODE_A_LOWER && code <= CODE_Z_LOWER) return CLS_LOWER;
+  if (code >= CODE_A_UPPER && code <= CODE_Z_UPPER) return CLS_UPPER;
+  if (code >= CODE_0 && code <= CODE_9) return CLS_NUMBER;
+  // Space, tab, newline, vertical tab, form feed, carriage return, NBSP.
+  if (
+    code === 32 ||
+    code === 9 ||
+    code === 10 ||
+    code === 11 ||
+    code === 12 ||
+    code === 13 ||
+    code === 0x85 ||
+    code === 0xa0
+  ) {
+    return CLS_WHITE;
+  }
+  if (code < 128) {
+    return DELIMITERS.includes(String.fromCharCode(code))
+      ? CLS_DELIMITER
+      : CLS_NONWORD;
+  }
+  // Non-ASCII. Treat letters and digits as word characters so that accented
+  // nicknames and non-Latin room names still match, and everything else as a
+  // non-word boundary.
+  const ch = String.fromCharCode(code);
+  if (/\p{L}/u.test(ch)) return CLS_LETTER;
+  if (/\p{N}/u.test(ch)) return CLS_NUMBER;
+  if (/\s/u.test(ch)) return CLS_WHITE;
+  return CLS_NONWORD;
+}
+
+/**
+ * How much a match at a position is worth, given what precedes it.
+ * Ported verbatim from fzf `bonusFor` (algo.go:298-320).
+ */
+function bonusFor(prevClass: number, cls: number): number {
+  if (cls > CLS_NONWORD) {
+    if (prevClass === CLS_WHITE) return BONUS_BOUNDARY_WHITE;
+    if (prevClass === CLS_DELIMITER) return BONUS_BOUNDARY_DELIMITER;
+    if (prevClass === CLS_NONWORD) return BONUS_BOUNDARY;
+  }
+  // camelCase, and letter-to-digit as in "room2".
+  if (
+    (prevClass === CLS_LOWER && cls === CLS_UPPER) ||
+    (prevClass !== CLS_NUMBER && cls === CLS_NUMBER)
+  ) {
+    return BONUS_CAMEL;
+  }
+  if (cls === CLS_NONWORD || cls === CLS_DELIMITER) return BONUS_NONWORD;
+  if (cls === CLS_WHITE) return BONUS_BOUNDARY_WHITE;
+  return 0;
+}
+
+// Module-level scratch buffers. The matcher runs once per candidate per term on
+// every keystroke, so it must not allocate. Sized for the caps above:
+// MAX_PATTERN * MAX_TEXT = 16384 cells, 32 KB per Int16Array.
+const bonus = new Int16Array(MAX_TEXT);
+const h0 = new Int16Array(MAX_TEXT);
+const c0 = new Int16Array(MAX_TEXT);
+const firstOccurrence = new Int32Array(MAX_PATTERN);
+const matrixH = new Int16Array(MAX_PATTERN * MAX_TEXT);
+const matrixC = new Int16Array(MAX_PATTERN * MAX_TEXT);
+
+/**
+ * Cheap in-order prefilter. Returns the index of the first character that could
+ * begin a match, or -1 when the pattern is not present in order at all.
+ * This rejects the large majority of candidates before the DP runs.
+ */
+function fuzzyIndex(lowText: string, lowPattern: string, n: number): number {
+  let first = -1;
+  let from = 0;
+  for (let p = 0; p < lowPattern.length; p++) {
+    const at = lowText.indexOf(lowPattern[p], from);
+    if (at < 0 || at >= n) return -1;
+    if (p === 0) first = at;
+    from = at + 1;
+  }
+  return first;
+}
+
+/**
+ * Match `lowPattern` against `lowText`.
+ *
+ * Both arguments MUST already be lowercased by the caller. Lowercasing here
+ * would dominate the cost, which is the mistake cmdk's scorer documents.
+ *
+ * @returns The score and matched positions, or `null` when there is no match.
+ */
+export function match(lowText: string, lowPattern: string): MatchResult | null {
+  const m = lowPattern.length;
+  if (m === 0) return null;
+  if (m > MAX_PATTERN) return null;
+
+  const n = Math.min(lowText.length, MAX_TEXT);
+  if (m > n) return null;
+
+  const start = fuzzyIndex(lowText, lowPattern, n);
+  if (start < 0) return null;
+
+  // Phase 1+2: per-position bonuses and the first matrix row, computed in one
+  // pass. Also records where each pattern character first appears, which bounds
+  // the columns the remaining rows have to visit.
+  const pChar0 = lowPattern[0];
+  let pIdx = 0;
+  let pChar = lowPattern[0];
+  let lastIdx = start;
+  let prevH0 = 0;
+  // fzf seeds this with whitespace because its DP starts at the prefilter
+  // index, which silently grants a word-boundary bonus to whatever character
+  // happens to sit there: "Battery" would score `t` as highly as "Set Theme".
+  // Read the real preceding character instead. This is a deliberate
+  // improvement on the original, and it leaves matches that genuinely start at
+  // a boundary unchanged.
+  let prevClass =
+    start === 0 ? CLS_WHITE : classOf(lowText.charCodeAt(start - 1));
+  let inGap = false;
+  let maxScore = 0;
+  let maxScorePos = start;
+
+  for (let i = start; i < n; i++) {
+    const ch = lowText[i];
+    const cls = classOf(lowText.charCodeAt(i));
+    const b = bonusFor(prevClass, cls);
+    bonus[i] = b;
+    prevClass = cls;
+
+    if (ch === pChar) {
+      if (pIdx < m) {
+        firstOccurrence[pIdx] = i;
+        pIdx++;
+        pChar = lowPattern[Math.min(pIdx, m - 1)];
+      }
+      lastIdx = i;
+    }
+
+    if (ch === pChar0) {
+      const score = SCORE_MATCH + b * BONUS_FIRST_CHAR_MULTIPLIER;
+      h0[i] = score;
+      c0[i] = 1;
+      if (m === 1 && score > maxScore) {
+        maxScore = score;
+        maxScorePos = i;
+        // A word-boundary hit on a one-character pattern cannot be beaten.
+        if (b >= BONUS_BOUNDARY) break;
+      }
+      inGap = false;
+    } else {
+      // Affine gap: opening costs more than extending, so one long skip is
+      // cheaper than several short ones.
+      const penalty = inGap ? SCORE_GAP_EXTENSION : SCORE_GAP_START;
+      h0[i] = Math.max(prevH0 + penalty, 0);
+      c0[i] = 0;
+      inGap = true;
+    }
+    prevH0 = h0[i];
+  }
+
+  if (pIdx !== m) return null;
+
+  if (m === 1) {
+    return { score: maxScore, positions: [maxScorePos] };
+  }
+
+  // Phase 3: the remaining rows, restricted to columns [firstOccurrence[row], lastIdx].
+  const f0 = firstOccurrence[0];
+  const width = lastIdx - f0 + 1;
+
+  for (let col = f0; col <= lastIdx; col++) {
+    matrixH[col - f0] = h0[col];
+    matrixC[col - f0] = c0[col];
+  }
+
+  for (let row = 1; row < m; row++) {
+    const rowStart = row * width;
+    const f = firstOccurrence[row];
+    const rowChar = lowPattern[row];
+    inGap = false;
+    // fzf zeroes the cell immediately left of the row's first column so the
+    // "come from the left" branch cannot read a stale value.
+    if (f - f0 - 1 >= 0) matrixH[rowStart + f - f0 - 1] = 0;
+
+    for (let col = f; col <= lastIdx; col++) {
+      const offset = rowStart + col - f0;
+      const diagOffset = offset - width - 1;
+
+      // Skip this target character. The annotation is load-bearing: `inGap` is
+      // assigned from `s2` at the bottom of this loop, so without it TypeScript
+      // chases the back edge and reports a circular inference.
+      const left = col > f ? matrixH[offset - 1] : 0;
+      const s2: number = left + (inGap ? SCORE_GAP_EXTENSION : SCORE_GAP_START);
+
+      let s1 = 0;
+      let consecutive = 0;
+      if (rowChar === lowText[col]) {
+        s1 = matrixH[diagOffset] + SCORE_MATCH;
+        let b = bonus[col];
+        consecutive = matrixC[diagOffset] + 1;
+        if (consecutive > 1) {
+          const firstBonus = bonus[col - consecutive + 1];
+          // A strong boundary in the middle of a run starts a new run instead
+          // of extending the old one, so "myRoom" on "room" credits the
+          // boundary rather than a 4-char run from the wrong place.
+          if (b >= BONUS_BOUNDARY && b > firstBonus) {
+            consecutive = 1;
+          } else {
+            // The run bonus does not stack with the boundary bonus.
+            b = Math.max(b, Math.max(BONUS_CONSECUTIVE, firstBonus));
+          }
+        }
+        if (s1 + b < s2) {
+          s1 += bonus[col];
+          consecutive = 0;
+        } else {
+          s1 += b;
+        }
+      }
+
+      matrixC[offset] = consecutive;
+      inGap = s1 < s2;
+      const score = Math.max(s1, s2, 0);
+      if (row === m - 1 && score > maxScore) {
+        maxScore = score;
+        maxScorePos = col;
+      }
+      matrixH[offset] = score;
+    }
+  }
+
+  // Phase 4: backtrace for the matched positions. A forward-greedy walk picks
+  // visibly wrong characters, so preferMatch carries run state backwards.
+  const positions: number[] = [];
+  let row = m - 1;
+  let col = maxScorePos;
+  let preferMatch = true;
+  for (;;) {
+    const rowStart = row * width;
+    const offset = rowStart + col - f0;
+    const here = matrixH[offset];
+
+    const diag =
+      row > 0 && col >= firstOccurrence[row] ? matrixH[offset - width - 1] : 0;
+    const left = col > firstOccurrence[row] ? matrixH[offset - 1] : 0;
+
+    if (here > diag && (here > left || (here === left && preferMatch))) {
+      positions.push(col);
+      if (row === 0) break;
+      row--;
+    }
+    const below = offset + width + 1;
+    preferMatch =
+      matrixC[offset] > 1 || (below < matrixC.length && matrixC[below] > 0);
+    col--;
+    if (col < f0) break;
+  }
+
+  positions.reverse();
+  return { score: maxScore, positions };
+}
+
+/**
+ * Collapse ascending positions into contiguous ranges for rendering.
+ * `[0, 1, 2, 7]` becomes `[{0,3}, {7,8}]`.
+ */
+export function toRanges(positions: readonly number[]): MatchRange[] {
+  const out: MatchRange[] = [];
+  for (const p of positions) {
+    const last = out[out.length - 1];
+    if (last && last.end === p) last.end = p + 1;
+    else out.push({ start: p, end: p + 1 });
+  }
+  return out;
+}
+
+/**
+ * Merge overlapping or touching ranges from several terms into one ascending,
+ * non-overlapping list. Needed because a multi-term query produces one range
+ * set per term against the same text.
+ */
+export function mergeRanges(ranges: readonly MatchRange[]): MatchRange[] {
+  if (ranges.length < 2) return ranges.slice();
+  const sorted = ranges.slice().sort((a, b) => a.start - b.start);
+  const out: MatchRange[] = [{ ...sorted[0] }];
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = out[out.length - 1];
+    const cur = sorted[i];
+    if (cur.start <= prev.end) prev.end = Math.max(prev.end, cur.end);
+    else out.push({ ...cur });
+  }
+  return out;
+}
+
+/** Total span the match covers. Used as a tie-break: tighter matches win. */
+export function span(positions: readonly number[]): number {
+  if (positions.length === 0) return 0;
+  return positions[positions.length - 1] - positions[0] + 1;
+}
+
+/**
+ * Contiguous case-insensitive substring match, for quoted queries.
+ * Returns the same shape as `match` so callers can treat them alike.
+ */
+export function matchExact(
+  lowText: string,
+  lowPattern: string,
+): MatchResult | null {
+  if (lowPattern.length === 0) return null;
+  const at = lowText.indexOf(lowPattern);
+  if (at < 0) return null;
+  const positions: number[] = [];
+  for (let i = 0; i < lowPattern.length; i++) positions.push(at + i);
+  // Score it like a run of matches so it stays comparable with fuzzy scores.
+  const base = SCORE_MATCH * lowPattern.length;
+  const boundary = at === 0 ? BONUS_BOUNDARY_WHITE * BONUS_FIRST_CHAR_MULTIPLIER : 0;
+  return { score: base + boundary, positions };
+}

--- a/frontend/src/lib/palette/types.ts
+++ b/frontend/src/lib/palette/types.ts
@@ -1,0 +1,162 @@
+import type { Component } from "svelte";
+import type { IconProps } from "@lucide/svelte";
+import type { MatchRange } from "./scorer";
+
+/** A `@lucide/svelte` icon component, rendered as `<cmd.icon class="size-4" />`. */
+export type PaletteIcon = Component<IconProps>;
+
+/**
+ * Relevance tiers.
+ *
+ * These are baselines added to a command's character score, spaced far enough
+ * apart that character points can never lift a weaker tier past a stronger one.
+ * That is the whole trick behind "it always puts the thing I meant first":
+ * a prefix hit on a title must never lose to a brilliant fuzzy hit inside a
+ * subtitle, no matter how the characters land. Blending weights instead of
+ * tiering is what makes a palette feel random.
+ *
+ * Borrowed from VS Code's fuzzy scorer, which uses the same 1<<N spacing.
+ */
+export const TIER_EXACT = 1 << 20;
+export const TIER_PREFIX = 1 << 18;
+export const TIER_TITLE = 1 << 16;
+export const TIER_KEYWORD = 1 << 14;
+export const TIER_SUBTITLE = 1 << 12;
+
+/**
+ * What happens when the user accepts a command.
+ *
+ * `act` runs it. `page` pushes a nested page, which is how a command that needs
+ * an argument asks for one ("Join room" then which room).
+ */
+export type CmdAction =
+  | {
+      kind: "act";
+      perform: () => void | Promise<void>;
+      /**
+       * Keep the palette open after running. Use for commands a user repeats,
+       * such as adjusting a volume, so they do not reopen it each time.
+       */
+      keepOpen?: boolean;
+    }
+  | { kind: "page"; open: () => Page };
+
+/** One row in the palette. */
+export interface Cmd {
+  /**
+   * Stable and unique. This keys the `{#each}` block, the MRU record, and the
+   * `aria-activedescendant` target, so it must not be derived from the title:
+   * two rooms can share a name.
+   */
+  id: string;
+  /** Primary label. Matched at the highest tiers. */
+  title: string;
+  /** Secondary label, shown dimmed. Matched at the lowest tier. */
+  subtitle?: string;
+  /** Aliases. Matched below the title so a keyword hit cannot outrank a title hit. */
+  keywords?: string[];
+  /** Heading this row appears under. Groups sort by their best member. */
+  group: string;
+  icon?: PaletteIcon;
+  /** Current value, shown right-aligned. For example "On" for a toggle. */
+  badge?: string;
+  /** Keys that trigger this command outside the palette, rendered as `<kbd>`. */
+  shortcut?: string[];
+  /**
+   * Destructive. Styled as such, and MUST be paired with a `confirm` page
+   * rather than acting straight from `Enter`.
+   */
+  danger?: boolean;
+  action: CmdAction;
+}
+
+/**
+ * A palette page. The stack of these is the palette's navigation model:
+ * `[]` is the root, and each push narrows to one argument.
+ */
+export type Page =
+  | {
+      kind: "list";
+      id: string;
+      /** Breadcrumb text. */
+      title: string;
+      placeholder?: string;
+      /**
+       * Rows for this page. May be async, for example enumerating audio
+       * devices. The caller cancels a stale load rather than debouncing.
+       */
+      items: () => Cmd[] | Promise<Cmd[]>;
+      /** Shown when `items` yields nothing. */
+      emptyText?: string;
+    }
+  | {
+      kind: "prompt";
+      id: string;
+      title: string;
+      placeholder?: string;
+      /** Prefilled text. Selected on open so typing replaces it. */
+      initial?: string;
+      /** Returns an error message, or `null` when the value is acceptable. */
+      validate?: (value: string) => string | null;
+      submit: (value: string) => void | Promise<void>;
+      submitLabel?: string;
+    }
+  | {
+      kind: "confirm";
+      id: string;
+      title: string;
+      message: string;
+      confirmLabel: string;
+      confirm: () => void | Promise<void>;
+    };
+
+/** A command that survived filtering, with everything the row needs to render. */
+export interface RankedCmd {
+  cmd: Cmd;
+  /** Tier baseline plus character score. Only meaningful within one query. */
+  score: number;
+  /** The weakest tier any query term matched at. Drives the comparator. */
+  tier: number;
+  titleRanges: MatchRange[];
+  subtitleRanges: MatchRange[];
+  /** Total span of the title match. Tie-break: tighter wins. */
+  titleSpan: number;
+}
+
+/** Rows under one heading. Groups sort by their best member's score. */
+export interface RankedGroup {
+  name: string;
+  items: RankedCmd[];
+}
+
+/**
+ * Query scope prefixes. The sigil stays in the input text and the ranker strips
+ * it, so deleting the character returns to the root scope with no extra state.
+ */
+export const SIGILS = {
+  "#": "Rooms",
+  "@": "People",
+  ">": "Settings",
+  "?": "Help",
+} as const;
+
+export type Sigil = keyof typeof SIGILS;
+
+/** One whitespace-separated piece of the query. All pieces must match. */
+export interface QueryTerm {
+  /** Lowercased. The matcher requires this. */
+  text: string;
+  /** Came from a quoted segment, so it must match contiguously. */
+  exact: boolean;
+}
+
+export interface ParsedQuery {
+  /** Exactly what the user typed. */
+  raw: string;
+  /** The scope prefix, or `null` at the root. */
+  sigil: Sigil | null;
+  /** The query with the sigil removed, trimmed. */
+  body: string;
+  /** Terms to match. Empty means "show everything". */
+  terms: QueryTerm[];
+}

--- a/frontend/src/lib/ui-state.svelte.ts
+++ b/frontend/src/lib/ui-state.svelte.ts
@@ -12,6 +12,11 @@ export const uiState = $state({
    * in the sidebar, so the request travels through here.
    */
   returnToCallRequested: false,
+  /**
+   * Somebody asked for the command palette. AppView owns it and binds
+   * Cmd/Ctrl+K, so anything outside that tree travels through here too.
+   */
+  paletteOpenRequested: false,
 });
 
 export function openSettings(tab: string | null = null): void {
@@ -21,4 +26,12 @@ export function openSettings(tab: string | null = null): void {
 
 export function requestReturnToCall(): void {
   uiState.returnToCallRequested = true;
+}
+
+/**
+ * Ask for the command palette. The palette is owned by AppView, which also binds
+ * Cmd/Ctrl+K, so anything outside that tree requests it here.
+ */
+export function openPalette(): void {
+  uiState.paletteOpenRequested = true;
 }


### PR DESCRIPTION
## What

`Cmd/Ctrl+K` opens a command palette over the app. From one keyboard surface you can search and switch rooms, join a room by code or a pasted invite link, flip any preference, jump to a settings tab, pick an audio device, change your nickname, and run the call and app actions.

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/01-root.png" width="900" alt="Command palette open at the root, showing a Recently used group above Rooms and Settings" />

## Why not `bits-ui`'s `Command`

`bits-ui` is already a dependency and it ships a `Command` primitive, so this needs justifying. I read its source. It is a faithful port of `cmdk`, and it inherits three traits that disqualify it here:

1. **`compute-command-score.js` is a literal copy of cmdk's scorer.** It returns a bare number, so **a row cannot show which characters matched**. It also has no length cap of any kind — measured **29.30 ms for a single 300-character label**, enough to drop frames on one keystroke. VS Code caps at 128 characters; fzf falls back to a greedy path. cmdk does neither.
2. **Its item registry is keyed by the item's value string**, so two rows with the same label collide. Room names collide routinely — see the two `Design review` rooms below.
3. **It sets `role="application"` on the palette root**, which turns off screen-reader browse mode.

Decisive factor: this repo has no DOM test environment (`vitest` runs `environment: "node"`, no jsdom — `plugins/state.svelte.ts:25` already notes *"a regular Map, not $state, for testability"*). Leaning on `bits-ui`'s `Command` would trap all the ranking behaviour in DOM internals that cannot be tested here.

So the **shell is `bits-ui` `Dialog`** — same as every other overlay in the app, and it supplies the portal, focus trap, focus restore and body scroll lock (all verified working). The **combobox and listbox are ours**, and so is the matcher.

## Ranking

The matcher is a port of **fzf's `FuzzyMatchV2`** (Smith–Waterman with affine gap penalties) that returns a score **and the matched positions**. Its bonus table is fzf's, which is calibrated rather than guessed: `BONUS_BOUNDARY` (8) against `GAP_EXTENSION` (−1) means an acronym jump pays for itself across about eight characters. Scratch buffers are module-level typed arrays, so a keystroke allocates nothing.

Positions are what make the result explainable — `jr` finds **J**oin **r**oom:

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/02-acronym-match.png" width="900" alt="Query jr highlighting the J and r of Join room by code" />

On top of the character score sit **tiered baselines**, borrowed from VS Code's fuzzy scorer: exact title, title prefix, title fuzzy, keyword, subtitle. The tiers are spaced far wider than any character score can reach, so **a prefix hit on a title can never lose to a brilliant fuzzy hit in a subtitle**. Blending weights instead of tiering is what makes a palette feel like it is guessing.

Final order is a **lexicographic tuple** — tier, then recency, then character score, then match tightness, then title length, then locale, then authored order. It never returns `0` before the last rule, because every unbroken tie shows up as rows swapping places between keystrokes.

Space-separated terms all have to match, so typing more words always narrows, and the ranges merge:

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/03-multi-term.png" width="900" alt="Query aud dev highlighting Aud and dev in Audio input device" />

Quoting a term (`"exact"`) forces a contiguous match, for when fuzzy is too eager.

**Recency** is pure recency, not frequency, bounded to 50 entries in `localStorage`. It is applied as a sort tier *inside* a relevance class, never as a score bonus, so a recently used command can outrank an equally relevant one but never a better match. Recently used rows are shown under their own heading and each carries an `×` to forget it — ranking a user cannot see feels arbitrary.

## Scopes and pages

A leading sigil scopes the search and is stripped from the terms. Deleting the character returns to the root, so there is no hidden mode state. `#` rooms, `@` people, `>` settings, `?` the list of prefixes.

| | |
|---|---|
| <img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/04-rooms-scope.png" alt="Hash scope listing only rooms, each with its room code" /> | <img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/05-settings-scope.png" alt="Greater-than scope listing settings with live On and Off badges" /> |
| `#` — rooms only. Every room shows its code, because two rooms can share a name. Searching `a1b2c3` finds a room by code. | `>` — settings only. Each toggle reads its value live, and running one keeps the palette open so the badge flips in place. |

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/06-prefix-help.png" width="900" alt="Question-mark scope listing the four prefixes" />

A command that needs an argument pushes a **page** rather than guessing. Pages carry a breadcrumb, and `Backspace` on an empty input pops one — read from the event target, not from state, because on a key repeat a state read lags a tick and pops a page the user was still typing in.

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/07-nested-prompt.png" width="900" alt="Join room by code prompt page rejecting an invalid value" />

Join accepts a bare six-hex code, a full `/r/<code>` invite link, or a `web+awfl://` link.

**Destructive commands** are never one keystroke away. They set `danger`, they route through a confirm page instead of firing on `Enter`, **Cancel is the preselected row**, and they earn no recency at all — otherwise erasing your data could float to the top of an empty palette, which is exactly where `Enter` rests.

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/cmd-k/08-destructive-confirm.png" width="900" alt="Erase all local data confirm page with Cancel selected" />

## Keyboard and accessibility

`Escape` is owned in one handler and undoes exactly one thing per press: clear the query, then pop the page, then close. The dialog is configured `escapeKeydownBehavior="ignore"` so it cannot also act — six other listeners in this app handle `Escape` and none of them stop propagation.

Arrows clamp rather than wrap, `Home`/`End` jump to the ends, `PageUp`/`PageDown` move by a **measured** viewport of rows, and `Alt+Arrow` jumps between groups. Every key handler guards `isComposing || keyCode === 229`; the second arm is not optional, because `isComposing` is unreliable for Japanese IME in Safari.

ARIA follows the [APG combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/): **focus never leaves the input** and the active row is named by `aria-activedescendant`, since moving real focus onto a row is what stops a user typing. `aria-expanded` is bound to the result count rather than hardcoded `true`. A polite atomic live region announces the count. This is the app's first live region, so it is an improvement rather than an existing convention.

Two smaller guards worth naming: hover only takes the selection after the pointer has genuinely moved, so opening the palette under the cursor does not steal the keyboard selection; and the selection is reset to the first row whenever the query changes, so nobody is tracking a row that ranking is about to move.

## Shape

Ranking logic is in plain `.ts` so it is testable with the runner that exists. `.svelte` files hold markup and wiring only.

```
frontend/src/lib/palette/
  scorer.ts      fzf-style DP, returns score + positions   (+ tests)
  rank.ts        tiers, comparator, grouping, recents      (+ tests)
  query.ts       sigils, terms, quoting, room codes        (+ tests)
  mru.ts         bounded recency, persisted                (+ tests)
  types.ts       Cmd, Page, tiers
  host.ts        the slice of app behaviour AppView owns
  palette.svelte.ts   state machine: page stack, selection, async pages
  commands/      rooms, settings, actions
frontend/src/lib/components/palette/
  CommandPalette.svelte  dialog, combobox, listbox, keyboard
  PaletteRow.svelte      one option row
  HighlightedText.svelte match highlighting
```

Room navigation delegates back to `AppView` through a small `PaletteHost` interface, because `AppView` owns `activeRoomCode`, the history push, the persistence and the room-name broadcast. Reproducing that in the palette would fork the join path. Settings go through the existing `openSettings(tab)` request bus rather than mounting a second settings dialog.

`Cmd/Ctrl+K` extends `AppView`'s existing `<svelte:window onkeydown>` instead of adding a competing listener. It calls `preventDefault()` even though nothing else claims the key, because Firefox maps it to the search bar, and it is gated on `identityStore.isUnlocked`.

## Defects found and fixed along the way

Four of these were caught by driving the real palette in a browser, not by reading code:

- **Scorer:** fzf seeds `prevClass` to whitespace at the prefilter index, which silently grants a word-boundary bonus to whatever character sits there — `Battery` scored `t` as highly as `Set Theme`. Now reads the real preceding character.
- **Ranking:** the prefix tier contributed only a length boost (24) instead of a real character score (114), so `join room` ranked *Create or join a room* **above** *Join room by code*. Fixed, and pinned with a regression test.
- **Safety:** opening the erase-data confirm page recorded recency, floating a destructive command to row 1. Destructive commands now earn none.
- **Discoverability:** typing `settings` returned **zero results**, because the tab rows were titled bare `Profile`, `Audio`, `App`. They are now `Open Audio settings` and carry aliases.

## Verification

- **392 tests pass** (37 files), of which **104 are new**. Four pin the scorer to fzf's own reference values for `Join Room`: `jr` → score 56 positions `[0,5]`; `join` → 114; `room` → 114; `jroom` → 134.
- `svelte-check`: **0 errors, 0 warnings** across the whole app. `tsc -p tsconfig.node.json` clean. Production `vite build` succeeds.
- Driven in a real browser: ranking and highlighting, all four scopes, nested prompt pages with validation, the `Escape` ladder, `Backspace` pop, clamped arrows, `Home`/`End`, measured `PageDown`, `Alt+Arrow`, live badge flips with the selection surviving a full catalog rebuild, recents with forget, the confirm page, focus restore, `Cmd+B` still working, `Cmd+K` firing from inside a focused text input, and the palette inert while locked. Changing the nickname was verified end to end into app state.
- **Rebased onto `main` at `ee80c7c`** (the floating DM panel). Both conflicts were additive and in the two files this branch shares with that work: `ui-state.svelte.ts` gained a second request flag alongside `returnToCallRequested`, and `AppView.svelte` mounts `CommandPalette` next to `FloatingDmPanel`. Git's auto-merge also left the `uiState` import duplicated, since both sides added the identical line; that was removed. Tests, checks, build and a browser pass were all re-run after the rebase.

### Two honest gaps

- **A relay-backed room join was not exercised.** The Go relay will not build in my environment (`proxy.golang.org` unreachable), so `joinRoom` always returned `false`. I verified instead that the palette's room command produces **behaviour identical to the app's own sidebar click**, and seeded four rooms through the backup-restore path to verify listing, code search and same-name disambiguation. The join path itself is untouched existing code.
- **Screenshots were taken in headless Chromium, where `animationend` never fires** (a plain 0.1 s CSS animation does not complete). That means a closed `bits-ui` dialog stays mounted there — reproduced with the app's existing `SettingsDialog`, so it is an environment artifact, not a regression.

## Review notes

- Nothing outside `frontend/src/lib/palette/`, `frontend/src/lib/components/palette/`, `AppView.svelte` and `ui-state.svelte.ts` is touched. No new dependency.
- Two `svelte-ignore` comments in `PaletteRow.svelte` are deliberate and explained inline: a keydown handler per option would need DOM focus to fire, which is precisely what the combobox pattern forbids.
- Screenshots live on the orphan `pr-media/cmd-k` branch, matching the existing `pr-media/*` convention.

