### PR TITLE
fix: stabilize profile name effects and identity layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .env
 tmp/
 relay/relay
+.specs/

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -217,15 +217,6 @@ body {
   }
 }
 
-@keyframes glow {
-  0%, 100% {
-    text-shadow: 0 0 8px var(--name-glow-color, currentColor);
-  }
-  50% {
-    text-shadow: 0 0 16px var(--name-glow-color, currentColor);
-  }
-}
-
 @keyframes rainbow {
   0% {
     filter: hue-rotate(0deg);
@@ -237,7 +228,6 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   .name-effect-shimmer,
-  .name-effect-glow,
   .name-effect-rainbow {
     animation: none !important;
   }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -219,10 +219,10 @@ body {
 
 @keyframes glow {
   0%, 100% {
-    text-shadow: 0 0 8px currentColor;
+    text-shadow: 0 0 8px var(--name-glow-color, currentColor);
   }
   50% {
-    text-shadow: 0 0 16px currentColor;
+    text-shadow: 0 0 16px var(--name-glow-color, currentColor);
   }
 }
 

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -1832,7 +1832,7 @@
                         {initials(msg)}
                       {/if}
                     </div>
-                    <div class="flex items-baseline gap-2">
+                    <div class="flex min-w-0 items-baseline gap-2">
                       {#if isOwn}
                         {@const effectStyle = nameEffectStyle(profileStore.nameEffect, profileStore.color, profileStore.gradient2 ?? undefined, profileStore.gradient3 ?? undefined, profileStore.nameShimmer, profileStore.nameGlow)}
                         <span
@@ -1842,7 +1842,7 @@
                           onkeydown={(e) => {
                             if (e.key === "Enter") openProfileFromMessage(msg);
                           }}
-                          class="cursor-pointer text-(length:--chat-font-size) font-medium text-primary {displayPrefs.italicOwnName
+                          class="max-w-72 truncate cursor-pointer text-(length:--chat-font-size) font-medium text-primary {displayPrefs.italicOwnName
                             ? 'italic'
                             : ''} {effectStyle.class}"
                           style={effectStyle.style || (profileStore.color ? `color: ${profileStore.color}` : "")}
@@ -1874,7 +1874,7 @@
                           onkeydown={(e) => {
                             if (e.key === "Enter") openProfileFromMessage(msg);
                           }}
-                          class="cursor-pointer text-(length:--chat-font-size) font-medium text-foreground {effectStyle.class}"
+                          class="max-w-72 truncate cursor-pointer text-(length:--chat-font-size) font-medium text-foreground {effectStyle.class}"
                           style={effectStyle.style || (color ? `color: ${color}` : "")}
                         >
                           {displayName(msg)}

--- a/frontend/src/lib/components/SidebarControls.svelte
+++ b/frontend/src/lib/components/SidebarControls.svelte
@@ -205,20 +205,13 @@
           profileStore.nameGlow ?? undefined
         )}
         <div class="flex flex-col gap-1.5 mt-1 w-full min-w-0">
-          <div class="flex items-baseline gap-1 w-full min-w-0">
+          <div class="flex items-baseline w-full min-w-0">
             <span
-              class="truncate flex-1 min-w-0 text-xs font-semibold text-foreground font-mono leading-tight {effectStyle.class}"
+              class="truncate max-w-26 text-xs font-semibold text-foreground font-mono leading-tight {effectStyle.class}"
               style={effectStyle.style ||
                 (profileStore.color ? `color: ${profileStore.color}` : "")}
               >{profileStore.nickname}</span
             >
-            {#if profileStore.tagText}
-              <span
-                class="shrink-0 rounded px-1 py-px font-mono text-[10px] font-semibold uppercase leading-4"
-                style={`background-color: ${profileStore.tagChipColor ?? "#e5e7eb"}; color: ${profileStore.tagTextColor ?? "#000000"}`}
-                >{profileStore.tagText}</span
-              >
-            {/if}
           </div>
           <!-- Connection status text: always shown, not gated on showConnectionInfo.
                That setting controls only the floating panel on the right. -->

--- a/frontend/src/lib/components/SidebarControls.svelte
+++ b/frontend/src/lib/components/SidebarControls.svelte
@@ -20,6 +20,7 @@
     leaveCall,
   } from "$lib/transport/call.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
+  import { nameEffectStyle } from "$lib/name-effect";
   import { displayPrefs } from "$lib/display-prefs.svelte";
   import AvatarPickerDialog from "$lib/components/AvatarPickerDialog.svelte";
   import SettingsDialog from "$lib/components/SettingsDialog.svelte";
@@ -195,11 +196,29 @@
 
       <!-- Name + status -->
       {#if !collapsed}
-        <div class="flex flex-col gap-1.5 mt-1 w-full">
-          <div
-            class="truncate w-26 text-xs font-semibold text-foreground font-mono leading-tight"
-          >
-            {profileStore.nickname}
+        {@const effectStyle = nameEffectStyle(
+          profileStore.nameEffect,
+          profileStore.color ?? undefined,
+          profileStore.gradient2 ?? undefined,
+          profileStore.gradient3 ?? undefined,
+          profileStore.nameShimmer ?? undefined,
+          profileStore.nameGlow ?? undefined
+        )}
+        <div class="flex flex-col gap-1.5 mt-1 w-full min-w-0">
+          <div class="flex items-baseline gap-1 w-full min-w-0">
+            <span
+              class="truncate flex-1 min-w-0 text-xs font-semibold text-foreground font-mono leading-tight {effectStyle.class}"
+              style={effectStyle.style ||
+                (profileStore.color ? `color: ${profileStore.color}` : "")}
+              >{profileStore.nickname}</span
+            >
+            {#if profileStore.tagText}
+              <span
+                class="shrink-0 rounded px-1 py-px font-mono text-[10px] font-semibold uppercase leading-4"
+                style={`background-color: ${profileStore.tagChipColor ?? "#e5e7eb"}; color: ${profileStore.tagTextColor ?? "#000000"}`}
+                >{profileStore.tagText}</span
+              >
+            {/if}
           </div>
           <!-- Connection status text: always shown, not gated on showConnectionInfo.
                That setting controls only the floating panel on the right. -->

--- a/frontend/src/lib/components/UserProfileCard.svelte
+++ b/frontend/src/lib/components/UserProfileCard.svelte
@@ -161,16 +161,16 @@
         {/if}
       </div>
 
-      <div class="flex flex-wrap items-center gap-2 px-1">
+      <div class="flex min-w-0 items-center gap-2 px-1">
         <span
-          class="text-lg font-mono font-semibold {effectStyle.class}"
+          class="min-w-0 flex-1 truncate text-lg font-mono font-semibold {effectStyle.class}"
           style={effectStyle.style || (color ? `color: ${color}` : "")}
         >
           {name}
         </span>
         {#if tagText}
           <div
-            class="px-2 py-1 rounded text-xs font-mono font-semibold uppercase"
+            class="shrink-0 rounded px-2 py-1 text-xs font-mono font-semibold uppercase"
             style={`background-color: ${tagChipColor}; color: ${tagTextColor}`}
           >
             {tagText}

--- a/frontend/src/lib/components/UserProfileCard.svelte
+++ b/frontend/src/lib/components/UserProfileCard.svelte
@@ -163,7 +163,7 @@
 
       <div class="flex min-w-0 items-center gap-2 px-1">
         <span
-          class="min-w-0 flex-1 truncate text-lg font-mono font-semibold {effectStyle.class}"
+          class="w-0 min-w-0 flex-1 truncate text-lg font-mono font-semibold {effectStyle.class}"
           style={effectStyle.style || (color ? `color: ${color}` : "")}
         >
           {name}

--- a/frontend/src/lib/components/UserProfileCard.svelte
+++ b/frontend/src/lib/components/UserProfileCard.svelte
@@ -161,9 +161,9 @@
         {/if}
       </div>
 
-      <div class="flex min-w-0 items-center gap-2 px-1">
+      <div class="flex min-w-0 items-center justify-start gap-2 px-1 text-left">
         <span
-          class="w-0 min-w-0 flex-1 truncate text-lg font-mono font-semibold {effectStyle.class}"
+          class="w-0 min-w-0 flex-1 truncate text-left text-lg font-mono font-semibold {effectStyle.class}"
           style={effectStyle.style || (color ? `color: ${color}` : "")}
         >
           {name}

--- a/frontend/src/lib/components/settings/ProfileSettings.svelte
+++ b/frontend/src/lib/components/settings/ProfileSettings.svelte
@@ -357,6 +357,9 @@
           <input
             type="color"
             bind:value={colorValue}
+            oninput={() => {
+              colorTouched = true;
+            }}
             onchange={() => {
               colorTouched = true;
               saveColor(colorValue).catch(() => {});

--- a/frontend/src/lib/components/settings/ProfileSettings.svelte
+++ b/frontend/src/lib/components/settings/ProfileSettings.svelte
@@ -106,6 +106,7 @@
   }
 
   async function commitGradients() {
+    gradientTouched = true;
     await saveGradientColors(gradient2Value, gradient3Value ?? undefined);
   }
 
@@ -116,6 +117,24 @@
   let gradient3Value = $state<string | null>(null);
   let gradient3El = $state<HTMLInputElement | null>(null);
   let addColorEl = $state<HTMLButtonElement | null>(null);
+  let nameEditorEl = $state<HTMLElement | null>(null);
+  let colorTouched = $state(false);
+  let gradientTouched = $state(false);
+
+  // Native colour pickers take focus outside the page. That produces a
+  // focusout with no destination, but no in-page pointer event. Only a real
+  // pointerdown outside this editor is a click-away.
+  $effect(() => {
+    if (editing !== "name") return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!nameEditorEl) return;
+      const target = e.target;
+      if (!(target instanceof Node) || nameEditorEl.contains(target)) return;
+      void commitName();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  });
 
   const profileInitial = $derived(
     (profileStore.nickname || nameValue || "?").charAt(0).toUpperCase()
@@ -165,6 +184,20 @@
   async function commitName() {
     const trimmed = nameValue.trim();
     if (trimmed && trimmed !== profileStore.nickname) await saveName(trimmed);
+    if (colorTouched) {
+      const color = colorValue || undefined;
+      if (color !== (profileStore.color ?? undefined)) await saveColor(color);
+    }
+    if (gradientTouched) {
+      const gradient2 = gradient2Value || undefined;
+      const gradient3 = gradient3Value || undefined;
+      if (
+        gradient2 !== (profileStore.gradient2 ?? undefined) ||
+        gradient3 !== (profileStore.gradient3 ?? undefined)
+      ) {
+        await saveGradientColors(gradient2, gradient3);
+      }
+    }
     editing = null;
   }
 
@@ -293,23 +326,12 @@
              keeps the layout while giving focusout one shared boundary. -->
         <div
           class="contents"
+          bind:this={nameEditorEl}
           onfocusout={(e) => {
-            // A focused control Svelte just swapped out of the DOM (the
-            // + color button replacing itself with the input) fires
-            // focusout with relatedTarget null - indistinguishable from a
-            // click-away except the target is no longer connected. Only a
-            // still-connected target means focus really left the editor.
-            //
-            // The buttons inside this editor also cancel mousedown so they
-            // never take focus at all (see keepFocus). Relying on
-            // relatedTarget alone was not enough: a browser that does not
-            // focus a button on mousedown reports null, which is
-            // indistinguishable from clicking the page background, so
-            // pressing "+ color" committed and unmounted the editor between
-            // mousedown and mouseup and the click never landed.
             if (!(e.target as HTMLElement).isConnected) return;
             const editor = e.currentTarget as HTMLElement;
-            if (!editor.contains(e.relatedTarget as Node)) commitName();
+            const next = e.relatedTarget as Node | null;
+            if (next && !editor.contains(next)) void commitName();
           }}
         >
         <div class="flex flex-wrap items-center gap-2">
@@ -317,7 +339,7 @@
             use:focusOnMount
             bind:value={nameValue}
             onkeydown={(e) => {
-              if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+              if (e.key === "Enter") void commitName();
               if (e.key === "Escape") {
                 nameValue = profileStore.nickname;
                 editing = null;
@@ -335,7 +357,10 @@
           <input
             type="color"
             bind:value={colorValue}
-            onchange={() => saveColor(colorValue).catch(() => {})}
+            onchange={() => {
+              colorTouched = true;
+              saveColor(colorValue).catch(() => {});
+            }}
             aria-label="Nickname color"
             class="size-7 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0.5"
           />
@@ -471,7 +496,11 @@
         <div class="flex flex-wrap items-center gap-2">
           <button
             type="button"
-            onclick={() => (editing = "name")}
+            onclick={() => {
+              colorTouched = false;
+              gradientTouched = false;
+              editing = "name";
+            }}
             aria-label="Edit name, color and effect"
             class="group flex cursor-pointer items-center gap-1.5"
           >

--- a/frontend/src/lib/components/settings/ProfileSettings.svelte
+++ b/frontend/src/lib/components/settings/ProfileSettings.svelte
@@ -508,10 +508,12 @@
               editing = "name";
             }}
             aria-label="Edit name, color and effect"
-            class="group flex min-w-0 flex-1 cursor-pointer items-center gap-1.5"
+            class="group flex min-w-0 cursor-pointer items-center gap-1.5 {profileStore.tagText
+              ? 'max-w-[calc(100%-3.5rem)]'
+              : 'max-w-full'}"
           >
             <span
-              class="min-w-0 flex-1 truncate text-left font-mono text-base font-semibold {effectStyle.class}"
+              class="min-w-0 truncate text-left font-mono text-base font-semibold {effectStyle.class}"
               style={effectStyle.style ||
                 (profileStore.color ? `color: ${profileStore.color}` : "")}
             >

--- a/frontend/src/lib/components/settings/ProfileSettings.svelte
+++ b/frontend/src/lib/components/settings/ProfileSettings.svelte
@@ -118,6 +118,7 @@
   let gradient3El = $state<HTMLInputElement | null>(null);
   let addColorEl = $state<HTMLButtonElement | null>(null);
   let nameEditorEl = $state<HTMLElement | null>(null);
+  let tagEditorEl = $state<HTMLElement | null>(null);
   let colorTouched = $state(false);
   let gradientTouched = $state(false);
 
@@ -125,12 +126,14 @@
   // focusout with no destination, but no in-page pointer event. Only a real
   // pointerdown outside this editor is a click-away.
   $effect(() => {
-    if (editing !== "name") return;
+    if (editing !== "name" && editing !== "tag") return;
     const onPointerDown = (e: PointerEvent) => {
-      if (!nameEditorEl) return;
+      const editor = editing === "name" ? nameEditorEl : tagEditorEl;
+      if (!editor) return;
       const target = e.target;
-      if (!(target instanceof Node) || nameEditorEl.contains(target)) return;
-      void commitName();
+      if (!(target instanceof Node) || editor.contains(target)) return;
+      if (editing === "name") void commitName();
+      else void commitTag();
     };
     document.addEventListener("pointerdown", onPointerDown, true);
     return () => document.removeEventListener("pointerdown", onPointerDown, true);
@@ -496,7 +499,7 @@
         </div>
         </div>
       {:else}
-        <div class="flex flex-wrap items-center gap-2">
+        <div class="flex min-w-0 items-center gap-2">
           <button
             type="button"
             onclick={() => {
@@ -505,17 +508,17 @@
               editing = "name";
             }}
             aria-label="Edit name, color and effect"
-            class="group flex cursor-pointer items-center gap-1.5"
+            class="group flex min-w-0 flex-1 cursor-pointer items-center gap-1.5"
           >
             <span
-              class="font-mono text-base font-semibold {effectStyle.class}"
+              class="min-w-0 flex-1 truncate font-mono text-base font-semibold {effectStyle.class}"
               style={effectStyle.style ||
                 (profileStore.color ? `color: ${profileStore.color}` : "")}
             >
               {profileStore.nickname || "Anonymous"}
             </span>
             <Pencil
-              class="size-3 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+              class="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
             />
           </button>
 
@@ -525,7 +528,7 @@
                 type="button"
                 onclick={() => (editing = "tag")}
                 aria-label="Edit tag"
-                class="cursor-pointer rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase hover:opacity-80"
+                class="shrink-0 cursor-pointer rounded px-2 py-0.5 font-mono text-xs font-semibold uppercase hover:opacity-80"
                 style={`background-color: ${profileStore.tagChipColor ?? "#e5e7eb"}; color: ${profileStore.tagTextColor ?? "#000000"}`}
               >
                 {profileStore.tagText}
@@ -549,9 +552,12 @@
              check-button-only silently discarded a typed tag on blur. -->
         <div
           class="flex flex-wrap items-center gap-2"
+          bind:this={tagEditorEl}
           onfocusout={(e) => {
+            if (!(e.target as HTMLElement).isConnected) return;
             const row = e.currentTarget as HTMLElement;
-            if (!row.contains(e.relatedTarget as Node)) commitTag();
+            const next = e.relatedTarget as Node | null;
+            if (next && !row.contains(next)) void commitTag();
           }}
         >
           <input
@@ -571,6 +577,8 @@
           <input
             type="color"
             bind:value={tagTextColor}
+            onchange={() =>
+              saveTagColors(tagTextColor || undefined, tagChipColor || undefined).catch(() => {})}
             aria-label="Tag text color"
             title="Text"
             class="size-7 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0.5"
@@ -578,6 +586,8 @@
           <input
             type="color"
             bind:value={tagChipColor}
+            onchange={() =>
+              saveTagColors(tagTextColor || undefined, tagChipColor || undefined).catch(() => {})}
             aria-label="Tag chip color"
             title="Chip"
             class="size-7 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0.5"

--- a/frontend/src/lib/components/settings/ProfileSettings.svelte
+++ b/frontend/src/lib/components/settings/ProfileSettings.svelte
@@ -511,7 +511,7 @@
             class="group flex min-w-0 flex-1 cursor-pointer items-center gap-1.5"
           >
             <span
-              class="min-w-0 flex-1 truncate font-mono text-base font-semibold {effectStyle.class}"
+              class="min-w-0 flex-1 truncate text-left font-mono text-base font-semibold {effectStyle.class}"
               style={effectStyle.style ||
                 (profileStore.color ? `color: ${profileStore.color}` : "")}
             >

--- a/frontend/src/lib/name-effect.test.ts
+++ b/frontend/src/lib/name-effect.test.ts
@@ -58,12 +58,9 @@ describe("nameEffectStyle", () => {
 
       // Must ALSO have text-shadow for glow
       expect(result.style).toContain("text-shadow:");
-      expect(result.style).toContain("0 0 8px");
+      expect(result.style).toContain("0 0 3px");
       expect(result.style).toContain("#3b82f6");
-
-      // Must have both animations
-      expect(result.style).toContain("animation:");
-      expect(result.style).toContain("glow");
+      expect(result.style).not.toContain("animation:");
 
       // Must have glow class
       expect(result.class).toContain("name-effect-glow");
@@ -90,14 +87,13 @@ describe("nameEffectStyle", () => {
       // Must have glow text-shadow
       expect(result.style).toContain("text-shadow:");
 
-      // Must have both animations in one property (comma-separated)
+      // Shimmer remains animated; glow stays static and tight.
       expect(result.style).toContain("animation:");
       const animMatch = result.style.match(/animation:\s*([^;]+)/);
       expect(animMatch).toBeTruthy();
       const animations = animMatch![1];
       expect(animations).toContain("shimmer");
-      expect(animations).toContain("glow");
-      // Should be comma-separated, not two separate animation properties
+      expect(animations).not.toContain("glow");
       expect((result.style.match(/animation:/g) || []).length).toBe(1);
     });
   });
@@ -133,11 +129,11 @@ describe("nameEffectStyle", () => {
 
       // Should have text-shadow
       expect(result.style).toContain("text-shadow:");
-      expect(result.style).toContain("0 0 8px");
+      expect(result.style).toContain("0 0 3px");
 
-      // Should have glow animation
-      expect(result.style).toContain("animation:");
-      expect(result.style).toContain("glow");
+      // Glow stays a tight static halo so it does not bloom into a box around
+      // short names while the text is animated by another fill effect.
+      expect(result.style).not.toContain("animation:");
 
       // Should NOT have background-clip (no fill)
       expect(result.style).not.toContain("background-clip:");
@@ -167,7 +163,9 @@ describe("nameEffectStyle", () => {
         expect(result.style).toContain(`--name-glow-color: ${color}`);
 
         if (effect === undefined) {
-          expect(result.style).toContain(`color: ${color}`);
+          expect(result.style).toMatch(
+            new RegExp(`(?:^|; )color: ${color}(?:;|$)`)
+          );
           expect(result.style).not.toContain("background-clip: text");
         } else {
           expect(result.style).toContain("background-clip: text");

--- a/frontend/src/lib/name-effect.test.ts
+++ b/frontend/src/lib/name-effect.test.ts
@@ -145,6 +145,37 @@ describe("nameEffectStyle", () => {
     });
   });
 
+  describe("glow preserves the selected fill", () => {
+    it.each([
+      [undefined, false, "#d946ef", "solid"],
+      ["gradient", false, "#d946ef", "gradient"],
+      ["gradient", true, "#d946ef", "shimmer"],
+      ["rainbow", false, "#d946ef", "rainbow"],
+    ] as const)(
+      "keeps the %s fill and uses the saved colour for its glow",
+      (effect, shimmer, color, _label) => {
+        const result = nameEffectStyle(
+          effect,
+          color,
+          "#22d3ee",
+          undefined,
+          shimmer,
+          true
+        );
+
+        expect(result.class).toContain("name-effect-glow");
+        expect(result.style).toContain(`--name-glow-color: ${color}`);
+
+        if (effect === undefined) {
+          expect(result.style).toContain(`color: ${color}`);
+          expect(result.style).not.toContain("background-clip: text");
+        } else {
+          expect(result.style).toContain("background-clip: text");
+        }
+      }
+    );
+  });
+
   describe("no effects", () => {
     it("no effects returns empty style", () => {
       const result = nameEffectStyle(undefined, "#3b82f6");

--- a/frontend/src/lib/name-effect.ts
+++ b/frontend/src/lib/name-effect.ts
@@ -170,8 +170,7 @@ export function nameEffectStyle(
   if (model.glow) {
     classes.push("name-effect-glow");
     cssProperties["--name-glow-color"] = color!;
-    cssProperties["text-shadow"] = `0 0 8px ${color}`;
-    animations.push("glow 2s ease-in-out infinite");
+    cssProperties["text-shadow"] = `0 0 3px ${color}`;
   }
 
   if (color && model.fill === "none" && !model.shimmer) {

--- a/frontend/src/lib/name-effect.ts
+++ b/frontend/src/lib/name-effect.ts
@@ -169,8 +169,13 @@ export function nameEffectStyle(
   // -webkit-text-fill-color, so it layers on top of any fill.
   if (model.glow) {
     classes.push("name-effect-glow");
+    cssProperties["--name-glow-color"] = color!;
     cssProperties["text-shadow"] = `0 0 8px ${color}`;
-    animations.push("glow 2s steps(24) infinite");
+    animations.push("glow 2s ease-in-out infinite");
+  }
+
+  if (color && model.fill === "none" && !model.shimmer) {
+    cssProperties["color"] = color;
   }
 
   // Combine animations into a single property to avoid cascade issues


### PR DESCRIPTION
## Summary

This contribution makes profile name customisation reliable across browser and system colour pickers, while keeping long identity labels readable across profile surfaces.

- Preserve nickname-colour selections when native pickers move focus outside the page.
- Apply the same focus-safe colour-picker flow to tag text and chip colours.
- Make glow compose with solid, gradient, shimmer, and rainbow fills without resetting the selected colour.
- Replace the animated glow bloom with a tight static glyph shadow.
- Render name effects in the bottom-left sidebar card.
- Keep tags out of the compact sidebar card, while preserving them alongside names in profile settings and profile cards.
- Add bounded truncation for sidebar, chat, profile-modal, and profile-settings name rows.

## Implementation notes

Native colour pickers can emit a focus loss with no in-page destination. The editor now treats only an outside pointer event as click-away, so picker interaction no longer unmounts the editor before a change is saved. Tag controls follow the same rule and persist each picker change.

Name effects share `nameEffectStyle`, including a stable `--name-glow-color` for all fill modes. Solid names explicitly retain their selected text colour. The glow is now a small non-animated shadow, avoiding the rectangular bloom from the prior animation.

Long-name rows use flex-safe truncation: the name is the shrinkable item, and tags are shrink-protected where they remain visible.

## Validation

- `pnpm test`
  - 60 test files passed
  - 727 tests passed
- `pnpm check`
  - 0 Svelte diagnostics
  - 0 TypeScript errors
- Added coverage for glow composition across solid, gradient, shimmer, and rainbow fills.
- Mutation checks confirmed the tests fail if the glow colour or the solid text-colour property is removed.

## Scope

- `.specs/` is ignored locally and is not included in this PR.