### PR TITLE
feat: mention people who are away, and set the chat font

### DIFF
--- a/frontend/src/lib/chat-font.test.ts
+++ b/frontend/src/lib/chat-font.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  FONT_STACKS,
+  FONT_STACK_IDS,
+  DEFAULT_CHAT_FONT_SIZE,
+  MIN_CHAT_FONT_SIZE,
+  MAX_CHAT_FONT_SIZE,
+  clampChatFontSize,
+  sanitizeFontFamily,
+  resolveChatFontStack,
+} from "./chat-font";
+
+describe("clampChatFontSize", () => {
+  it("passes an in-range number through unchanged", () => {
+    expect(clampChatFontSize(16)).toBe(16);
+  });
+
+  it("clamps below the minimum", () => {
+    expect(clampChatFontSize(1)).toBe(MIN_CHAT_FONT_SIZE);
+  });
+
+  it("clamps above the maximum", () => {
+    expect(clampChatFontSize(999)).toBe(MAX_CHAT_FONT_SIZE);
+  });
+
+  it("accepts a numeric string, as read from localStorage", () => {
+    expect(clampChatFontSize("18")).toBe(18);
+  });
+
+  it("rounds a fractional value", () => {
+    expect(clampChatFontSize(15.6)).toBe(16);
+  });
+
+  it("falls back to the default for anything that isn't a real, finite number", () => {
+    expect(clampChatFontSize("not a number")).toBe(DEFAULT_CHAT_FONT_SIZE);
+    expect(clampChatFontSize(null)).toBe(DEFAULT_CHAT_FONT_SIZE);
+    expect(clampChatFontSize(undefined)).toBe(DEFAULT_CHAT_FONT_SIZE);
+    expect(clampChatFontSize(NaN)).toBe(DEFAULT_CHAT_FONT_SIZE);
+    expect(clampChatFontSize(Infinity)).toBe(DEFAULT_CHAT_FONT_SIZE);
+    expect(clampChatFontSize({})).toBe(DEFAULT_CHAT_FONT_SIZE);
+  });
+});
+
+describe("sanitizeFontFamily", () => {
+  it("passes a plain family through", () => {
+    expect(sanitizeFontFamily("Comic Sans MS")).toBe("Comic Sans MS");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeFontFamily("  Comic Sans MS  ")).toBe("Comic Sans MS");
+  });
+
+  it("collapses inner whitespace runs to one space", () => {
+    expect(sanitizeFontFamily("Comic   Sans\t\tMS")).toBe("Comic Sans MS");
+  });
+
+  // Every one of these must reject on its own: a filter that only catches
+  // some of them would still let an injection through.
+  const forbiddenChars = [
+    ";",
+    "{",
+    "}",
+    "<",
+    ">",
+    "(",
+    ")",
+    '"',
+    "'",
+    "\\",
+    "\n",
+    "\r",
+  ];
+  for (const ch of forbiddenChars) {
+    it(`rejects a family containing ${JSON.stringify(ch)}`, () => {
+      expect(sanitizeFontFamily(`Comic${ch}Sans`)).toBeNull();
+    });
+  }
+
+  it("rejects url(...) regardless of case", () => {
+    expect(sanitizeFontFamily("url(evil.com)")).toBeNull();
+    expect(sanitizeFontFamily("UrL(evil.com)")).toBeNull();
+    expect(sanitizeFontFamily("a font named url")).toBeNull();
+  });
+
+  it("caps an over-long value instead of rejecting it", () => {
+    const long = "a".repeat(100);
+    const result = sanitizeFontFamily(long);
+    expect(result).toHaveLength(64);
+    expect(result).toBe("a".repeat(64));
+  });
+
+  it("rejects an empty or whitespace-only value", () => {
+    expect(sanitizeFontFamily("")).toBeNull();
+    expect(sanitizeFontFamily("   ")).toBeNull();
+  });
+
+  it("rejects a non-string value", () => {
+    expect(sanitizeFontFamily(null)).toBeNull();
+    expect(sanitizeFontFamily(undefined)).toBeNull();
+    expect(sanitizeFontFamily(42)).toBeNull();
+  });
+});
+
+describe("resolveChatFontStack", () => {
+  const monoStack = FONT_STACKS.find((f) => f.id === "mono")!.stack;
+
+  it("resolves every known id to its own stack", () => {
+    for (const id of FONT_STACK_IDS) {
+      const expected = FONT_STACKS.find((f) => f.id === id)!.stack;
+      expect(resolveChatFontStack(id)).toBe(expected);
+    }
+  });
+
+  it("resolves an unknown-but-safe family to a quoted family plus the mono fallback tail", () => {
+    expect(resolveChatFontStack("Comic Sans MS")).toBe(
+      `"Comic Sans MS", ${monoStack}`,
+    );
+  });
+
+  it("falls back to the mono stack for a dangerous value", () => {
+    expect(resolveChatFontStack('Comic";color:red;--x:"Sans')).toBe(
+      monoStack,
+    );
+  });
+
+  it("falls back to the mono stack for an empty string", () => {
+    expect(resolveChatFontStack("")).toBe(monoStack);
+  });
+});
+
+describe("FONT_STACKS", () => {
+  it("has unique ids", () => {
+    const ids = FONT_STACKS.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("lists mono first", () => {
+    expect(FONT_STACKS[0].id).toBe("mono");
+  });
+
+  it("guarantees a generic CSS family as a real fallback in every stack", () => {
+    // Checked as containment, not strict suffix: `sans` deliberately
+    // appends quoted emoji-glyph font names after its generic `sans-serif`
+    // token, for color emoji coverage, so the generic keyword is not
+    // literally the last word even though it still guarantees the
+    // fallback the other stacks provide by ending with it.
+    const generic = /\b(monospace|sans-serif|serif)\b/;
+    for (const { stack } of FONT_STACKS) {
+      expect(stack).toMatch(generic);
+    }
+  });
+});

--- a/frontend/src/lib/chat-font.ts
+++ b/frontend/src/lib/chat-font.ts
@@ -1,0 +1,113 @@
+/**
+ * Chat text appearance: curated font stacks plus a validated custom-family
+ * path. Every curated stack ends in (or, for `sans`, guarantees) a generic
+ * CSS family so an absent font degrades instead of the message text
+ * vanishing.
+ */
+
+export type FontStackId =
+  | "mono"
+  | "sans"
+  | "serif"
+  | "rounded"
+  | "verdana"
+  | "trebuchet";
+
+interface FontStackEntry {
+  id: FontStackId;
+  label: string;
+  stack: string;
+}
+
+// Order is display order in the settings picker; `mono` first because it is
+// the historical default and must stay a visual no-op for existing users.
+export const FONT_STACKS: readonly FontStackEntry[] = [
+  {
+    id: "mono",
+    label: "Monospace",
+    stack:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  },
+  {
+    id: "sans",
+    label: "System sans",
+    stack:
+      'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+  },
+  {
+    id: "serif",
+    label: "Serif",
+    stack: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
+  },
+  {
+    id: "rounded",
+    label: "Rounded",
+    stack: 'ui-rounded, "SF Pro Rounded", system-ui, sans-serif',
+  },
+  {
+    id: "verdana",
+    label: "Verdana",
+    stack: "Verdana, Geneva, sans-serif",
+  },
+  {
+    id: "trebuchet",
+    label: "Trebuchet",
+    stack: '"Trebuchet MS", Tahoma, sans-serif',
+  },
+];
+
+export const FONT_STACK_IDS: readonly FontStackId[] = FONT_STACKS.map(
+  (f) => f.id,
+);
+
+export const DEFAULT_FONT_STACK: FontStackId = "mono";
+
+export const MIN_CHAT_FONT_SIZE = 11;
+export const MAX_CHAT_FONT_SIZE = 24;
+// Matches --text-sm (0.875rem) at a 16px root, so the default is a visual
+// no-op against the current hardcoded size.
+export const DEFAULT_CHAT_FONT_SIZE = 14;
+
+/** Accepts anything (including a localStorage string) and returns a valid, in-range size. */
+export function clampChatFontSize(n: unknown): number {
+  const num = typeof n === "string" ? Number(n) : n;
+  if (typeof num !== "number" || !Number.isFinite(num)) {
+    return DEFAULT_CHAT_FONT_SIZE;
+  }
+  return Math.max(
+    MIN_CHAT_FONT_SIZE,
+    Math.min(MAX_CHAT_FONT_SIZE, Math.round(num)),
+  );
+}
+
+/** Longest custom family name we keep; anything past this is truncated, not rejected. */
+const MAX_FONT_FAMILY_LENGTH = 64;
+
+// Security boundary: the sanitized result is interpolated into an inline
+// `style` attribute by resolveChatFontStack, so a crafted family name is a
+// CSS/HTML injection vector. Anything that could close the property, open a
+// tag, or reference an external resource is rejected outright rather than
+// stripped, so a caller can't smuggle a payload past a partial filter.
+const FORBIDDEN_CHARS = /[;{}<>()"'\\\r\n]/;
+const URL_SUBSTRING = /url/i;
+
+/** Accepts a user-supplied font-family name and returns a safe value, or null if it can't be made safe. */
+export function sanitizeFontFamily(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  if (FORBIDDEN_CHARS.test(raw) || URL_SUBSTRING.test(raw)) return null;
+  const collapsed = raw.trim().replace(/\s+/g, " ");
+  if (collapsed.length === 0) return null;
+  return collapsed.slice(0, MAX_FONT_FAMILY_LENGTH);
+}
+
+/** The single resolver both the settings UI and the chat container use to turn a stored preference into a CSS value. */
+export function resolveChatFontStack(value: string): string {
+  const known = FONT_STACKS.find((f) => f.id === value);
+  if (known) return known.stack;
+  // sanitizeFontFamily rejects `"`, so wrapping the survivor in quotes here
+  // cannot be used to break out of the family name.
+  const monoStack = FONT_STACKS.find((f) => f.id === DEFAULT_FONT_STACK)!
+    .stack;
+  const family = sanitizeFontFamily(value);
+  return family === null ? monoStack : `"${family}", ${monoStack}`;
+}

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -53,6 +53,7 @@
   import UserListSidebar from "./UserListSidebar.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
   import { displayPrefs } from "$lib/display-prefs.svelte";
+  import { resolveChatFontStack } from "$lib/chat-font";
   import { nameEffectStyle } from "$lib/name-effect";
   import { viewportHeight } from "$lib/actions/viewport-height";
   import {
@@ -80,7 +81,12 @@
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
   import { joinCall } from "$lib/transport/call.svelte";
-  import { serialize, mentionsMe, segmentDraft } from "$lib/mentions";
+  import {
+    buildMentionCandidates,
+    mentionsMe,
+    segmentDraft,
+    serialize,
+  } from "$lib/mentions";
   import { makeHostApi } from "$lib/plugins/host";
   import PluginIcon from "$lib/plugins/PluginIcon.svelte";
   import UserProfileCard from "./UserProfileCard.svelte";
@@ -132,6 +138,7 @@
 
   let {
     peers,
+    roomUsers,
     messages,
     inCall,
     callRoomCode,
@@ -437,15 +444,29 @@
    */
   const draftSegments = $derived(segmentDraft(draft, draftMentionMap));
 
+  /**
+   * `roomUsers` is DID-keyed and seeded on join from the persisted participant
+   * list, and `peerNames` is seeded from stored peer profiles, so an offline
+   * member is still mentionable by name. The selection rules live in
+   * `mentions.ts` because they are testable there and this file is not.
+   */
+  const mentionCandidates = $derived(
+    buildMentionCandidates({
+      roomUsers,
+      peers,
+      toDid: senderDid,
+      nameOf: (id) => peerNames.get(id),
+      selfIds: [identityStore.did ?? "", selfId(), myPeerId()],
+    }),
+  );
+
   const filteredMembersForMention = $derived.by(() => {
     if (!mentionPopupOpen) return [];
-    const self = selfId();
-    const mine = myPeerId();
     const lower = mentionPrefix.toLowerCase();
-    return peers
-      .filter((pid) => pid !== self && pid !== mine)
-      .map((pid) => ({ did: senderDid(pid), name: displayNameFor(pid) }))
-      .filter((m) => !lower || m.name.toLowerCase().includes(lower));
+    if (!lower) return mentionCandidates;
+    return mentionCandidates.filter((m) =>
+      m.name.toLowerCase().includes(lower),
+    );
   });
 
   function updateMentionState() {
@@ -1254,6 +1275,13 @@
   // Desktop only: below sm there is no room for two columns, and the call
   // stage would squeeze the messages to nothing.
   const callBeside = $derived(displayPrefs.callChatBeside && !isMobile);
+
+  // The stored pref is a stack id or a custom family name; the resolver turns
+  // either into a complete CSS stack, and sanitises the custom case because the
+  // value lands in an inline style attribute.
+  const chatFontStack = $derived(
+    resolveChatFontStack(displayPrefs.chatFontFamily),
+  );
   // Opening the user list widens the chat column instead of crushing the
   // message text into what the w-60 aside leaves behind.
   const chatColClass = $derived(
@@ -1294,9 +1322,16 @@
 
 <svelte:document onvisibilitychange={markSeenOnReturn} />
 
+<!--
+  The two chat font properties are declared here and consumed by the message
+  body. They are purpose-named on purpose: overriding Tailwind's `--font-mono`
+  instead would also retarget every shiki code block, because Preflight resolves
+  `code`/`pre`/`kbd`/`samp` from that token.
+-->
 <div
   use:viewportHeight
-  class="relative flex flex-col bg-background text-foreground font-mono overflow-hidden"
+  style="--chat-font-size: {displayPrefs.chatFontSize}px; --chat-font-family: {chatFontStack}"
+  class="relative flex flex-col bg-background text-foreground font-(family-name:--chat-font-family) overflow-hidden"
   role="main"
   ondragenter={handleRootDragEnter}
   ondragover={handleRootDragOver}
@@ -2058,6 +2093,13 @@
               >
                 <span class="text-muted-foreground">@</span>
                 <span class="truncate">{member.name}</span>
+                {#if !member.online}
+                  <!-- Say so rather than hiding them: mentioning an away member
+                       is the point, and a silent list looks like a bug. -->
+                  <span class="ml-auto shrink-0 text-[10px] text-muted-foreground">
+                    away
+                  </span>
+                {/if}
               </button>
             {/each}
           </div>

--- a/frontend/src/lib/components/FloatingDmPanel.svelte
+++ b/frontend/src/lib/components/FloatingDmPanel.svelte
@@ -10,6 +10,8 @@
     defaultPanelPosition,
   } from "$lib/dm-panel.svelte";
   import { closeDmPanel, sendDirectMessage } from "$lib/transport/dm.svelte";
+  import { displayPrefs } from "$lib/display-prefs.svelte";
+  import { resolveChatFontStack } from "$lib/chat-font";
   import {
     requestFileDownload,
     selfId,
@@ -54,6 +56,9 @@
   }
 
   const height = $derived(dmPanel.minimized ? BAR_HEIGHT : HEIGHT);
+  const chatFontStack = $derived(
+    resolveChatFontStack(displayPrefs.chatFontFamily),
+  );
 
   // A viewport that shrank under a parked panel (rotation, a resized window)
   // would otherwise leave it half off screen with its drag handle out of reach.
@@ -108,9 +113,13 @@
     the panel belongs with them: it floats over a live call without stealing
     focus the way a modal dialog would.
   -->
+  <!--
+    The same two properties ChatView declares. Miss this and a DM read in the
+    floating panel disagrees with the same DM read in the room.
+  -->
   <div
-    class="fixed z-50 flex flex-col overflow-hidden rounded-lg border border-border bg-card font-mono shadow-2xl"
-    style="left: {dmPanel.x}px; top: {dmPanel.y}px; width: {WIDTH}px; height: {height}px;"
+    class="fixed z-50 flex flex-col overflow-hidden rounded-lg border border-border bg-card font-(family-name:--chat-font-family) shadow-2xl"
+    style="left: {dmPanel.x}px; top: {dmPanel.y}px; width: {WIDTH}px; height: {height}px; --chat-font-size: {displayPrefs.chatFontSize}px; --chat-font-family: {chatFontStack}"
   >
     <div
       use:draggable={{
@@ -169,7 +178,10 @@
     </div>
 
     {#if !dmPanel.minimized}
-      <div bind:this={list} class="flex-1 overflow-y-auto px-2 py-1.5 text-sm">
+      <div
+        bind:this={list}
+        class="flex-1 overflow-y-auto px-2 py-1.5 text-(length:--chat-font-size) leading-normal"
+      >
         {#if dmPanel.loading}
           <div class="flex h-full items-center justify-center">
             <div class="size-2 animate-pulse rounded-full bg-muted-foreground"></div>

--- a/frontend/src/lib/components/MentionInput.svelte
+++ b/frontend/src/lib/components/MentionInput.svelte
@@ -37,8 +37,15 @@
    *
    * pr-28 keeps the text clear of the icon buttons the caller overlays on the
    * right; widen it if a button is added there.
+   *
+   * The font comes from the chat font properties so what you type matches what
+   * you just read. `leading-normal` replaces the old fixed `leading-5`: a
+   * 1.25rem line box clips once the chosen size passes it, and it clips the
+   * mirror and the textarea by different amounts, which drifts the mention
+   * chips off their glyphs.
    */
-  const BOX = "border py-2 pl-3 pr-28 font-mono text-sm leading-5";
+  const BOX =
+    "border py-2 pl-3 pr-28 font-(family-name:--chat-font-family) text-(length:--chat-font-size) leading-normal";
 
   let scrollTop = $state(0);
   /**

--- a/frontend/src/lib/components/MsgRender.svelte
+++ b/frontend/src/lib/components/MsgRender.svelte
@@ -19,6 +19,9 @@
   import AudioPlayer from "./AudioPlayer.svelte";
   import GifImage from "./GifImage.svelte";
   import { mediaPrefs } from "$lib/media-prefs.svelte";
+  // The queued tooltip must not promise the relay is holding a copy when the
+  // sender opted out of the mailbox, in which case no deposit happened.
+  import { mailboxPrefs } from "$lib/transport/mailbox.svelte";
   import { putSavedGif, deleteSavedGif, isGifSaved, getAttachmentsByInfoHash } from "$lib/storage";
   import { humanize } from "$lib/mentions";
   import { makeHostApi } from "$lib/plugins/host";
@@ -389,7 +392,15 @@
   }
 </script>
 
-<div class="ml-9 text-sm text-foreground wrap-break-word">
+<!--
+  `leading-normal` is not decoration. `text-sm` shipped a ratio line-height with
+  it for free; `text-(length:…)` emits font-size only, so without an explicit
+  line-height the body would render on the container's line box and clip at
+  larger sizes.
+-->
+<div
+  class="ml-9 text-(length:--chat-font-size) leading-normal text-foreground wrap-break-word"
+>
   {#if isFileMessage}
     {#if msg.content}
       <!-- Through linkifyText like every other body: rendered raw, a caption
@@ -743,7 +754,9 @@
   {#if isOwn && msg.status}
     <Tip
       text={msg.status === "sending"
-        ? "Queued - will send when the recipient is reachable"
+        ? mailboxPrefs.enabled
+          ? "Queued - waiting in their offline inbox"
+          : "Queued - will send when the recipient is reachable"
         : msg.status.charAt(0).toUpperCase() + msg.status.slice(1)}
     >
       {#snippet children(props)}

--- a/frontend/src/lib/components/settings/AppSettings.svelte
+++ b/frontend/src/lib/components/settings/AppSettings.svelte
@@ -10,11 +10,83 @@ import { mediaPrefs, setGifAutoplay } from "$lib/media-prefs.svelte";
 import {
   displayPrefs,
   setCallChatBeside,
+  setChatFontFamily,
+  setChatFontSize,
   setItalicOwnName,
   setShowConnectionInfo,
   setShowPeerNicknameColors,
   setSidebarCollapsed,
 } from "$lib/display-prefs.svelte";
+import { Slider } from "$lib/components/ui/slider";
+import { Input } from "$lib/components/ui/input";
+import { Button } from "$lib/components/ui/button";
+import {
+  FONT_STACKS,
+  MAX_CHAT_FONT_SIZE,
+  MIN_CHAT_FONT_SIZE,
+  resolveChatFontStack,
+  sanitizeFontFamily,
+} from "$lib/chat-font";
+
+/** Three short lines: the desktop dialog is a fixed height, mobile is a drawer. */
+const PREVIEW_LINES = [
+  { name: "ana", text: "did the relay come back up?" },
+  { name: "you", text: "yes — mailbox drained, nothing lost" },
+  { name: "kai", text: "0x1f4a9 renders fine at this size 💩" },
+] as const;
+
+const previewStack = $derived(resolveChatFontStack(displayPrefs.chatFontFamily));
+
+let customFamily = $state("");
+let localFonts = $state<string[]>([]);
+let loadingFonts = $state(false);
+let fontsError = $state<string | null>(null);
+
+// Feature-detected, not assumed. `queryLocalFonts` is Chromium-on-desktop only:
+// Firefox and Safari have never implemented it, and Chrome on Android does not
+// either. So the typed field above is the mechanism and this is the shortcut.
+//
+// Typed here rather than in vite-env.d.ts because that file is a global script,
+// where `declare global` cannot augment `Window`, and one call site does not
+// justify reshaping the ambient types.
+type LocalFont = { family: string };
+const queryLocalFonts = (
+  globalThis as unknown as {
+    queryLocalFonts?: () => Promise<LocalFont[]>;
+  }
+).queryLocalFonts;
+const canQueryLocalFonts = typeof queryLocalFonts === "function";
+
+function applyCustomFamily(): void {
+  const safe = sanitizeFontFamily(customFamily);
+  if (safe === null) return;
+  setChatFontFamily(safe);
+  customFamily = "";
+}
+
+async function loadLocalFonts(): Promise<void> {
+  loadingFonts = true;
+  fontsError = null;
+  try {
+    // MUST run from a click: the API throws SecurityError without a real user
+    // gesture, and the first call prompts for permission.
+    const faces = await queryLocalFonts!();
+    // One entry per FACE, so Menlo Regular/Bold/Italic all report family
+    // "Menlo". Dedupe to families, which is what font-family takes.
+    const families = [...new Set(faces.map((f) => f.family))]
+      .filter((f) => sanitizeFontFamily(f) !== null)
+      .sort((a, b) => a.localeCompare(b));
+    localFonts = families;
+    if (families.length === 0) {
+      fontsError = "The browser returned no fonts. Type a name instead.";
+    }
+  } catch {
+    // Denial is a normal answer, not a failure worth a stack trace.
+    fontsError = "No permission to list fonts. Type a name instead.";
+  } finally {
+    loadingFonts = false;
+  }
+}
 </script>
 
 <div class="flex flex-col gap-6">
@@ -143,6 +215,151 @@ import {
       checked={displayPrefs.callChatBeside}
       onCheckedChange={(checked) => setCallChatBeside(checked)}
     />
+  </div>
+</div>
+
+<!-- Chat text Section -->
+<div
+  class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+>
+  <div class="flex items-center gap-2">
+    <div class="w-1 h-4 bg-teal-500 rounded-full"></div>
+    <Label
+      class="text-xs font-mono text-muted-foreground uppercase tracking-wider"
+      >Chat text</Label
+    >
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <div class="flex items-center justify-between">
+      <span class="text-xs font-mono text-muted-foreground">Size</span>
+      <span class="text-xs font-mono tabular-nums text-green-400"
+        >{displayPrefs.chatFontSize}px</span
+      >
+    </div>
+    <Slider
+      type="single"
+      value={displayPrefs.chatFontSize}
+      min={MIN_CHAT_FONT_SIZE}
+      max={MAX_CHAT_FONT_SIZE}
+      step={1}
+      onValueChange={(v) => setChatFontSize(v)}
+      class="w-full **:data-[orientation=vertical]:h-full"
+    />
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <span class="text-xs font-mono text-muted-foreground">Font</span>
+    <!--
+      Each option renders in its own family, so you can see whether a stack
+      actually resolved on this machine. That is a better answer than a dropdown
+      of names, and it needs no permission prompt.
+    -->
+    <div class="flex flex-wrap items-center gap-1.5">
+      {#each FONT_STACKS as entry (entry.id)}
+        <button
+          type="button"
+          onclick={() => setChatFontFamily(entry.id)}
+          style="font-family: {entry.stack}"
+          class="cursor-pointer rounded-full border px-2.5 py-1 text-xs transition-colors {displayPrefs.chatFontFamily ===
+          entry.id
+            ? 'border-primary bg-primary/10'
+            : 'border-border hover:border-primary/40'}"
+        >
+          {entry.label}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <div class="flex flex-col gap-2">
+    <span class="text-xs font-mono text-muted-foreground"
+      >Or name a font installed on this device</span
+    >
+    <div class="flex items-center gap-2">
+      <Input
+        value={customFamily}
+        placeholder="Consolas, Inter, Comic Sans MS…"
+        oninput={(e) => (customFamily = e.currentTarget.value)}
+        onkeydown={(e) => {
+          if (e.key === "Enter") applyCustomFamily();
+        }}
+        class="h-8 text-xs"
+      />
+      <Button
+        variant="outline"
+        size="sm"
+        class="h-8 shrink-0 text-xs"
+        disabled={sanitizeFontFamily(customFamily) === null}
+        onclick={applyCustomFamily}
+      >
+        Use
+      </Button>
+    </div>
+    {#if localFonts.length > 0}
+      <!--
+        Populated only after a click, because queryLocalFonts needs a real user
+        gesture and asks the user's permission.
+      -->
+      <div class="flex flex-wrap items-center gap-1.5">
+        {#each localFonts as family (family)}
+          <button
+            type="button"
+            onclick={() => setChatFontFamily(family)}
+            style="font-family: '{family}'"
+            class="cursor-pointer rounded-full border px-2.5 py-1 text-xs transition-colors {displayPrefs.chatFontFamily ===
+            family
+              ? 'border-primary bg-primary/10'
+              : 'border-border hover:border-primary/40'}"
+          >
+            {family}
+          </button>
+        {/each}
+      </div>
+    {:else if canQueryLocalFonts}
+      <Button
+        variant="outline"
+        size="sm"
+        class="h-8 self-start text-xs"
+        disabled={loadingFonts}
+        onclick={loadLocalFonts}
+      >
+        {loadingFonts ? "Asking…" : "List my installed fonts"}
+      </Button>
+    {:else}
+      <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+        This browser cannot list your fonts, so type the name instead. Any font
+        installed on this device works.
+      </span>
+    {/if}
+    {#if fontsError}
+      <span class="text-xs font-mono text-destructive">{fontsError}</span>
+    {/if}
+  </div>
+
+  <!--
+    The preview declares the SAME two custom properties the real chat container
+    does, so it is structurally identical to production rather than an
+    approximation of it. Kept to three short lines: the desktop dialog has a
+    fixed height and the mobile path is a bottom drawer.
+  -->
+  <div
+    style="--chat-font-size: {displayPrefs.chatFontSize}px; --chat-font-family: {previewStack}"
+    class="rounded-md border border-border bg-background p-3 font-(family-name:--chat-font-family)"
+  >
+    <div class="flex flex-col gap-1.5">
+      {#each PREVIEW_LINES as line (line.name)}
+        <div class="flex gap-2">
+          <span class="shrink-0 text-xs font-semibold text-primary"
+            >{line.name}</span
+          >
+          <span
+            class="text-(length:--chat-font-size) leading-normal text-foreground"
+            >{line.text}</span
+          >
+        </div>
+      {/each}
+    </div>
   </div>
 </div>
 

--- a/frontend/src/lib/display-prefs.svelte.ts
+++ b/frontend/src/lib/display-prefs.svelte.ts
@@ -3,16 +3,43 @@
  * preference about this screen, not part of the identity or profile.
  */
 
+import {
+  DEFAULT_CHAT_FONT_SIZE,
+  DEFAULT_FONT_STACK,
+  FONT_STACK_IDS,
+  clampChatFontSize,
+  sanitizeFontFamily,
+} from "./chat-font";
+
 const ITALIC_KEY = "awful:italic-own-name:v1";
 const PEER_COLORS_KEY = "awful:show-peer-colors:v1";
 const SIDEBAR_COLLAPSED_KEY = "awful:sidebar-collapsed:v1";
 const CALL_CHAT_BESIDE_KEY = "awful:call-chat-beside:v1";
 const CONNECTION_INFO_KEY = "awful:debug-connection-info:v1";
+const CHAT_FONT_SIZE_KEY = "awful:chat-font-size:v1";
+const CHAT_FONT_FAMILY_KEY = "awful:chat-font-family:v1";
 
 function readStored(key: string, defaultValue: boolean): boolean {
   if (typeof localStorage === "undefined") return defaultValue;
   const v = localStorage.getItem(key);
   return v === null ? defaultValue : v === "1";
+}
+
+function readChatFontSize(): number {
+  if (typeof localStorage === "undefined") return DEFAULT_CHAT_FONT_SIZE;
+  const raw = localStorage.getItem(CHAT_FONT_SIZE_KEY);
+  // Number(null) is 0, which would clamp to the minimum instead of the
+  // default, so the missing-key case must be checked before conversion.
+  return raw === null ? DEFAULT_CHAT_FONT_SIZE : clampChatFontSize(raw);
+}
+
+// Shared by the reader, the setter, and the cross-tab listener: a stored id
+// is kept as-is, a custom family is sanitized, and anything that survives
+// neither check falls back to the default stack.
+function normalizeChatFontFamily(value: unknown): string {
+  if (typeof value !== "string") return DEFAULT_FONT_STACK;
+  if ((FONT_STACK_IDS as readonly string[]).includes(value)) return value;
+  return sanitizeFontFamily(value) ?? DEFAULT_FONT_STACK;
 }
 
 export const displayPrefs = $state({
@@ -30,6 +57,14 @@ export const displayPrefs = $state({
    * and the room "Connected" pill. Off by default keeps them hidden.
    */
   showConnectionInfo: readStored(CONNECTION_INFO_KEY, false),
+  /** Chat message text size, in pixels. */
+  chatFontSize: readChatFontSize(),
+  /** Chat message font: a FontStackId, or a sanitized custom family name. */
+  chatFontFamily: normalizeChatFontFamily(
+    typeof localStorage === "undefined"
+      ? null
+      : localStorage.getItem(CHAT_FONT_FAMILY_KEY),
+  ),
 });
 
 export function setItalicOwnName(on: boolean): void {
@@ -77,6 +112,24 @@ export function setShowConnectionInfo(on: boolean): void {
   }
 }
 
+export function setChatFontSize(px: number): void {
+  displayPrefs.chatFontSize = clampChatFontSize(px);
+  try {
+    localStorage.setItem(CHAT_FONT_SIZE_KEY, String(displayPrefs.chatFontSize));
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
+export function setChatFontFamily(value: string): void {
+  displayPrefs.chatFontFamily = normalizeChatFontFamily(value);
+  try {
+    localStorage.setItem(CHAT_FONT_FAMILY_KEY, displayPrefs.chatFontFamily);
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
 // A second tab flipping a switch should be reflected here, not fought.
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (e) => {
@@ -90,5 +143,12 @@ if (typeof window !== "undefined") {
       displayPrefs.callChatBeside = e.newValue === "1";
     if (e.key === CONNECTION_INFO_KEY)
       displayPrefs.showConnectionInfo = e.newValue === "1";
+    if (e.key === CHAT_FONT_SIZE_KEY)
+      displayPrefs.chatFontSize =
+        e.newValue === null
+          ? DEFAULT_CHAT_FONT_SIZE
+          : clampChatFontSize(e.newValue);
+    if (e.key === CHAT_FONT_FAMILY_KEY)
+      displayPrefs.chatFontFamily = normalizeChatFontFamily(e.newValue);
   });
 }

--- a/frontend/src/lib/mentions.test.ts
+++ b/frontend/src/lib/mentions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { serialize, humanize, mentionsMe, segmentDraft } from "./mentions";
+import {
+  buildMentionCandidates,
+  humanize,
+  mentionsMe,
+  segmentDraft,
+  serialize,
+} from "./mentions";
 
 describe("mentions", () => {
   describe("serialize", () => {
@@ -249,5 +255,92 @@ describe("segmentDraft", () => {
     expect(serialize(draft, map)).toBe(
       "@[did:key:z6MkAlice] @Alice-bot @[did:key:z6MkBob] @Charlie"
     );
+  });
+});
+
+describe("buildMentionCandidates", () => {
+  /** A roster where names are known for everyone unless stated otherwise. */
+  const names: Record<string, string> = {
+    "did:alice": "Alice",
+    "did:bob": "Bob",
+    "did:carol": "Carol",
+    "did:me": "Me",
+  };
+  const peerToDid: Record<string, string> = {
+    "peer-alice": "did:alice",
+    "peer-me": "did:me",
+  };
+
+  function build(over: Partial<Parameters<typeof buildMentionCandidates>[0]> = {}) {
+    return buildMentionCandidates({
+      roomUsers: ["did:alice", "did:bob", "did:carol"],
+      peers: [],
+      toDid: (id) => peerToDid[id] ?? id,
+      nameOf: (id) => names[id],
+      selfIds: ["did:me", "peer-me"],
+      ...over,
+    });
+  }
+
+  it("offers a roster member who is not connected", () => {
+    // The whole point: nobody is online here, and all three are still offerable.
+    expect(build().map((c) => c.name)).toEqual(["Alice", "Bob", "Carol"]);
+  });
+
+  it("marks a connected member online and an absent one offline", () => {
+    const out = build({ peers: ["peer-alice"] });
+    expect(out.find((c) => c.name === "Alice")?.online).toBe(true);
+    expect(out.find((c) => c.name === "Bob")?.online).toBe(false);
+  });
+
+  it("puts online members before offline ones", () => {
+    // Carol sorts last alphabetically but first when she is the one connected.
+    const out = build({
+      peers: ["peer-carol"],
+      toDid: (id) => (id === "peer-carol" ? "did:carol" : (peerToDid[id] ?? id)),
+    });
+    expect(out[0].name).toBe("Carol");
+  });
+
+  it("sorts alphabetically within the same online state", () => {
+    expect(build({ roomUsers: ["did:carol", "did:bob", "did:alice"] }).map((c) => c.name)).toEqual(
+      ["Alice", "Bob", "Carol"]
+    );
+  });
+
+  it("never offers you yourself, by DID or by peer id", () => {
+    const out = build({ roomUsers: ["did:alice", "did:me"], peers: ["peer-me"] });
+    expect(out.map((c) => c.name)).toEqual(["Alice"]);
+  });
+
+  it("drops a member whose name is not known", () => {
+    // The caller's fallback would be a DID fragment, and `@did:key:z6Mk` is not
+    // a mention anybody means to type.
+    const out = build({ roomUsers: ["did:alice", "did:stranger"] });
+    expect(out.map((c) => c.did)).toEqual(["did:alice"]);
+  });
+
+  it("reports one entry per person when the roster and the peers overlap", () => {
+    const out = build({ roomUsers: ["did:alice"], peers: ["peer-alice"] });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ did: "did:alice", name: "Alice", online: true });
+  });
+
+  it("resolves a name keyed by peer id when the DID has none", () => {
+    const out = build({
+      roomUsers: [],
+      peers: ["peer-zed"],
+      toDid: (id) => (id === "peer-zed" ? "did:zed" : id),
+      nameOf: (id) => (id === "peer-zed" ? "Zed" : names[id]),
+    });
+    expect(out).toEqual([{ did: "did:zed", name: "Zed", online: true }]);
+  });
+
+  it("ignores empty ids", () => {
+    expect(build({ roomUsers: ["", "did:alice"] }).map((c) => c.name)).toEqual(["Alice"]);
+  });
+
+  it("returns nothing for an empty roster", () => {
+    expect(build({ roomUsers: [], peers: [] })).toEqual([]);
   });
 });

--- a/frontend/src/lib/mentions.ts
+++ b/frontend/src/lib/mentions.ts
@@ -154,6 +154,67 @@ export function mentionsMe(content: string, selfDids: string[]): boolean {
   return selfDids.some((did) => mentionedDids.has(did));
 }
 
+/** One offerable mention target. */
+export interface MentionCandidate {
+  did: string;
+  name: string;
+  /** Connected right now. Offline members are still offerable. */
+  online: boolean;
+}
+
+export interface MentionCandidateInput {
+  /** The room roster, as DIDs. Includes members who are not connected. */
+  roomUsers: readonly string[];
+  /** Live transport peer ids. */
+  peers: readonly string[];
+  /** Resolves a peer id or DID to its canonical DID. */
+  toDid: (id: string) => string;
+  /** Known display name for a DID or peer id, if any. */
+  nameOf: (id: string) => string | undefined;
+  /** Every id that means "me", so you are never offered yourself. */
+  selfIds: readonly string[];
+}
+
+/**
+ * Build the list of people a draft can mention.
+ *
+ * Sourced from the room ROSTER, not from live connections. Offering only
+ * connected peers meant an offline member never appeared, so their name-to-DID
+ * pair never reached the draft map, so `serialize` left the text as a literal
+ * `@Name` and `mentionsMe` was false forever: you could not mention somebody who
+ * was away, which is when a mention matters most.
+ *
+ * A member with no known name is dropped. The caller's fallback would be a DID
+ * fragment, and `@did:key:z6Mk` is not a mention anybody means to type.
+ */
+export function buildMentionCandidates(
+  input: MentionCandidateInput,
+): MentionCandidate[] {
+  const { roomUsers, peers, toDid, nameOf, selfIds } = input;
+  const mine = new Set(selfIds.filter(Boolean));
+  const onlineDids = new Set(peers.map(toDid));
+  const seen = new Set<string>();
+  const out: MentionCandidate[] = [];
+
+  for (const raw of [...roomUsers, ...peers]) {
+    if (!raw || mine.has(raw)) continue;
+    const did = toDid(raw);
+    if (!did || mine.has(did) || seen.has(did)) continue;
+    const name = nameOf(did) ?? nameOf(raw);
+    if (!name) continue;
+    seen.add(did);
+    out.push({ did, name, online: onlineDids.has(did) });
+  }
+
+  // People who can answer now come first, then alphabetical, so the list does
+  // not reshuffle under the cursor as connections come and go mid-type.
+  out.sort(
+    (a, b) =>
+      Number(b.online) - Number(a.online) || a.name.localeCompare(b.name),
+  );
+  return out;
+}
+
 /**
  * Escape special regex characters in a string.
  * Used to safely include user-provided names in regex patterns.

--- a/frontend/src/lib/transport/dm.svelte.ts
+++ b/frontend/src/lib/transport/dm.svelte.ts
@@ -18,6 +18,7 @@ import {
   type DMRoom,
   getMessages,
 } from "$lib/storage";
+import { roomsStore } from "$lib/rooms.svelte";
 import {
   appendToDmPanel,
   defaultPanelPosition,
@@ -468,15 +469,26 @@ async function _flushQueuedDmForPeer(peerId: string): Promise<void> {
   );
 }
 
+/**
+ * A readable name for the other side of a DM.
+ *
+ * `peerId` is a real peer id on the live path but the sender's DID on the
+ * mailbox path, so both keys are tried either way: the peerId-to-DID map misses
+ * for a DID input, which used to drop straight through to a `did:key:z6Mk`
+ * fragment as the sender's name.
+ */
 export function resolveDmDisplayName(peerId: string): string {
   const did = _peerIdToDid.get(peerId);
-  if (did)
-    return (
-      transportState.peerNames.get(did) ??
-      transportState.peerNames.get(peerId) ??
-      peerId.slice(0, 12)
-    );
-  return transportState.peerNames.get(peerId) ?? peerId.slice(0, 12);
+  const names = transportState.peerNames;
+  const named = (did ? names.get(did) : undefined) ?? names.get(peerId);
+  if (named) return named;
+  // The phonebook nickname survives a reload even when no profile was ever
+  // cached, which is exactly the case a mailbox DM from a stranger hits.
+  const entry = roomsStore.phonebook.find(
+    (e) => e.peerId === peerId || e.did === peerId || (!!did && e.did === did)
+  );
+  if (entry?.nickname) return entry.nickname;
+  return peerId.slice(0, 12);
 }
 
 export async function joinPhonebookDmRooms(): Promise<void> {

--- a/frontend/src/lib/transport/mailbox.svelte.ts
+++ b/frontend/src/lib/transport/mailbox.svelte.ts
@@ -149,10 +149,22 @@ export async function collectMailbox(): Promise<void> {
 }
 
 let _timer: ReturnType<typeof setInterval> | undefined;
+let _wakeBound = false;
 
 /** Start the collect loop. Idempotent; call after unlock. */
 export function startMailboxCollector(): void {
   if (_timer) return;
   void collectMailbox();
   _timer = setInterval(() => void collectMailbox(), COLLECT_EVERY);
+
+  // The interval alone means a worst case of COLLECT_EVERY, and worse than that
+  // in a background tab, where timers are throttled hard. Coming back to the
+  // app is the moment a waiting DM matters most, so drain then as well.
+  // `collectMailbox` already guards re-entry, so an extra call is free.
+  if (_wakeBound || typeof document === "undefined") return;
+  _wakeBound = true;
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) void collectMailbox();
+  });
+  window.addEventListener("online", () => void collectMailbox());
 }

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -94,6 +94,7 @@ import {
   touchCardStates,
 } from "../plugins/state.svelte";
 import { announceMessage } from "../announce";
+import { mentionsMe } from "../mentions";
 import { appendToDmPanel, dmPanelIsShowing } from "../dm-panel.svelte";
 import { profileStore } from "../profile.svelte";
 import { getPlugin } from "../plugins/registry";
@@ -1092,17 +1093,24 @@ async function _handleSyncBatch(
   for (const m of fullMessages) stripAndAdoptInlineFiles(m);
 
   // Newness has to be read BEFORE the write below, which would otherwise
-  // satisfy the lookup. Only worth the round trip for a live batch: repair
-  // never announces, so it never needs the answer.
-  const unannounced = live
-    ? await Promise.all(
-        fullMessages.map(
-          async (m) =>
-            !transportState.messages.some((x) => x.id === m.id) &&
-            !(await getMessage(m.id))
-        )
-      )
-    : [];
+  // satisfy the lookup.
+  //
+  // A live batch checks every message. A repair batch checks only the ones that
+  // mention me. "Repair never announces" is the right rule for bulk history --
+  // syncing a busy room must not fire a hundred notifications -- but a mention
+  // you were away for is the one thing you MUST still be told about, and that
+  // is exactly the case that used to be silent. Scoping the check to mentions
+  // keeps the round trips proportional to mentions, not to the backfill size:
+  // the `&&` short-circuits before `getMessage` for everything else.
+  const selfIds = _selfIds();
+  const unannounced = await Promise.all(
+    fullMessages.map(
+      async (m) =>
+        (live || mentionsMe(m.content ?? "", selfIds)) &&
+        !transportState.messages.some((x) => x.id === m.id) &&
+        !(await getMessage(m.id))
+    )
+  );
 
   await bulkPutMessages(fullMessages);
 
@@ -1139,11 +1147,11 @@ async function _handleSyncBatch(
   refreshUnreadCount(roomCode).catch(() => {});
   for (const m of fullMessages) noteRoomActivity(m.roomCode, m.timestamp);
 
-  if (live) {
-    fullMessages.forEach((m, i) => {
-      if (unannounced[i]) _announceMessage(m);
-    });
-  }
+  // No `live` gate here: `unannounced` already encodes the policy, and it is
+  // false for every non-mention in a repair batch.
+  fullMessages.forEach((m, i) => {
+    if (unannounced[i]) _announceMessage(m);
+  });
 
   // Storage got everything; the view only takes messages for the room that is
   // actually open (the user may have switched while the batch was in flight),
@@ -1645,6 +1653,11 @@ async function _verifyIncoming(
   return verifySignature(wire.senderDid, wire.sig, canonicalFor(wire));
 }
 
+/** Every id that means "me". Shared so the announce and mention checks agree. */
+function _selfIds(): string[] {
+  return [identityStore.did ?? "", _transport.selfId()];
+}
+
 /**
  * Bind an incoming message to this client's identity and view, then let
  * announce.ts decide whether to make a sound about it. The caller has already
@@ -1652,7 +1665,7 @@ async function _verifyIncoming(
  */
 function _announceMessage(msg: Message): void {
   announceMessage(msg, {
-    selfIds: [identityStore.did ?? "", _transport.selfId()],
+    selfIds: _selfIds(),
     uiRoomCode: transportState.uiRoomCode,
     resolveName: resolveMentionDisplayName,
   });
@@ -1947,7 +1960,7 @@ export function deliverMailboxDm(
   // AWAITABLE on purpose: the mailbox collector must not ack (= delete the
   // relay's only copy) until the local write actually settled - a locked
   // identity mid-drain throws here instead of vanishing the message.
-  return _handleDmChatAsync(senderDid, senderDid, { payload });
+  return _handleDmChatAsync(senderDid, senderDid, { payload }, true);
 }
 
 function _handleDmChat(
@@ -1961,7 +1974,14 @@ function _handleDmChat(
 function _handleDmChatAsync(
   peerId: string,
   senderDid: string,
-  envelope: { payload: DmPayload }
+  envelope: { payload: DmPayload },
+  /**
+   * This arrived from the relay mailbox, so `peerId` is the sender's DID
+   * standing in for a stream that does not exist. Passed explicitly rather than
+   * inferred from `peerId === senderDid`: that coincidence is not a contract,
+   * and getting it wrong emits a user-visible error.
+   */
+  viaMailbox = false
 ): Promise<void> {
   return (async () => {
     const roomCode = await ensureDmRoomForPeer(peerId);
@@ -2037,15 +2057,24 @@ function _handleDmChatAsync(
         }
         await refreshDmRooms();
         transportState.dmVersion += 1;
-        _transport
-          .send(peerId, encodeDmReadEnvelope([envelope.payload.id]))
-          .catch(() => {});
+        // No stream to reply on when the DM came out of the mailbox. Calling
+        // send() with a DID makes peerIdFromString throw inside libp2p, and
+        // that surfaces as a `stream-open-failed` toast the user reads as a
+        // real error - up to two per collected DM. The sender learns the
+        // message landed when the offline queue next reaches them live.
+        if (!viaMailbox) {
+          _transport
+            .send(peerId, encodeDmReadEnvelope([envelope.payload.id]))
+            .catch(() => {});
+        }
       }
     }
 
-    _transport
-      .send(peerId, encodeDmAckEnvelope(envelope.payload.id))
-      .catch(() => {});
+    if (!viaMailbox) {
+      _transport
+        .send(peerId, encodeDmAckEnvelope(envelope.payload.id))
+        .catch(() => {});
+    }
   })();
 }
 


### PR DESCRIPTION
## What

Two changes: you can mention people who are not online, and you can set the chat font.

Both came out of reading the code first, and the reading changed what needed building.

---

# 1. Mentioning people who are away

## The premise needed correcting

The ask was "make messaging offline users work, now that `mailbox.go` exists". **It already works.** Offline DM delivery is fully shipped: the sender falls back to a sealed relay deposit at `dm.svelte.ts:356-364`, the recipient drains and de-duplicates, and the relay never sees plaintext or sender identity.

The open question was whether the mailbox pref gates it. **It does, and on both ends, not just the recipient's:**

- `mailbox.svelte.ts:52` — the **sender's** own pref silently skips the deposit
- `mailbox.svelte.ts:90` — the **recipient's** pref skips collection

It is local-only and advertised nowhere on the wire, so a sender deposits blind. What defuses it: the default is ON and written defensively — `getItem(OPTIN_KEY) !== "0"` treats anything but an explicit opt-out as enabled. A default install works; only a deliberate opt-out on either side kills delivery. No change made here, but it is worth knowing that the switch is a two-sided one.

## What was actually broken

Mentions, and none of it was delivery.

**You could not compose a mention for an absent member at all.** The popup was built from `transportState.peers` — live libp2p connections. An offline member never appeared, so their name→DID pair never reached `draftMentionMap`, `serialize` left the text as a literal `@Name`, and `mentionsMe` returned false forever. The mailbox could not have helped: it is DM-only by design (`relay/mailbox.go:16-17`) and `_broadcastChatWire` never deposits.

**A mention that arrived late was deliberately silent.** `_pushMissingTo` omits `live`, the receiver defaults it false, and the announce block was gated `if (live)` — the comment reads *"repair never announces"*. The message was stored, watermarked, unread-counted and highlighted on open, and never announced.

## The fix

The popup now reads `transportState.roomUsers` — the DID roster, seeded on join from the persisted participant list — with names from `peerNames`, itself seeded from stored peer profiles at `_loadHistory`. So a member who is offline right now is still mentionable by name, and is labelled `away` rather than hidden. A member whose name was never learned is skipped on purpose: the fallback is a DID fragment, and `@did:key:z6Mk` is not a mention anybody means to type.

The repair path now announces a backfilled message when, and only when, it mentions you. Bulk history stays silent — syncing a busy room must not fire a hundred notifications. The mention check short-circuits before the storage read, so the round trips stay proportional to mentions rather than to the size of the backfill.

The existing sound policy then does the right thing without further work: a late mention chimes if you are not looking at that room, and raises an OS notification if the tab is hidden.

## Three mailbox defects found in the same pass

- **Collecting a DM raised a user-visible error toast**, up to two per message. `deliverMailboxDm` passes the sender's DID where a peer id is expected, so the ack called `_transport.send("did:key:...")`, `peerIdFromString` threw inside libp2p, and that surfaced as `stream-open-failed`, which `TransportStatus` renders as a real error. Now suppressed by an explicit `viaMailbox` flag rather than inferring it from `peerId === senderDid` — that coincidence is not a contract, and getting it wrong is exactly what produced the toast.
- **A mailbox DM could render its sender as a raw DID.** `resolveDmDisplayName` missed because the peerId→DID map cannot resolve a DID input. It now tries both keys and falls back to the phonebook nickname, which survives a reload even when no profile was ever cached — precisely the case a DM from a stranger hits.
- **Draining only happened on load and every five minutes**, worse in a throttled background tab. Returning to the app (`visibilitychange`) and regaining the network (`online`) now drain too. `collectMailbox` already guards re-entry, so the extra calls are free.

## One thing deliberately not fixed

The queued tooltip stopped being true when the mailbox shipped: it promised *"will send when the recipient is reachable"* for a message the relay is already holding. It now says *"waiting in their offline inbox"*, and only when the mailbox pref is actually on, so it never over-promises.

But the message still shows `sending`, because **a real delivery receipt needs acks to ride the mailbox**, and they do not today — `sendDmReadAcks` bails when the peer is offline and the drain only delivers `type === "chat"`. That is a protocol change, so it is out of scope here rather than half-done. Flagging it as the obvious follow-up.

---

# 2. Chat font size and family

A size slider and a family picker in Appearance, with a live preview.

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/offline-and-appearance/01-chat-font-default.png" width="900" alt="The Chat text card at its default of 14px monospace, with a three-line preview" />

The default is a deliberate no-op: `14px` matches `--text-sm` at a 16px root, and the default family is the same mono stack the chat already used, so an untouched install renders byte-identically.

## Three traps this had to avoid

- **`text-sm` is rem-based.** Setting `font-size` on the chat container would have done nothing to message bodies, because every text node in the chat path carries its own `text-*` utility. The size has to arrive as a custom property consumed by `text-(length:--chat-font-size)`.
- **`font-mono` sits in three places, not one:** `ChatView.svelte`, `FloatingDmPanel.svelte`, and `MentionInput.svelte`'s shared `BOX` constant. Miss the second and DMs disagree with rooms; miss the third and the composer disagrees with the transcript.
- **Redefining `--font-mono` would have been actively wrong.** Preflight resolves `code`/`kbd`/`samp`/`pre` from it, so every shiki code block would have switched to the user's prose font. Purpose-named properties leave code blocks correctly mono for free.

`leading-5` in `BOX` had to go with it. A fixed 1.25rem line box clips a larger font, and it clips the textarea and its aria-hidden mention-highlight mirror by different amounts — which drifts the mention chips off the glyphs they are supposed to sit under.

## The preview is production, not an approximation

It declares the *same* two custom properties the real chat container does and consumes them with the same utilities, so what you see is the mechanism rather than a mock-up of it.

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/offline-and-appearance/02-chat-font-serif-19px.png" width="900" alt="19px serif selected, with the preview rendering in serif at the larger size" />

Each family pill renders in its own face, so you can see immediately whether a stack resolved on your machine. That answers the "is this font installed?" question better than a dropdown of names, and it needs no permission prompt.

## Using a font from your own machine

Two routes, and the order matters.

The **typed field is the mechanism**: name any font installed on the device and it applies, on every browser. The **button is a shortcut**, offered only behind `"queryLocalFonts" in window`.

<img src="https://raw.githubusercontent.com/awful-org/awful.chat/pr-media/offline-and-appearance/03-installed-fonts.png" width="900" alt="The installed-font list populated, each font name rendered in its own face" />

That ordering is not arbitrary. `queryLocalFonts()` is **Chromium-on-desktop only** — Chrome 103+/Edge, explicitly unimplemented on Chrome Android, never implemented in Firefox or Safari on any platform. It also needs a secure context, a real user gesture, and a permission prompt, and the spec permits returning a *subset* in any order. For a PWA that targets mobile it is a progressive enhancement and nothing more, so browsers without it get an honest sentence rather than a dead button. Results are per-face, so families are de-duplicated before display.

`sanitizeFontFamily` is a security boundary, not politeness: the value lands in an inline `style` attribute. It rejects `; { } < > ( ) " ' \`, newlines and `url` in any case, caps the length, and a rejected value leaves the **Use** button disabled. A surviving custom family is emitted with the mono stack as its fallback tail, so a typo degrades instead of vanishing.

---

## Shape

Everything worth testing is in plain `.ts`, because runes are not testable in this repo — `vitest` runs `environment: "node"` with no jsdom, and `plugins/state.svelte.ts:25` already documents the constraint. `.svelte` files hold markup and wiring.

```
frontend/src/lib/chat-font.ts        stacks, clamp, sanitiser, resolver   (+32 tests)
frontend/src/lib/mentions.ts         + buildMentionCandidates             (+10 tests)
frontend/src/lib/display-prefs.svelte.ts   two new prefs, validated on every read
```

Both new prefs re-validate in the reader, the setter, and the cross-tab `storage` listener, because another tab's stored value is exactly as untrusted as disk. `raw === null` is checked before coercion, since `Number(null)` is `0` and would clamp to the minimum instead of returning the default.

## Verification

- **437 tests pass** (39 files), **42 of them new**. The jump from 330 is `main` moving under this branch, not extra work here.
- `svelte-check`: **0 errors, 0 warnings** across the whole app. `tsc -p tsconfig.node.json` clean. Production `vite build` succeeds.
- Confirmed in a real browser: the size slider and family pills both drive the preview live and persist; computed `font-size` really becomes `20px`, proving `text-(length:…)` compiles; `Comic Sans MS` applies with the mono fallback tail; `Evil; background:url(x)` leaves **Use** disabled; `queryLocalFonts` returns real families each rendered in its own face.
- Both arbitrary-value utilities are confirmed present in the **production** CSS bundle, not just the dev JIT output:
  ```
  .text-\(length\:--chat-font-size\){font-size:var(--chat-font-size)}
  .font-\(family-name\:--chat-font-family\){font-family:var(--chat-font-family)}
  ```

### One honest gap

**The offline-mention path is unit-tested, not browser-tested.** Exercising it needs two peers and a live relay, and the Go relay will not build in my environment — `proxy.golang.org` is unreachable, so `joinRoom` always returns `false` and `roomUsers` never populates. That is exactly why the selection rules were extracted into `mentions.ts` instead of left inline in `ChatView`: the offline case is covered by tests that assert a roster member with no connection is still offered, is marked offline, and sorts after the connected ones.

## Review notes

- "Collapse the sidebar" is **untouched** — an earlier plan to remove it was withdrawn before anything changed.
- No new dependency. No relay or wire-protocol change.
- **Rebased onto `main` at `44f43d0`**, which now includes the command palette (#18), the debug toggle (#20) and the DM tab-title fix (#19). Both conflicts were additive and both in the files the debug toggle also touched: `display-prefs.svelte.ts` gained the two font prefs alongside `showConnectionInfo`, and `AppSettings.svelte` gained a Chat text card alongside the new Debug card. That card had claimed `bg-sky-500`, which mine was also using, so Chat text moved to `bg-teal-500` and now sits before Debug — four cards, four distinct accents. Checks, tests, build and a browser pass were all re-run after the rebase.
- The palette from #18 exposes every boolean pref as a command. The two new font prefs are a slider and a family picker, not booleans, so they are deliberately not surfaced there — that would need a palette page for a numeric range, which is its own change.
- Screenshots live on the orphan `pr-media/offline-and-appearance` branch, matching the existing `pr-media/*` convention.

