### PR TITLE
fix: the tab title counts DM messages once

### DIFF
--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -199,9 +199,14 @@
 
   // Mirror everything unread onto the installed app icon and the tab title,
   // so a background tab shows "(3) Awful.chat" at a glance.
+  //
+  // Summed over the rooms that exist, not over every key in the map: summing
+  // the map wholesale meant any entry that was not a room inflated the title
+  // while the sidebar, which walks the room list, stayed right - and the two
+  // numbers disagreeing is the bug the reader actually notices.
   $effect(() => {
-    const rooms = [...roomsStore.unreadCounts.values()].reduce(
-      (sum, n) => sum + n,
+    const rooms = roomsStore.rooms.reduce(
+      (sum, room) => sum + (roomsStore.unreadCounts.get(room.roomCode) ?? 0),
       0
     );
     const total = rooms + dmUnreadTotal;

--- a/frontend/src/lib/rooms-unread.test.ts
+++ b/frontend/src/lib/rooms-unread.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  bulkPutMessages,
+  putRoom,
+  deleteMessagesForRoom,
+  type DMRoom,
+  type Room,
+} from "./storage";
+import { MessageType, type Message } from "./types/message";
+import { refreshUnreadCount, roomsStore } from "./rooms.svelte";
+
+const ROOM = "room-unread-spec";
+const DM = "dm-unread-spec";
+
+function room(): Room {
+  return {
+    roomCode: ROOM,
+    type: "text",
+    name: "Room",
+    lastSeenLamport: 0,
+    createdAt: 1,
+    participants: [],
+    participantLastSeen: {},
+  };
+}
+
+function dmRoom(): DMRoom {
+  return {
+    roomCode: DM,
+    type: "dm",
+    name: "",
+    lastSeenLamport: 0,
+    createdAt: 1,
+    participants: ["did:key:them"],
+    participantLastSeen: {},
+    participantDid: "did:key:them",
+  };
+}
+
+function msg(roomCode: string, lamport: number): Message {
+  return {
+    id: `${roomCode}-${lamport}`,
+    roomCode,
+    senderId: "did:key:them",
+    senderName: "Them",
+    timestamp: lamport,
+    lamport,
+    type: MessageType.Text,
+    content: "hi",
+    attachments: [],
+  };
+}
+
+describe("refreshUnreadCount", () => {
+  beforeEach(async () => {
+    await deleteMessagesForRoom(ROOM);
+    await deleteMessagesForRoom(DM);
+    roomsStore.rooms = [];
+    roomsStore.dmRooms = [];
+    roomsStore.unreadCounts = new Map();
+  });
+
+  it("counts a room from its read watermark", async () => {
+    await putRoom(room());
+    roomsStore.rooms = [room()];
+    await bulkPutMessages([msg(ROOM, 1), msg(ROOM, 2)]);
+    await refreshUnreadCount(ROOM);
+    expect(roomsStore.unreadCounts.get(ROOM)).toBe(2);
+  });
+
+  it("counts a room the sidebar mirror has not caught up to yet", async () => {
+    // The record exists but the mirror is still empty, which is what a
+    // deep-link join looks like while loadRooms is in flight.
+    await putRoom(room());
+    await bulkPutMessages([msg(ROOM, 1)]);
+    await refreshUnreadCount(ROOM);
+    expect(roomsStore.unreadCounts.get(ROOM)).toBe(1);
+  });
+
+  it("never files a DM conversation in the room counter", async () => {
+    // DM records live in the same storage as rooms, so the mirror fallback
+    // resolves one happily - and every consumer that sums this map also adds
+    // the separate DM total, so a dm- entry here is counted twice. A DM file, a
+    // DM plugin card and a DM history repair all arrive carrying a dm- code.
+    await putRoom(dmRoom());
+    roomsStore.dmRooms = [dmRoom()];
+    await bulkPutMessages([msg(DM, 1), msg(DM, 2)]);
+
+    await refreshUnreadCount(DM);
+
+    expect(roomsStore.unreadCounts.has(DM)).toBe(false);
+    expect([...roomsStore.unreadCounts.keys()].filter((k) => k.startsWith("dm-")))
+      .toEqual([]);
+  });
+});

--- a/frontend/src/lib/rooms.svelte.ts
+++ b/frontend/src/lib/rooms.svelte.ts
@@ -97,6 +97,16 @@ export async function refreshDmRooms(): Promise<void> {
 }
 
 export async function refreshUnreadCount(roomCode: string): Promise<void> {
+  // unreadCounts is the ROOM counter. DM conversations are counted separately,
+  // against roomsStore.dmRooms, and anything filed here is also added to that
+  // total - so a dm- code landing in this map is counted twice by every
+  // consumer that sums the whole thing.
+  //
+  // Worth stating because it is easy to reintroduce: DM records live in the
+  // same storage as rooms, so the getRoom fallback below happily resolves one.
+  // The callers cannot help: a DM file, a DM plugin card and a DM history
+  // repair all arrive through the room paths carrying a dm- roomCode.
+  if (roomCode.startsWith("dm-")) return;
   // Fall back to the database when the mirror has not caught up: a message can
   // arrive for a room whose record exists but whose sidebar entry is still in
   // flight (a deep-link join), and dropping the count there left the badge

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
+  // Compiled, so rune-backed stores (.svelte.ts) can be tested at all.
   plugins: [svelte()],
   resolve: {
     alias: {


### PR DESCRIPTION
The sidebar was right and the title was not. With three unread in a room and three across DMs, the switches read **3** and **3** while the title read **(8)**.

## Cause

My own regression from #14.

`refreshUnreadCount` gained a `getRoom` fallback there, so a message arriving before the sidebar mirror caught up would still be counted. But **DM records live in the same storage as rooms** — `getRoom` returns `Room | DMRoom` — so that fallback resolves a DM conversation happily. And `roomsStore.unreadCounts` is the *room* counter, which every consumer sums alongside the separate DM total. Every DM filed there got counted twice.

The callers cannot help. A DM file, a DM plugin card and a DM history repair all arrive through the room paths (`_handleChatMessage`, `_handleSyncBatch`) carrying a `dm-` roomCode. So the knowledge belongs in `refreshUnreadCount`, and it refuses them.

Why the sidebar stayed correct: the switches and the per-room badges walk `roomsStore.rooms`, so a `dm-` key was never visible to them. Only the title summed the raw map.

## Two layers

1. **`refreshUnreadCount` refuses `dm-` codes.** The DM mirror owns those counts.
2. **The title walks the room list** instead of summing the map wholesale, the way the sidebar already does. Nothing that is not a room can inflate it again, whatever put the entry there.

## Verification

Reproduced first, on `main`, driving the real caller shape against the live modules:

| | sidebar | title |
|---|---|---|
| seeded | Rooms 3, DMs 3 | `(6)` |
| after `refreshUnreadCount(dmCode)` | Rooms 3, DMs 3 | **`(8)`** |

With this branch, at every step:

| | title | rooms | DMs |
|---|---|---|---|
| seeded | 6 | 3 | 3 |
| two more arrive in Dogs | 8 | 5 | 3 |
| after reading Dogs | 4 | 1 | 3 |

And with `dm-forced-foreign-key: 99` plus `a-room-that-was-deleted: 42` written straight into the map, the title stayed `(6)` — the second layer holds on its own.

`src/lib/rooms-unread.test.ts` covers the invariant, plus the two counting cases the #14 fallback exists for. Removing the guard fails it:

```
× never files a DM conversation in the room counter
AssertionError: expected true to be false
```

No screenshot: a tab title is browser chrome, not page content, so it does not appear in a page capture. The numbers above are read from `document.title` and the rendered sidebar.

`vitest` compiles `.svelte.ts` so a rune-backed store can be tested at all; all 279 pre-existing tests pass under it. #16 makes the same one-line change, so whichever lands first the other rebases cleanly.

## Not changed

The title includes the room you are on; the sidebar switch excludes it. That is deliberate and they answer different questions — the switch hides the badge for the room you are reading, while the title exists to be read when you are *not* looking at the tab. During normal visible use `markSeen` zeroes the open room and both show the same number; in a hidden tab the title is the one that should count it, which is the under-counting #14 fixed.