### PR TITLE
feat: debug toggle for the connection & relay indicators

### DIFF
--- a/frontend/src/lib/components/RoomCreateJoin.svelte
+++ b/frontend/src/lib/components/RoomCreateJoin.svelte
@@ -12,6 +12,7 @@
   import { profileStore, loadProfile, saveName } from "$lib/profile.svelte";
   import AvatarPickerDialog from "$lib/components/AvatarPickerDialog.svelte";
   import { transportState } from "$lib/transport/transport.svelte";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
 
   interface Props {
     onJoin: (roomCode: string, displayName: string, roomName?: string) => void;
@@ -128,6 +129,7 @@
             </CardDescription>
           </div>
 
+          {#if displayPrefs.showConnectionInfo}
           {#if relayConnected}
             <div
               class="flex items-center gap-1.5 px-2 py-1 rounded-full bg-muted text-xs"
@@ -142,6 +144,7 @@
               <span class="size-2 rounded-full bg-amber-300"></span>
               <span class="text-muted-foreground">Connecting...</span>
             </div>
+          {/if}
           {/if}
         </div>
       </CardHeader>

--- a/frontend/src/lib/components/SidebarControls.svelte
+++ b/frontend/src/lib/components/SidebarControls.svelte
@@ -21,6 +21,7 @@
     leaveCall,
   } from "$lib/transport/call.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
   import AvatarPickerDialog from "$lib/components/AvatarPickerDialog.svelte";
   import SettingsDialog from "$lib/components/SettingsDialog.svelte";
   import { Tip } from "$lib/components/ui/tooltip";
@@ -181,10 +182,12 @@
             >
           {/if}
         </button>
-        <div
-          class="absolute -bottom-0.5 -right-0.5 size-3 rounded-full ring-2 ring-card
-          {transportState.relayConnected ? 'bg-primary' : 'bg-yellow-500'}"
-        ></div>
+        {#if displayPrefs.showConnectionInfo}
+          <div
+            class="absolute -bottom-0.5 -right-0.5 size-3 rounded-full ring-2 ring-card
+            {transportState.relayConnected ? 'bg-primary' : 'bg-yellow-500'}"
+          ></div>
+        {/if}
       </div>
 
       <!-- Name + status -->
@@ -195,9 +198,11 @@
           >
             {profileStore.nickname}
           </div>
-          <div class="text-xs text-muted-foreground font-mono leading-tight">
-            {transportState.relayConnected ? "Connected" : "Connecting..."}
-          </div>
+          {#if displayPrefs.showConnectionInfo}
+            <div class="text-xs text-muted-foreground font-mono leading-tight">
+              {transportState.relayConnected ? "Connected" : "Connecting..."}
+            </div>
+          {/if}
         </div>
       {/if}
     </div>

--- a/frontend/src/lib/components/TransportStatus.svelte
+++ b/frontend/src/lib/components/TransportStatus.svelte
@@ -18,6 +18,7 @@
   } from "@lucide/svelte";
   import { onMount, onDestroy } from "svelte";
   import { cn } from "$lib/utils";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
 
   type StatusType =
     | "connecting"
@@ -215,7 +216,7 @@
   }
 </script>
 
-{#if statusItems.length > 0 || (!relayConnected && sawRelayEvent) || peerCount > 0}
+{#if displayPrefs.showConnectionInfo && (statusItems.length > 0 || (!relayConnected && sawRelayEvent) || peerCount > 0)}
   <div
     class={cn(
       "fixed z-50 flex flex-col gap-2 max-w-sm",
@@ -278,7 +279,7 @@
 {/if}
 
 <!-- Toggle button when hidden -->
-{#if !isVisible && (peerCount > 0 || (!relayConnected && sawRelayEvent))}
+{#if displayPrefs.showConnectionInfo && !isVisible && (peerCount > 0 || (!relayConnected && sawRelayEvent))}
   <button
     class="fixed bottom-36 right-3.75 z-50 p-2 rounded-full bg-background border shadow-lg hover:bg-accent transition-colors"
     onclick={() => (isVisible = true)}

--- a/frontend/src/lib/components/UserListSidebar.svelte
+++ b/frontend/src/lib/components/UserListSidebar.svelte
@@ -359,7 +359,7 @@
               style={`background-color: ${user.tagChipColor ?? "#e5e7eb"}; color: ${user.tagTextColor ?? "#000000"}`}
             >{user.tagText}</span>
           {/if}
-          {#if user.isRelayed}
+          {#if user.isRelayed && displayPrefs.showConnectionInfo}
             <Tip text={RELAY_TIP}>
               {#snippet children(props)}
                 <button

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -1244,7 +1244,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
               ? `${tile.label} (You)`
               : tile.label}
         </span>
-        {#if !tile.isLocal && isRelayed(tile.peerId)}
+        {#if !tile.isLocal && isRelayed(tile.peerId) && displayPrefs.showConnectionInfo}
           <!-- pointer-events-auto: the badge itself ignores the pointer so it
                does not swallow clicks on the tile, but the tooltip needs the
                hover. -->
@@ -1302,7 +1302,7 @@ import PluginIcon from "$lib/plugins/PluginIcon.svelte";
             {:else}
               {label.charAt(0).toUpperCase()}
             {/if}
-            {#if relayed}
+            {#if relayed && displayPrefs.showConnectionInfo}
               <Tip text={RELAY_TIP} side="top">
                 {#snippet children(props)}
                   <button

--- a/frontend/src/lib/components/settings/AppSettings.svelte
+++ b/frontend/src/lib/components/settings/AppSettings.svelte
@@ -11,6 +11,7 @@ import {
   displayPrefs,
   setCallChatBeside,
   setItalicOwnName,
+  setShowConnectionInfo,
   setShowPeerNicknameColors,
   setSidebarCollapsed,
 } from "$lib/display-prefs.svelte";
@@ -141,6 +142,33 @@ import {
     <Switch
       checked={displayPrefs.callChatBeside}
       onCheckedChange={(checked) => setCallChatBeside(checked)}
+    />
+  </div>
+</div>
+
+<!-- Debug Section -->
+<div
+  class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+>
+  <div class="flex items-center gap-2">
+    <div class="w-1 h-4 bg-sky-500 rounded-full"></div>
+    <Label
+      class="text-xs font-mono text-muted-foreground uppercase tracking-wider"
+      >Debug</Label
+    >
+  </div>
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex flex-col gap-1 min-w-0">
+      <span class="text-xs font-mono">Connection &amp; relay indicators</span>
+      <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+        Off hides the transport status overlay, the "Relayed" peer badges, the
+        sidebar connection dot and the room "Connected" pill. Turn it on to see
+        relay and connection state.
+      </span>
+    </div>
+    <Switch
+      checked={displayPrefs.showConnectionInfo}
+      onCheckedChange={(checked) => setShowConnectionInfo(checked)}
     />
   </div>
 </div>

--- a/frontend/src/lib/display-prefs.svelte.ts
+++ b/frontend/src/lib/display-prefs.svelte.ts
@@ -7,6 +7,7 @@ const ITALIC_KEY = "awful:italic-own-name:v1";
 const PEER_COLORS_KEY = "awful:show-peer-colors:v1";
 const SIDEBAR_COLLAPSED_KEY = "awful:sidebar-collapsed:v1";
 const CALL_CHAT_BESIDE_KEY = "awful:call-chat-beside:v1";
+const CONNECTION_INFO_KEY = "awful:debug-connection-info:v1";
 
 function readStored(key: string, defaultValue: boolean): boolean {
   if (typeof localStorage === "undefined") return defaultValue;
@@ -23,6 +24,12 @@ export const displayPrefs = $state({
   sidebarCollapsed: readStored(SIDEBAR_COLLAPSED_KEY, false),
   /** Desktop only: in a call the chat sits beside the stage, not below it. */
   callChatBeside: readStored(CALL_CHAT_BESIDE_KEY, false),
+  /**
+   * Debug: render the relay/connection indicators - the transport status
+   * overlay, the "Relayed" peer badges, the sidebar connection dot and text,
+   * and the room "Connected" pill. Off by default keeps them hidden.
+   */
+  showConnectionInfo: readStored(CONNECTION_INFO_KEY, false),
 });
 
 export function setItalicOwnName(on: boolean): void {
@@ -61,6 +68,15 @@ export function setCallChatBeside(on: boolean): void {
   }
 }
 
+export function setShowConnectionInfo(on: boolean): void {
+  displayPrefs.showConnectionInfo = on;
+  try {
+    localStorage.setItem(CONNECTION_INFO_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
 // A second tab flipping a switch should be reflected here, not fought.
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (e) => {
@@ -72,5 +88,7 @@ if (typeof window !== "undefined") {
       displayPrefs.sidebarCollapsed = e.newValue === "1";
     if (e.key === CALL_CHAT_BESIDE_KEY)
       displayPrefs.callChatBeside = e.newValue === "1";
+    if (e.key === CONNECTION_INFO_KEY)
+      displayPrefs.showConnectionInfo = e.newValue === "1";
   });
 }


### PR DESCRIPTION
## What

Adds a **Debug** section in Settings -> App with one device-local switch, **"Connection & relay indicators"**, **off by default**. When off, the app hides the relay/connection status UI; turn it on to see it.

The switch gates:
- the transport status overlay (relay connected / disconnected, peer count, toasts)
- the "Relayed" peer badges in the user list and the call view (tiles + minimized)
- the sidebar connection dot and the "Connected / Connecting" text
- the room card "Connected / Connecting" pill

The in-call quality banner (`CallStatus`) is intentionally left alone - that is core call feedback, not a relay indicator.

The preference follows the existing `display-prefs` pattern: a `$state` field read from `localStorage`, a setter, and cross-tab `storage` sync.

## Screenshots

The new Debug setting (off by default):

![Debug setting](https://raw.githubusercontent.com/awful-org/awful.chat/assets/crop-images/pr/debug-indicators/debug-setting.png)

Default view - indicators hidden (no room pill, no sidebar status):

![Indicators off](https://raw.githubusercontent.com/awful-org/awful.chat/assets/crop-images/pr/debug-indicators/indicators-off.png)

Enabled - the room "Connecting" pill (top-right) and the sidebar dot + text (bottom-left) return:

![Indicators on](https://raw.githubusercontent.com/awful-org/awful.chat/assets/crop-images/pr/debug-indicators/indicators-on.png)

## Changes

- `src/lib/display-prefs.svelte.ts` - new `showConnectionInfo` pref (default `false`), setter, cross-tab sync.
- `src/lib/components/settings/AppSettings.svelte` - Debug section + Switch.
- `TransportStatus.svelte`, `SidebarControls.svelte`, `RoomCreateJoin.svelte`, `UserListSidebar.svelte`, `VoiceVideoCallView.svelte` - each indicator gated behind `displayPrefs.showConnectionInfo`.

## Verification

- `svelte-check`: 0 errors. `pnpm test`: 261/261 pass. `pnpm build`: succeeds.
- Browser, end to end: default view shows no connection text/dot/pill; enabling the toggle brings back the sidebar status + dot and the room pill (localStorage `awful:debug-connection-info:v1` = `1`); disabling hides them again; the value persists across reload and syncs across tabs.