### PR TITLE
peers: a link that reports connected must prove it carries something

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,12 +68,18 @@ TURN_SECRET=
 #PLUGIN_PROXY_SECRETS=STEAM@api.steampowered.com=your-steam-api-key
 
 # X-Forwarded-For hop count and trusted proxy ranges, for the relay behind a
-# reverse proxy or CDN. Comma-separated CIDR blocks. Defaults to private and
-# loopback (127.0.0.0/8, ::1/128, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
-# fc00::/7, fe80::/10), which is correct behind Traefik on a docker network.
-# Overrides that default to handle other topologies: e.g. add Cloudflare IPs
-# if the relay sits behind Cloudflare, so the CDN's hop is skipped when
-# calculating the client IP for rate limiting and plugin proxy requests.
+# reverse proxy or CDN. Comma-separated CIDR blocks.
+#
+# REQUIRED in production, narrowed to Traefik's own address. The default
+# below (private + loopback) is what a fresh checkout ships with, but on
+# docker-compose.dokploy.yml's shared dokploy-network EVERY container gets a
+# 10.x address - not only Traefik - so that default trusts the whole
+# network, not one proxy. Any container on it can set its own
+# X-Forwarded-For and pick its own per-IP rate-limit bucket for
+# /turn-credentials, /invite, /mailbox and /plugin-proxy, defeating all of
+# them. Look up Traefik's actual address on your dokploy-network and set
+# this to that ONE address as a /32 (or /128 for IPv6), not a whole private
+# range.
 #TRUSTED_PROXY_CIDRS=127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7,fe80::/10
 
 # MORE THAN ONE TURN SERVER. Comma-separated, served to clients as-is.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -189,3 +189,22 @@ disjoint worlds: peers registered on one would never discover peers on the
 other, and mail left with one would never reach a client polling the other.
 Federating it needs cross-relay peer exchange and a home relay per mailbox,
 which is a design change rather than a config one.
+
+**Do not set `deploy.replicas` on the relay service.** Nothing in the
+compose or the relay's own code stops it, but the registry and mailbox
+above live in this ONE process's memory and on its ONE volume. A second
+replica would load the same `relay.key` from that shared volume and
+announce the same PeerID, while holding a completely separate, empty
+registry - so half of every room's members would land on one replica and
+half on the other, and each half would never see the other half in its
+`PEERS` reply. The relay logs a warning naming this constraint at boot,
+next to its PeerID, but there is no code check that refuses a second
+replica outright.
+
+**Set `TRUSTED_PROXY_CIDRS` before you go live.** The relay's API port is
+reachable by every container on `dokploy-network`, not only Traefik, and the
+default trusted range (see `.env.example`) is the whole private address
+space - so on this compose shape, ANY container can forge `X-Forwarded-For`
+and pick its own bucket for every per-IP rate limit the relay has
+(`/turn-credentials`, `/invite`, `/mailbox`, `/plugin-proxy`). Narrow it to
+Traefik's own address on your `dokploy-network`, as a single `/32`.

--- a/frontend/src/lib/audio/dtln-processor.test.ts
+++ b/frontend/src/lib/audio/dtln-processor.test.ts
@@ -293,3 +293,41 @@ describe("DtlnProcessor lifecycle", () => {
     await expect(d.waitUntilReady()).rejects.toThrow("crashed during init");
   });
 });
+
+interface CrashableWorklet {
+  onprocessorerror: () => void;
+}
+
+describe("DtlnProcessor fatal callback (finding 1)", () => {
+  it("calls the registered handler when the worklet crashes after init", async () => {
+    const d = await makeProcessor();
+    await d.processStream(micStream);
+    let fatalCalls = 0;
+    d.onFatal(() => {
+      fatalCalls++;
+    });
+
+    // init() rewires node.onprocessorerror to handleFatal once the worklet
+    // is up - this is the browser firing it on a LIVE worklet, not the
+    // init-time crash the other tests cover.
+    const worklet = d.node as unknown as CrashableWorklet;
+    worklet.onprocessorerror();
+
+    expect(fatalCalls).toBe(1);
+    expect(d.isReady()).toBe(false);
+  });
+
+  it("onFatal(null) clears a previously registered handler", async () => {
+    const d = await makeProcessor();
+    let fatalCalls = 0;
+    d.onFatal(() => {
+      fatalCalls++;
+    });
+    d.onFatal(null);
+
+    const worklet = d.node as unknown as CrashableWorklet;
+    worklet.onprocessorerror();
+
+    expect(fatalCalls).toBe(0);
+  });
+});

--- a/frontend/src/lib/audio/dtln-processor.ts
+++ b/frontend/src/lib/audio/dtln-processor.ts
@@ -15,6 +15,14 @@ export class DtlnProcessor {
   private initializing = false;
   private noiseGate = AUDIO_PREF_DEFAULTS.noiseGate;
   private inputGain = 1.0;
+  /**
+   * Told once when the worklet dies after init (finding 1 of the voice
+   * audit): RTP keeps flowing on a track fed by a suspended context - the
+   * sender transmits digital silence forever, with connectionState reading
+   * "connected" on both ends the whole time. LibP2PVoice uses this to
+   * rebuild the mic instead of leaving that peer permanently unheard.
+   */
+  private fatalHandler: (() => void) | null = null;
 
   /**
    * The one compensation for the model's attenuation. The worklet itself is
@@ -139,6 +147,12 @@ export class DtlnProcessor {
     this.ready = false;
     this.initializing = false;
     this.armReadyPromise();
+    this.fatalHandler?.();
+  }
+
+  /** Set (or clear with null) the fatal callback. One slot: one caller owns it. */
+  onFatal(handler: (() => void) | null): void {
+    this.fatalHandler = handler;
   }
 
   /**

--- a/frontend/src/lib/call-quality.test.ts
+++ b/frontend/src/lib/call-quality.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyCallQualityStatus,
+  noteTrackAdded,
+  worstQuality,
+  type PeerVoiceQuality,
+} from "./call-quality";
+
+function m(
+  entries: [string, PeerVoiceQuality][] = []
+): Map<string, PeerVoiceQuality> {
+  return new Map(entries);
+}
+
+describe("applyCallQualityStatus", () => {
+  it("records a p2p verdict on a direct ICE connect", () => {
+    const next = applyCallQualityStatus(m(), {
+      type: "voice-ice-connected",
+      peerId: "a",
+      relayed: false,
+    });
+    expect(next.get("a")).toBe("p2p");
+  });
+
+  it("records a relayed verdict when the ICE event says relayed", () => {
+    const next = applyCallQualityStatus(m(), {
+      type: "voice-ice-connected",
+      peerId: "a",
+      relayed: true,
+    });
+    expect(next.get("a")).toBe("relayed");
+  });
+
+  it("removes only the named peer on voice-peer-left", () => {
+    const peers = m([
+      ["a", "degraded"],
+      ["b", "p2p"],
+    ]);
+    const next = applyCallQualityStatus(peers, {
+      type: "voice-peer-left",
+      peerId: "a",
+    });
+    expect(next.has("a")).toBe(false);
+    expect(next.get("b")).toBe("p2p");
+  });
+
+  it("one peer's degraded event never touches another peer's entry", () => {
+    const peers = m([["b", "p2p"]]);
+    const next = applyCallQualityStatus(peers, {
+      type: "voice-degraded",
+      peerId: "a",
+    });
+    expect(next.get("a")).toBe("degraded");
+    expect(next.get("b")).toBe("p2p");
+  });
+});
+
+describe("noteTrackAdded", () => {
+  it("regression: an unrelated peer's track arriving must not erase this peer's degraded verdict", () => {
+    // This is the exact defect from voice-audit finding 8: a single shared
+    // quality value let ANY peer's trackAdded repaint the whole badge "p2p",
+    // erasing a real, unrelated degradation.
+    let peers = m([["a", "degraded"]]);
+    peers = noteTrackAdded(peers, "b") as Map<string, PeerVoiceQuality>;
+    expect(peers.get("a")).toBe("degraded");
+    expect(peers.get("b")).toBe("p2p");
+  });
+
+  it("does not downgrade a peer's own existing verdict", () => {
+    const peers = m([["a", "failed"]]);
+    const next = noteTrackAdded(peers, "a");
+    expect(next.get("a")).toBe("failed");
+  });
+
+  it("fills in a first verdict for a peer with none yet", () => {
+    const next = noteTrackAdded(m(), "a");
+    expect(next.get("a")).toBe("p2p");
+  });
+});
+
+describe("worstQuality", () => {
+  it("returns null when nobody has a verdict", () => {
+    expect(worstQuality(m())).toBeNull();
+  });
+
+  it("picks failed over degraded over healthy", () => {
+    expect(
+      worstQuality(
+        m([
+          ["a", "p2p"],
+          ["b", "degraded"],
+          ["c", "failed"],
+        ])
+      )
+    ).toBe("failed");
+  });
+
+  it("treats p2p and relayed as equally healthy", () => {
+    expect(
+      worstQuality(
+        m([
+          ["a", "relayed"],
+          ["b", "p2p"],
+        ])
+      )
+    ).not.toBe("degraded");
+  });
+});

--- a/frontend/src/lib/call-quality.ts
+++ b/frontend/src/lib/call-quality.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure per-peer voice call quality derivation, split out of CallStatus.svelte
+ * so it is unit testable without mounting Svelte.
+ *
+ * The component used to hold ONE shared quality value for the whole call.
+ * That let a single peer's "degraded" event paint every tile "poor
+ * connection", and let any OTHER peer's track arriving repaint the whole
+ * badge healthy again a moment later - erasing a real, ongoing degradation
+ * that had nothing to do with the peer whose track just showed up
+ * (voice-audit finding 8). Keying every verdict by peerId makes that
+ * impossible: one peer's state can only ever overwrite its own entry.
+ */
+
+export type PeerVoiceQuality = "p2p" | "relayed" | "degraded" | "failed";
+
+const QUALITY_RANK: Record<PeerVoiceQuality, number> = {
+  p2p: 0,
+  relayed: 0,
+  degraded: 1,
+  failed: 2,
+};
+
+export type CallQualityStatusEvent =
+  | { type: "voice-ice-connected"; peerId: string; relayed: boolean }
+  | { type: "voice-connection-failed"; peerId: string }
+  | { type: "voice-degraded"; peerId: string }
+  | { type: "voice-peer-left"; peerId: string };
+
+function withPeer(
+  peers: ReadonlyMap<string, PeerVoiceQuality>,
+  peerId: string,
+  quality: PeerVoiceQuality
+): ReadonlyMap<string, PeerVoiceQuality> {
+  if (peers.get(peerId) === quality) return peers;
+  const next = new Map(peers);
+  next.set(peerId, quality);
+  return next;
+}
+
+/**
+ * Apply one transport status event to the per-peer quality map. Returns the
+ * SAME map instance when nothing changed, so a caller assigning the result
+ * into `$state` can skip a reactive update.
+ */
+export function applyCallQualityStatus(
+  peers: ReadonlyMap<string, PeerVoiceQuality>,
+  event: CallQualityStatusEvent
+): ReadonlyMap<string, PeerVoiceQuality> {
+  switch (event.type) {
+    case "voice-ice-connected":
+      return withPeer(peers, event.peerId, event.relayed ? "relayed" : "p2p");
+    case "voice-connection-failed":
+      return withPeer(peers, event.peerId, "failed");
+    case "voice-degraded":
+      return withPeer(peers, event.peerId, "degraded");
+    case "voice-peer-left": {
+      if (!peers.has(event.peerId)) return peers;
+      const next = new Map(peers);
+      next.delete(event.peerId);
+      return next;
+    }
+  }
+}
+
+/**
+ * A track is proof a peer has SOME link, but says nothing about the path -
+ * never overwrite an existing verdict (an ICE event, or a prior failure)
+ * with the mere fact that a track arrived. Only fills in peers with no
+ * verdict yet, so an unrelated peer's track can never erase this peer's
+ * degradation.
+ */
+export function noteTrackAdded(
+  peers: ReadonlyMap<string, PeerVoiceQuality>,
+  peerId: string
+): ReadonlyMap<string, PeerVoiceQuality> {
+  if (peers.has(peerId)) return peers;
+  return withPeer(peers, peerId, "p2p");
+}
+
+/** Worst (most alarming) quality across every peer with a known verdict. */
+export function worstQuality(
+  peers: ReadonlyMap<string, PeerVoiceQuality>
+): PeerVoiceQuality | null {
+  let worst: PeerVoiceQuality | null = null;
+  for (const q of peers.values()) {
+    if (worst === null || QUALITY_RANK[q] > QUALITY_RANK[worst]) worst = q;
+  }
+  return worst;
+}

--- a/frontend/src/lib/components/CallStatus.svelte
+++ b/frontend/src/lib/components/CallStatus.svelte
@@ -18,6 +18,12 @@
   import { onMount, onDestroy } from "svelte";
   import { cn } from "$lib/utils";
   import type { TransportStatus } from "$lib/transport/types";
+  import {
+    applyCallQualityStatus,
+    noteTrackAdded,
+    worstQuality,
+    type PeerVoiceQuality,
+  } from "$lib/call-quality";
 
   interface Props {
     /** Icon-rail layout: one icon, the whole status in a tooltip. */
@@ -27,7 +33,22 @@
 
   type CallQuality = "connecting" | "p2p" | "relayed" | "degraded" | "failed";
 
-  let quality = $state<CallQuality>("connecting");
+  // Per-peer voice link quality, keyed by peerId. A single shared value let
+  // one peer's "degraded" paint the whole call, and let any OTHER peer's
+  // trackAdded erase it moments later (voice-audit finding 8) - keying by
+  // peerId makes that impossible. transportQuality is a separate axis: the
+  // relay itself can fail while every peer's own verdict is still the
+  // healthy one from before the drop.
+  let peerQuality = $state<Map<string, PeerVoiceQuality>>(new Map());
+  let transportQuality = $state<"ok" | "degraded" | "failed">("ok");
+
+  const QUALITY_RANK: Record<CallQuality, number> = {
+    connecting: 0,
+    p2p: 1,
+    relayed: 1,
+    degraded: 2,
+    failed: 3,
+  };
 
   let handlers: (() => void)[] = [];
 
@@ -82,56 +103,57 @@
 
     const handleStatus = (status: TransportStatus) => {
       switch (status.type) {
+        case "relay-connected":
+          transportQuality = "ok";
+          break;
         case "relay-disconnected":
-          quality = "failed";
+          transportQuality = "failed";
           break;
         case "relay-reconnecting":
-          quality = "degraded";
+          transportQuality = "degraded";
           break;
         case "relay-reconnect-failed":
-          quality = "failed";
+          transportQuality = "failed";
           break;
         case "voice-ice-connected":
-          quality = status.relayed ? "relayed" : "p2p";
-          break;
         case "voice-connection-failed":
-          quality = "failed";
-          break;
-        case "voice-peer-left":
-          if ((_voice?.activePeers().length ?? 0) === 0) {
-            quality = "connecting";
-          }
-          break;
         case "voice-degraded":
-          quality = "degraded";
+        case "voice-peer-left":
+          peerQuality = new Map(applyCallQualityStatus(peerQuality, status));
           break;
       }
     };
 
-    const handleTrackAdded = () => {
+    const handleTrackAdded = (peerId: string) => {
       // A track is proof of connection but says nothing about the path -
-      // never overwrite the ICE event's relayed verdict with "p2p".
-      if (quality === "connecting" || quality === "degraded") quality = "p2p";
-    };
-
-    const handleTrackRemoved = () => {
-      if ((_voice?.activePeers().length ?? 0) === 0) {
-        quality = "connecting";
-      }
+      // never overwrite an existing verdict, ours or another peer's, with
+      // the mere fact that a track arrived.
+      peerQuality = new Map(noteTrackAdded(peerQuality, peerId));
     };
 
     _transport.on("status", handleStatus);
     _voice?.on("trackAdded", handleTrackAdded);
-    _voice?.on("trackRemoved", handleTrackRemoved);
 
     handlers = [
       () => _transport?.off("status", handleStatus),
       () => _voice?.off("trackAdded", handleTrackAdded),
-      () => _voice?.off("trackRemoved", handleTrackRemoved),
     ];
   });
 
   onDestroy(() => handlers.forEach((h) => h()));
+
+  // The one summary badge: the worse of "is the relay itself in trouble"
+  // and "is any peer's own voice link in trouble" - never a value some
+  // unrelated peer's event can stomp.
+  const quality = $derived.by<CallQuality>(() => {
+    const worst = worstQuality(peerQuality);
+    const peerLevel: CallQuality = worst ?? "connecting";
+    const transportLevel: CallQuality =
+      transportQuality === "ok" ? "connecting" : transportQuality;
+    return QUALITY_RANK[transportLevel] >= QUALITY_RANK[peerLevel]
+      ? transportLevel
+      : peerLevel;
+  });
 
   // "Connected" used to flip on the FIRST peer while the rest were still
   // handshaking - true for one friend, false for the call. Compare who is

--- a/frontend/src/lib/components/TransportStatus.svelte
+++ b/frontend/src/lib/components/TransportStatus.svelte
@@ -144,9 +144,6 @@
         case "voice-dial-failed":
           addStatus("error", status.message, PhoneOff);
           break;
-        case "voice-dial-retrying":
-          addStatus("warning", status.message, RefreshCw);
-          break;
         case "voice-peer-left":
           addStatus("disconnected", status.message, PhoneOff);
           break;

--- a/frontend/src/lib/components/UserListSidebar.svelte
+++ b/frontend/src/lib/components/UserListSidebar.svelte
@@ -10,6 +10,10 @@
   } from "$lib/transport/transport.svelte";
   import { looksLikePeerId } from "$lib/identity/identity-utils";
   import {
+    derivePeerOnlineState,
+    PEER_PROOF_GRACE_MS,
+  } from "$lib/peer-online-status";
+  import {
     openDmPanel,
     addToPhonebook,
     removeFromPhonebook,
@@ -63,6 +67,7 @@
     tagTextColor: string | null;
     tagChipColor: string | null;
     isOnline: boolean;
+    isConnecting: boolean;
     isSelf: boolean;
     isRelayed: boolean;
     inCall: boolean;
@@ -84,6 +89,41 @@
     getRoomUsers();
   });
 
+  // When each currently-connected peer id was first observed, so the grace
+  // window below measures from the actual connect, not from whenever this
+  // component happened to re-render.
+  let connectedSince = $state(new Map<string, number>());
+  $effect(() => {
+    const nowTs = Date.now();
+    const next = new Map(connectedSince);
+    let changed = false;
+    for (const p of peers) {
+      if (!next.has(p)) {
+        next.set(p, nowTs);
+        changed = true;
+      }
+    }
+    for (const p of [...next.keys()]) {
+      if (!peers.includes(p)) {
+        next.delete(p);
+        changed = true;
+      }
+    }
+    if (changed) connectedSince = next;
+  });
+
+  // A connected-but-unproven peer must downgrade from "online" to
+  // "connecting" on its own once the grace window elapses, not only the
+  // next time some other reactive input happens to change - so this needs
+  // its own clock, not a derivation of state that only ticks on its own.
+  let now = $state(Date.now());
+  $effect(() => {
+    const tick = setInterval(() => {
+      now = Date.now();
+    }, 500);
+    return () => clearInterval(tick);
+  });
+
   const users = $derived.by(() => {
     const allUsers: User[] = [];
 
@@ -97,12 +137,29 @@
         connectedPeerId ??
         didToPeerId(did) ??
         (looksLikePeerId(did) ? did : null);
-      const directlyConnected = peers.includes(did);
-      const isOnline =
-        isSelf ||
-        !!connectedPeerId ||
-        directlyConnected ||
-        (!!mappedPeerId && peers.includes(mappedPeerId));
+      // Which member of `peers` (if any) is this user's connected id -
+      // libp2p's connectedPeers says nothing about whether a frame can
+      // reach them, so "connected" and "proven" are checked separately
+      // (libp2p-audit finding 1).
+      const onlinePeerId = connectedPeerId ??
+        (peers.includes(did)
+          ? did
+          : mappedPeerId && peers.includes(mappedPeerId)
+            ? mappedPeerId
+            : null);
+      const proven = !!onlinePeerId && transportState.provenPeers.has(onlinePeerId);
+      const connectedSinceMs = onlinePeerId
+        ? connectedSince.get(onlinePeerId)
+        : undefined;
+      const { isOnline, isConnecting } = isSelf
+        ? { isOnline: true, isConnecting: false }
+        : derivePeerOnlineState(
+            !!onlinePeerId,
+            proven,
+            connectedSinceMs,
+            now,
+            PEER_PROOF_GRACE_MS
+          );
       const relayedPeerId = connectedPeerId ?? mappedPeerId;
       const userIsRelayed =
         !!relayedPeerId && isOnline && isRelayed(relayedPeerId);
@@ -187,6 +244,7 @@
         nameShimmer,
         nameGlow,
         isOnline,
+        isConnecting,
         isSelf,
         isRelayed: userIsRelayed,
         inCall,
@@ -204,6 +262,8 @@
       if (!a.isSelf && b.isSelf) return 1;
       if (a.isOnline && !b.isOnline) return -1;
       if (!a.isOnline && b.isOnline) return 1;
+      if (a.isConnecting && !b.isConnecting) return -1;
+      if (!a.isConnecting && b.isConnecting) return 1;
       return a.name.localeCompare(b.name);
     });
   });
@@ -348,7 +408,9 @@
       <div
         class="absolute -bottom-0.5 -right-0.5 size-3 rounded-full border-2 border-background {user.isOnline
           ? 'bg-green-500'
-          : 'bg-muted-foreground'}"
+          : user.isConnecting
+            ? 'bg-yellow-500'
+            : 'bg-muted-foreground'}"
       ></div>
     </div>
     <div class="min-w-0 flex-1">
@@ -399,7 +461,9 @@
             ? "In call"
             : user.isOnline
               ? "Online"
-              : "Offline"}
+              : user.isConnecting
+                ? "Connecting"
+                : "Offline"}
       </div>
     </div>
   </div>

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -3,6 +3,7 @@
   import { formatReactorNames } from "$lib/reaction-names";
   import GifImage from "./GifImage.svelte";
   import { RELAY_TIP } from "$lib/copy";
+  import { applyVoiceLinkStatus } from "$lib/voice-link-status";
   import { openDmPanel } from "$lib/transport/dm.svelte";
   import {
     getVoicePeerVolume,
@@ -103,6 +104,10 @@ import {
     deafened?: boolean;
     /** Announced in the call but their voice link is not up yet. */
     connecting?: boolean;
+    /** getStats saw the consumer stop advancing - a track object exists
+     *  but proves nothing about whether RTP is still arriving
+     *  (sfu-audit finding 14). */
+    stalled?: boolean;
     /** True when this is a screen-share transmission tile that hasn't been joined yet. */
     isPending?: boolean;
     /** The SFU producerId - only set on pending transmission tiles. */
@@ -250,23 +255,15 @@ import {
     if (peerId) await openDmPanel(peerId);
   }
 
-  // Peers whose voice ICE actually completed - a roster tile without a track
-  // AND without this is still connecting, and must not render as present.
+  // Peers whose voice ICE actually completed - a roster tile without a
+  // track AND without this is still connecting, and must not render as
+  // present. Insert and delete key are the SAME reducer, so they can never
+  // drift apart the way an insert-by-full-id/delete-by-short-id split once
+  // did (voice-audit finding 8) - a torn-down peer always leaves this set.
   let iceConnectedPeers = $state(new Set<string>());
   $effect(() => {
     const onStatus = (st: { type: string; peerId?: string }) => {
-      if (st.type === "voice-ice-connected" && st.peerId) {
-        iceConnectedPeers = new Set([...iceConnectedPeers, st.peerId]);
-      }
-      if (
-        (st.type === "voice-peer-left" ||
-          st.type === "voice-connection-failed") &&
-        st.peerId
-      ) {
-        const next = new Set(iceConnectedPeers);
-        next.delete(st.peerId);
-        iceConnectedPeers = next;
-      }
+      iceConnectedPeers = new Set(applyVoiceLinkStatus(iceConnectedPeers, st));
     };
     _transport?.on("status", onStatus);
     return () => _transport?.off("status", onStatus);
@@ -357,6 +354,8 @@ import {
         videoTrack: null,
         screenTrack: null,
         screenAudioTrack: null,
+        videoStalled: false,
+        screenStalled: false,
       };
       const label = getPeerLabel(peerId);
       const avatarUrl = getPeerAvatar(peerId);
@@ -374,6 +373,7 @@ import {
         deafened: remoteCallState?.deafened,
         connecting:
           !p.audioTrack && !p.videoTrack && !iceConnectedPeers.has(peerId),
+        stalled: p.videoStalled,
       });
     }
     if (localScreenTrack) {
@@ -399,6 +399,7 @@ import {
           kind: "screen",
           videoTrack: p.screenTrack,
           peerId: p.peerId,
+          stalled: p.screenStalled,
         });
       }
     }
@@ -1176,6 +1177,26 @@ import {
           class="rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs font-mono text-foreground shadow-sm transition-all group-hover:border-primary/50 group-hover:shadow-md"
         >
           Watch {tile.label}'s screen
+        </div>
+      </div>
+    {/if}
+
+    <!-- Stalled overlay: getStats saw the consumer stop advancing. A track
+         object is proof a consumer exists, not that RTP still arrives
+         (sfu-audit finding 14) - this is the honest signal instead. -->
+    {#if tile.stalled && hasVideo}
+      <div
+        class="pointer-events-none absolute inset-0 grid place-items-center bg-background/50"
+      >
+        <div
+          class="flex items-center gap-1.5 rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs font-mono text-foreground shadow-sm"
+        >
+          {#if tile.kind === "screen"}
+            <MonitorOff class="size-3.5" />
+          {:else}
+            <CameraOff class="size-3.5" />
+          {/if}
+          Frozen - reconnecting
         </div>
       </div>
     {/if}

--- a/frontend/src/lib/peer-online-status.test.ts
+++ b/frontend/src/lib/peer-online-status.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { derivePeerOnlineState, PEER_PROOF_GRACE_MS } from "./peer-online-status";
+
+describe("derivePeerOnlineState", () => {
+  it("is fully offline when not connected at all", () => {
+    const state = derivePeerOnlineState(false, false, undefined, 0, PEER_PROOF_GRACE_MS);
+    expect(state).toEqual({ isOnline: false, isConnecting: false });
+  });
+
+  it("is online immediately once the stream is proven", () => {
+    const state = derivePeerOnlineState(true, true, 0, 0, PEER_PROOF_GRACE_MS);
+    expect(state).toEqual({ isOnline: true, isConnecting: false });
+  });
+
+  it("reads online, not connecting, inside the grace window with no proof yet", () => {
+    // Regression for libp2p-audit finding 1's UI half: a peer connected
+    // 1s ago with no proof yet must not flicker to "Connecting" - the
+    // ordinary handshake has not had time to confirm.
+    const state = derivePeerOnlineState(
+      true,
+      false,
+      1000,
+      2000,
+      PEER_PROOF_GRACE_MS
+    );
+    expect(state).toEqual({ isOnline: true, isConnecting: false });
+  });
+
+  it("downgrades to connecting once the grace window elapses with no proof", () => {
+    const state = derivePeerOnlineState(
+      true,
+      false,
+      0,
+      PEER_PROOF_GRACE_MS + 1,
+      PEER_PROOF_GRACE_MS
+    );
+    expect(state).toEqual({ isOnline: false, isConnecting: true });
+  });
+
+  it("regression: a peer connected with zero proof and no grace start never renders as plain online", () => {
+    // This is libp2p-audit finding 1 exactly: connectedPeers gained the peer
+    // with no proof check at all. connectedSinceMs undefined means the
+    // caller never observed a connect for this peer - it must not default
+    // to "online".
+    const state = derivePeerOnlineState(
+      true,
+      false,
+      undefined,
+      1_000_000,
+      PEER_PROOF_GRACE_MS
+    );
+    expect(state.isOnline).toBe(false);
+    expect(state.isConnecting).toBe(true);
+  });
+
+  it("treats exactly the grace boundary as still within grace", () => {
+    const state = derivePeerOnlineState(
+      true,
+      false,
+      0,
+      PEER_PROOF_GRACE_MS - 1,
+      PEER_PROOF_GRACE_MS
+    );
+    expect(state.isOnline).toBe(true);
+  });
+});

--- a/frontend/src/lib/peer-online-status.ts
+++ b/frontend/src/lib/peer-online-status.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure derivation of a peer's online/connecting/offline display state.
+ *
+ * The transport's own connected-peers membership says nothing about whether
+ * a frame can actually reach the peer (libp2p-audit finding 1). A peer with
+ * a connection but no proven stream used to render as a plain green
+ * "Online" dot, identical to a peer whose stream is confirmed carrying
+ * traffic. This computes the distinction, with a grace window so the
+ * ordinary handshake - every peer is briefly connected-without-proof while
+ * its stream confirms - never flickers into "Connecting" on a normal fast
+ * join.
+ */
+
+export const PEER_PROOF_GRACE_MS = 3000;
+
+export interface PeerOnlineState {
+  /** Render the solid "Online" state. */
+  isOnline: boolean;
+  /** Render the distinct "Connecting" state - connected, but unproven past grace. */
+  isConnecting: boolean;
+}
+
+/**
+ * @param connected The peer is a member of the transport's connected set.
+ * @param proven The peer's stream is confirmed to carry traffic.
+ * @param connectedSinceMs When this peer was first seen connected, or
+ *   undefined if it is not currently tracked as connected.
+ * @param nowMs Current time.
+ * @param graceMs Window after first connecting during which an unproven
+ *   peer still reads "online" rather than "connecting".
+ */
+export function derivePeerOnlineState(
+  connected: boolean,
+  proven: boolean,
+  connectedSinceMs: number | undefined,
+  nowMs: number,
+  graceMs: number
+): PeerOnlineState {
+  if (!connected) return { isOnline: false, isConnecting: false };
+  if (proven) return { isOnline: true, isConnecting: false };
+  const withinGrace =
+    connectedSinceMs !== undefined && nowMs - connectedSinceMs < graceMs;
+  return { isOnline: withinGrace, isConnecting: !withinGrace };
+}

--- a/frontend/src/lib/transport/call-lifecycle.test.ts
+++ b/frontend/src/lib/transport/call-lifecycle.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// call.svelte.ts pulls in the real transport singletons (transport.svelte.ts
+// builds a libp2p node at import time - see the comment in call-error.ts),
+// so every dependency it touches gets a plain mock here instead.
+
+vi.mock("$lib/sounds", () => ({
+  playCameraOffSound: vi.fn(async () => {}),
+  playCameraOnSound: vi.fn(async () => {}),
+  playDeafenSound: vi.fn(async () => {}),
+  playJoinSound: vi.fn(async () => {}),
+  playLeaveSound: vi.fn(async () => {}),
+  playMuteSound: vi.fn(async () => {}),
+  playScreenShareStartSound: vi.fn(async () => {}),
+  playScreenShareStopSound: vi.fn(async () => {}),
+  playUndeafenSound: vi.fn(async () => {}),
+  playUnmuteSound: vi.fn(async () => {}),
+}));
+
+vi.mock("./transmission.svelte", () => ({
+  setTransmissionOutputVolume: vi.fn(),
+}));
+
+// A plain object standing in for the real $state-backed transportState -
+// reactivity is irrelevant here, only the field values call.svelte.ts reads
+// and writes.
+const transportState: Record<string, unknown> = {
+  roomCode: "room1",
+  relayConnected: true,
+  inCall: false,
+  callRoomCode: null,
+  joiningCall: false,
+  muted: false,
+  deafened: false,
+  transmissionOutputVolume: 1,
+  localMicStream: null,
+  localCameraStream: null,
+  localScreenStream: null,
+  cameraOff: true,
+  screenSharing: false,
+  participants: new Map(),
+  pendingTransmissions: new Map(),
+  transmissionViewers: new Map(),
+  watchingTransmissionPeerId: null,
+  watchingTransmissionProducerId: null,
+  error: null,
+};
+
+let outputVolume = 1;
+let voiceMuted = false;
+const voiceMock = {
+  join: vi.fn(async () => {}),
+  leave: vi.fn(),
+  isMuted: () => voiceMuted,
+  mute: vi.fn(() => {
+    voiceMuted = true;
+  }),
+  unmute: vi.fn(() => {
+    voiceMuted = false;
+  }),
+  getMicStream: () => null,
+  getOutputVolume: () => outputVolume,
+  setOutputVolume: (v: number) => {
+    outputVolume = v;
+  },
+};
+
+const videoMock = {
+  join: vi.fn(async () => {}),
+  leave: vi.fn(),
+  ensureLive: vi.fn(),
+  stopCamera: vi.fn(),
+  stopScreenShare: vi.fn(),
+};
+
+const transportMock = {
+  reconcileNow: vi.fn(),
+  selfId: () => "self-id",
+  send: vi.fn(),
+  broadcast: vi.fn(),
+  peers: () => [] as string[],
+  announce: vi.fn(),
+};
+
+const syncVoiceRoster = vi.fn();
+
+vi.mock("./transport.svelte", () => ({
+  transportState,
+  _transport: transportMock,
+  _video: videoMock,
+  _voice: voiceMock,
+  _syncVoiceRoster: syncVoiceRoster,
+  connect: vi.fn(async () => {}),
+}));
+
+// Dynamic import, matching files-announce.test.ts/files-inline.test.ts: the
+// vi.mock calls above must resolve before call.svelte.ts's own top-level
+// `import { ... } from "./transport.svelte"` runs, and only a module loaded
+// after those mocks land observes the mocked version.
+const { joinCall, leaveCall, setDeafened } = await import("./call.svelte");
+
+beforeEach(() => {
+  transportState.roomCode = "room1";
+  transportState.relayConnected = true;
+  transportState.inCall = false;
+  transportState.callRoomCode = null;
+  transportState.deafened = false;
+  transportState.muted = false;
+  transportState.transmissionOutputVolume = 1;
+  outputVolume = 1;
+  voiceMuted = false;
+  syncVoiceRoster.mockReset();
+  videoMock.join.mockReset();
+  videoMock.join.mockImplementation(async () => {});
+});
+
+afterEach(() => {
+  // Every test that joins leaves a presence heartbeat interval running;
+  // leaveCall() is the only thing that clears it.
+  leaveCall();
+});
+
+describe("_joinCall roster sequencing (finding 6)", () => {
+  it("sets inCall/callRoomCode before the FIRST roster sync, not after _video.join()", async () => {
+    const snapshots: Array<{ inCall: unknown; callRoomCode: unknown }> = [];
+    syncVoiceRoster.mockImplementation(() => {
+      snapshots.push({
+        inCall: transportState.inCall,
+        callRoomCode: transportState.callRoomCode,
+      });
+    });
+    // _video.join() never resolves during this assertion window - if the
+    // first sync ran before inCall/callRoomCode were set (the bug), it
+    // would still see the stale values here since nothing else touches
+    // them until after this same await.
+    let resolveVideoJoin: () => void = () => {};
+    videoMock.join.mockImplementation(
+      () => new Promise<void>((resolve) => (resolveVideoJoin = resolve))
+    );
+
+    const joined = joinCall();
+    // Let the microtask queue drain up to the point _video.join() is
+    // in flight and awaiting.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Resolve BEFORE asserting: on a failing assertion, an un-resolved
+    // _video.join() would leave _joinPromise pending forever and hang
+    // every later test that calls joinCall() again.
+    resolveVideoJoin();
+    await joined;
+
+    expect(snapshots.length).toBeGreaterThanOrEqual(1);
+    // Before the fix this was {inCall: false, callRoomCode: null} - an
+    // empty roster (default-deny, nobody admitted) for the whole
+    // _video.join() round trip (finding 6).
+    expect(snapshots[0]).toEqual({ inCall: true, callRoomCode: "room1" });
+  });
+});
+
+describe("deafen, leave, rejoin: peer gain is not stuck at 0 (finding 5)", () => {
+  it("restores voice output volume on leaveCall when deafened", async () => {
+    await joinCall();
+    expect(outputVolume).toBe(1);
+
+    setDeafened(true);
+    expect(outputVolume).toBe(0);
+
+    leaveCall();
+    // Before the fix, leaveCall only wrote transportState.deafened = false
+    // directly and never told _voice to restore its gain - so the NEXT
+    // join's setupRemoteAudio would seed every peer's gain node at
+    // currentOutputVolume(0) * peerVolume, leaving every peer silent while
+    // the deafen icon read normal.
+    expect(outputVolume).not.toBe(0);
+    expect(transportState.deafened).toBe(false);
+  });
+
+  it("does not touch voice output volume on a leave that was never deafened", () => {
+    leaveCall();
+    expect(outputVolume).toBe(1);
+  });
+});

--- a/frontend/src/lib/transport/call.svelte.ts
+++ b/frontend/src/lib/transport/call.svelte.ts
@@ -20,7 +20,6 @@ import {
   connect,
   transportState,
 } from "./transport.svelte";
-import type { VideoSource } from "./types";
 import { setTransmissionOutputVolume } from "./transmission.svelte";
 import {
   cancelErrorClear,
@@ -157,15 +156,15 @@ async function _joinCall(): Promise<void> {
     _transport.reconcileNow();
     await _voice.join(transportState.roomCode ?? "");
     throwIfAbandoned();
-    // Close the default-deny window right away: incoming voice signals are
-    // rejected until setCallPeers() is called at least once.
-    // _video.join() below is a network round trip, and without this call the
-    // voice layer would sit rosterless for its
-    // whole duration. transportState.inCall/.callRoomCode are not set yet at
-    // this point, so this first pass syncs an empty roster (default-deny with
-    // nobody admitted) - the real roster lands with the call below, and the
-    // reconcile tick (VOICE_RECONCILE_MS) plus the presence heartbeat pick up
-    // anyone still missing from there.
+    // Set before the first roster sync below: _syncVoiceRoster reads inCall
+    // and callRoomCode to know who belongs in this call. Setting them AFTER
+    // _video.join() used to hand the voice layer an empty roster (default-
+    // deny, nobody admitted) for that whole network round trip - every
+    // offer arriving in that window was silently dropped, sometimes for the
+    // full 30s setup deadline (finding 6). Voice is peer-to-peer and does
+    // not depend on the SFU, so there is no reason this waits for it.
+    transportState.inCall = true;
+    transportState.callRoomCode = transportState.roomCode; // Track which room the call is in
     _syncVoiceRoster();
     // Voice is peer-to-peer; only camera and screen share go through the SFU.
     // Awaiting this unguarded meant a media server that was down (or a VPS
@@ -179,11 +178,8 @@ async function _joinCall(): Promise<void> {
       _video.ensureLive();
     }
     throwIfAbandoned();
-    transportState.inCall = true;
-    transportState.callRoomCode = transportState.roomCode; // Track which room the call is in
     // Peers already in this call are known from their presence heartbeats -
-    // hand them over now rather than waiting for the next heartbeat, which is
-    // the difference between hearing people at once and 20s of silence.
+    // sync again in case one arrived while _video.join() was in flight.
     _syncVoiceRoster();
     acquireWakeLock();
     playJoinSound();
@@ -249,6 +245,12 @@ export function leaveCall(): void {
   }
   stopCamera();
   stopScreenShare();
+  // Deafened, then left: setOutputVolume(0) zeroed _voice's persisted gain
+  // and leave() never resets it, so the NEXT join seeded every peer's gain
+  // node at 0 while the deafen icon read normal (finding 5). setDeafened(
+  // false) restores it to what it was before deafening; guarded so a
+  // non-deafened leave (the common path) does not play the undeafen chime.
+  if (transportState.deafened) setDeafened(false);
   _voice.leave();
   _video.leave();
   transportState.inCall = false;
@@ -261,7 +263,6 @@ export function leaveCall(): void {
   transportState.localMicStream = null;
   transportState.cameraOff = true;
   transportState.screenSharing = false;
-  transportState.sfuPeerIds = new Set();
   transportState.pendingTransmissions = new Map();
   transportState.transmissionViewers = new Map();
   transportState.watchingTransmissionPeerId = null;
@@ -454,13 +455,6 @@ export function stopScreenShare(): void {
   transportState.screenSharing = false;
   playScreenShareStopSound();
   _video.stopScreenShare();
-}
-
-export function pauseVideo(source: VideoSource): void {
-  _video.pauseVideo(source);
-}
-export function resumeVideo(source: VideoSource): void {
-  _video.resumeVideo(source);
 }
 
 export function setDeafened(deafened: boolean): void {

--- a/frontend/src/lib/transport/ice-server-list.test.ts
+++ b/frontend/src/lib/transport/ice-server-list.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getIceServers,
+  refreshTurnCredentials,
+  _resetIceServersForTest,
+} from "./ice-server-list";
+
+// The real endpoint returns username, credential, ttl (seconds) and urls, or
+// a 204 when TURN_SECRET is unset (relay/turn.go).
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => "application/json" },
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function noContentResponse(): Response {
+  return {
+    ok: true,
+    status: 204,
+    headers: { get: () => null },
+    json: async () => {
+      throw new Error("must not be parsed for a 204");
+    },
+  } as unknown as Response;
+}
+
+const credential = (ttl: number) => ({
+  username: "1234567890:abcd",
+  credential: "c29tZS1obWFj",
+  ttl,
+  urls: ["turn:relay.example.com:3478?transport=udp"],
+});
+
+describe("refreshTurnCredentials", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetIceServersForTest();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("re-arms itself at half the ttl, so a day-old tab keeps a live credential", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(credential(7200))); // 2h, relay/turn.go's TTL
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshTurnCredentials();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      getIceServers().some((s) => s.username === credential(7200).username)
+    ).toBe(true);
+
+    // Nothing happens before half the ttl (relay-audit.md finding 3: the
+    // old code never refreshed at all, so this window used to run out).
+    await vi.advanceTimersByTimeAsync(3599 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the previous timer instead of stacking a second refresh chain", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(credential(7200)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshTurnCredentials();
+    await refreshTurnCredentials(); // e.g. a second connect() in the same session
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(3600 * 1000);
+    // One re-arm from the second call, not two: had the first call's timer
+    // survived, this would be 4.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("stays STUN-only and schedules nothing on a 204 (TURN_SECRET unset)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(noContentResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshTurnCredentials();
+    expect(getIceServers()).toHaveLength(2); // STUN only
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // never re-armed
+  });
+
+  it("does not schedule a refresh when the response has no usable ttl", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        username: "1234567890:abcd",
+        credential: "c29tZS1obWFj",
+        urls: ["turn:relay.example.com:3478?transport=udp"],
+        // ttl omitted
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await refreshTurnCredentials();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a network error and leaves the list STUN-only", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(refreshTurnCredentials()).resolves.toBeUndefined();
+    expect(getIceServers()).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/transport/ice-server-list.ts
+++ b/frontend/src/lib/transport/ice-server-list.ts
@@ -43,9 +43,25 @@ function withTurn(turn: RTCIceServer): RTCIceServer[] {
 // credentialled TURN entry.
 let cached: RTCIceServer[] = [...STUN_SERVERS];
 
+// Pending self-refresh timer. connect() calls refreshTurnCredentials() once
+// per session today, but nothing enforces that, and the function also
+// calls itself - so every call clears whatever is already pending first,
+// and only one refresh chain is ever running at a time.
+// The handle type differs between the browser and Node, and @types/node is in
+// scope here, so it is named rather than pinned to `number`.
+type TimerHandle = ReturnType<typeof setTimeout>;
+let refreshTimer: TimerHandle | undefined;
+
 /** ICE servers for a new RTCPeerConnection. Read synchronously at PC creation. */
 export function getIceServers(): RTCIceServer[] {
   return cached;
+}
+
+/** Test seam: a fresh module per case is not worth a vi.resetModules dance. */
+export function _resetIceServersForTest(): void {
+  clearTimeout(refreshTimer);
+  refreshTimer = undefined;
+  cached = [...STUN_SERVERS];
 }
 
 /**
@@ -55,8 +71,20 @@ export function getIceServers(): RTCIceServer[] {
  * peers that can connect directly still do and only relayed ones are
  * affected. Cheap to call on every connect, and worth retrying: without it a
  * mobile or CGNAT peer has no path at all.
+ *
+ * Self-schedules its own next call at HALF the credential's ttl. awful.chat
+ * is a PWA - a tab can live for days - and this used to run once per
+ * session with no timer at all: two hours after connect(), coturn started
+ * rejecting every new allocation because the credential's embedded expiry
+ * timestamp had passed, and every RTCPeerConnection created after that
+ * point gathered zero relay candidates, silently (relay-audit.md
+ * finding 3). Re-arming at half the ttl, not on failure, means a relayed
+ * call already in progress always holds a credential with most of its
+ * lifetime still ahead of it.
  */
 export async function refreshTurnCredentials(): Promise<void> {
+  clearTimeout(refreshTimer);
+  refreshTimer = undefined;
   try {
     const base =
       (import.meta.env.VITE_API_URL as string | undefined) ||
@@ -81,6 +109,7 @@ export async function refreshTurnCredentials(): Promise<void> {
       username?: unknown;
       credential?: unknown;
       urls?: unknown;
+      ttl?: unknown;
     };
     if (
       typeof d?.username !== "string" ||
@@ -96,6 +125,16 @@ export async function refreshTurnCredentials(): Promise<void> {
       username: d.username,
       credential: d.credential,
     });
+    // ttl is in seconds (relay/turn.go). A missing or unusable ttl leaves
+    // this credential unrefreshed until the next connect() - the same
+    // fallback the old, never-refreshed code had - rather than guessing a
+    // number the relay did not send.
+    if (typeof d.ttl === "number" && Number.isFinite(d.ttl) && d.ttl > 0) {
+      refreshTimer = setTimeout(
+        () => void refreshTurnCredentials(),
+        (d.ttl * 1000) / 2
+      );
+    }
   } catch {
     // Stay STUN-only. The next connect() calls this again.
   }

--- a/frontend/src/lib/transport/libp2p/transport-lifecycle.test.ts
+++ b/frontend/src/lib/transport/libp2p/transport-lifecycle.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// transport.ts imports @libp2p/webrtc at module scope, which requires the
+// native node-datachannel binding this test environment does not build (see
+// sync.test.ts's FakeTransport for the same constraint). Nothing here calls
+// connect(), so webRTC() itself never runs - only the import needs a stub.
+// vitest hoists this above the static import below.
+vi.mock("@libp2p/webrtc", () => ({ webRTC: () => ({}) }));
+
+import { LibP2PTransport } from "./transport";
+
+// Every case below drives the transport through its private state directly,
+// the same pattern voice-redial.test.ts uses: LibP2PTransport's constructor
+// does nothing but installFaultHook(), so a real instance is cheap to build,
+// and casting to internals lets a test reach the lifecycle machinery without
+// standing up a real libp2p node.
+
+interface FakeStream {
+  status: string;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+  abort: () => void;
+  send: () => boolean;
+  onDrain: () => Promise<void>;
+}
+
+function fakeStream(): FakeStream {
+  return {
+    status: "open",
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    abort: () => {},
+    send: () => true,
+    onDrain: () => Promise.resolve(),
+  };
+}
+
+interface FakeConnection {
+  remotePeer: { toString: () => string };
+  direct: boolean;
+  status: string;
+  remoteAddr: { toString: () => string };
+  close: () => Promise<void>;
+}
+
+function fakeConnection(peerId: string, direct: boolean): FakeConnection {
+  return {
+    remotePeer: { toString: () => peerId },
+    direct,
+    status: "open",
+    remoteAddr: { toString: () => `/p2p-circuit/webrtc/p2p/${peerId}` },
+    close: () => Promise.resolve(),
+  };
+}
+
+function makeTransport() {
+  const transport = new LibP2PTransport();
+  const internals = transport as never as Record<string, unknown>;
+  return { transport, internals };
+}
+
+describe("stream proof reaches app state (finding 1)", () => {
+  it("emits streamProven the moment a stream confirms, and streamLost when cleanup withdraws it", () => {
+    const { transport, internals } = makeTransport();
+    const peerId = "peerA";
+    const stream = fakeStream();
+    (internals.peerStreams as Map<string, FakeStream>).set(peerId, stream);
+
+    const proven: string[] = [];
+    const lost: string[] = [];
+    transport.on("streamProven", (id: string) => proven.push(id));
+    transport.on("streamLost", (id: string) => lost.push(id));
+
+    (internals.confirmOutboundStream as (peerId: string) => void).call(
+      internals,
+      peerId
+    );
+    expect(proven).toEqual([peerId]);
+    expect(
+      (internals.confirmedStreams as WeakSet<FakeStream>).has(stream)
+    ).toBe(true);
+
+    (internals.cleanupPeerStream as (peerId: string) => void).call(
+      internals,
+      peerId
+    );
+    expect(lost).toEqual([peerId]);
+  });
+
+  it("does not announce a loss for a stream that never proved anything", () => {
+    const { transport, internals } = makeTransport();
+    const peerId = "peerB";
+    const stream = fakeStream();
+    (internals.peerStreams as Map<string, FakeStream>).set(peerId, stream);
+
+    const lost: string[] = [];
+    transport.on("streamLost", (id: string) => lost.push(id));
+
+    // No confirmOutboundStream call: this stream never confirmed.
+    (internals.cleanupPeerStream as (peerId: string) => void).call(
+      internals,
+      peerId
+    );
+    expect(lost).toEqual([]);
+  });
+});
+
+describe("a liveness drop always schedules a redial (finding 2)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("dropPeer schedules redialPeer even though it deletes connectedPeers before closing connections", () => {
+    const { internals } = makeTransport();
+    const peerId = "peerC";
+    internals.node = { getConnections: () => [] };
+    (internals.connectedPeers as Set<string>).add(peerId);
+
+    const redialSpy = vi.fn();
+    internals.redialPeer = redialSpy;
+
+    (internals.dropPeer as (peerId: string) => void).call(internals, peerId);
+    // The bug this guards: dropPeer deletes connectedPeers before this point,
+    // so peer:disconnect's own dedup guard (`if (!connectedPeers.has(id))
+    // return`) would otherwise swallow the redial it relies on. dropPeer must
+    // schedule its own.
+    expect((internals.connectedPeers as Set<string>).has(peerId)).toBe(false);
+    expect(redialSpy).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(3000);
+    expect(redialSpy).toHaveBeenCalledWith(peerId);
+  });
+
+  it("schedules no redial when the disconnect is intentional", () => {
+    const { internals } = makeTransport();
+    const peerId = "peerD";
+    internals.node = { getConnections: () => [] };
+    (internals.connectedPeers as Set<string>).add(peerId);
+    internals.intentionalDisconnect = true;
+
+    const redialSpy = vi.fn();
+    internals.redialPeer = redialSpy;
+
+    (internals.dropPeer as (peerId: string) => void).call(internals, peerId);
+    vi.advanceTimersByTime(10_000);
+    expect(redialSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("reconcile never re-registers a peer whose connections are still closing (finding 3)", () => {
+  it("skips re-registration inside the close-timeout window after dropPeer", () => {
+    const { transport, internals } = makeTransport();
+    const peerId = "peerE";
+    const connected: string[] = [];
+    transport.on("connect", (id: string) => connected.push(id));
+
+    internals.node = {
+      getConnections: () => [fakeConnection(peerId, true)],
+      getPeers: () => [{ toString: () => peerId }],
+    };
+    // Simulate dropPeer having just closed this peer's connection - the
+    // window connection.close() can take to actually finish.
+    (internals.droppedAt as Map<string, number>).set(peerId, Date.now());
+
+    (internals.reconcileConnections as () => void).call(internals);
+
+    expect((internals.connectedPeers as Set<string>).has(peerId)).toBe(false);
+    expect(connected).toEqual([]);
+  });
+
+  it("re-registers the same peer once the close-timeout window has passed", () => {
+    const { transport, internals } = makeTransport();
+    const peerId = "peerF";
+    const connected: string[] = [];
+    transport.on("connect", (id: string) => connected.push(id));
+
+    internals.node = {
+      getConnections: () => [fakeConnection(peerId, true)],
+      getPeers: () => [{ toString: () => peerId }],
+    };
+    (internals.droppedAt as Map<string, number>).set(
+      peerId,
+      Date.now() - 5000
+    );
+
+    (internals.reconcileConnections as () => void).call(internals);
+
+    expect((internals.connectedPeers as Set<string>).has(peerId)).toBe(true);
+    expect(connected).toEqual([peerId]);
+  });
+
+  it("registers a peer with no prior drop at all (baseline)", () => {
+    const { transport, internals } = makeTransport();
+    const peerId = "peerG";
+    const connected: string[] = [];
+    transport.on("connect", (id: string) => connected.push(id));
+
+    internals.node = {
+      getConnections: () => [fakeConnection(peerId, true)],
+      getPeers: () => [{ toString: () => peerId }],
+    };
+
+    (internals.reconcileConnections as () => void).call(internals);
+
+    expect((internals.connectedPeers as Set<string>).has(peerId)).toBe(true);
+    expect(connected).toEqual([peerId]);
+  });
+
+  it("drops a connectedPeers entry no longer backed by any connection (finding 11)", () => {
+    const { internals } = makeTransport();
+    const peerId = "peerH";
+    internals.node = { getConnections: () => [] };
+    (internals.connectedPeers as Set<string>).add(peerId);
+    // Avoid the drop's own redial reaching into a fake node with no dial().
+    internals.redialPeer = vi.fn();
+
+    (internals.reconcileConnections as () => void).call(internals);
+
+    expect((internals.connectedPeers as Set<string>).has(peerId)).toBe(false);
+  });
+});

--- a/frontend/src/lib/transport/libp2p/transport.ts
+++ b/frontend/src/lib/transport/libp2p/transport.ts
@@ -58,6 +58,14 @@ const RELAY_DIAL_BASE_MS = 700;
 const RELAY_DIAL_MAX_MS = 6_000;
 const CONNECTION_RECONCILE_MS = 5_000;
 /**
+ * Upstream libp2p's own grace period for `connection.close()` to finish
+ * (`@libp2p/connection-manager`'s `CONNECTION_CLOSE_TIMEOUT`). A connection
+ * dropPeer just closed still shows up in `getConnections()` for up to this
+ * long - the window a reconcile tick can walk into and re-register a peer
+ * whose old connection has not actually gone yet.
+ */
+const CONNECTION_CLOSE_TIMEOUT_MS = 1_000;
+/**
  * The gap between upgrade attempts, and the ceiling once they keep failing.
  * The FIRST attempt goes out on the next reconcile tick, not after this delay.
  */
@@ -71,6 +79,16 @@ const PING_MISSES_ALLOWED = 2;
 /** A fresh stream is pinged this often until its first pong. */
 const STREAM_CONFIRM_INTERVAL_MS = 700;
 const STREAM_CONFIRM_ATTEMPTS = 8;
+/**
+ * How long probeSilentPeers waits before judging one missed probe,
+ * independent of the send() promise it rides on. A stream that never
+ * confirms holds the ping on the pending queue for the whole confirm
+ * budget before send() resolves at all - chaining the release to that
+ * promise doubled the stated timeout, and an unbounded queue could pin it
+ * forever. This is the stated bound instead.
+ */
+const PEER_PROBE_RELEASE_MS =
+  STREAM_CONFIRM_INTERVAL_MS * STREAM_CONFIRM_ATTEMPTS + PEER_PING_TIMEOUT_MS;
 // Liveness lives at this layer rather than as a libp2p service: the ping
 // package pulls in a second copy of @libp2p/interface and the type skew breaks
 // the build. These ride the direct stream we already keep open. Pings carry a
@@ -87,10 +105,18 @@ function pongFrame(nonce: number): Uint8Array {
   return new TextEncoder().encode(JSON.stringify({ type: "__pong", n: nonce }));
 }
 const RENDEZVOUS_RECONNECT_DELAY_MS = 2_000;
+/**
+ * How often a registered rendezvous stream proves it is alive. The relay
+ * closes a registered stream that stays quiet for three intervals
+ * (`rendezvousLivenessTimeout` in relay/main.go), so this number is a
+ * contract with the relay: raising it eats the two-miss margin.
+ */
+const RENDEZVOUS_PING_INTERVAL_MS = 20_000;
 
 type RendezvousClientMsg =
   | { type: "REGISTER"; room: string }
-  | { type: "UNREGISTER"; room: string };
+  | { type: "UNREGISTER"; room: string }
+  | { type: "PING" };
 
 type RendezvousServerMsg =
   | { type: "PEERS"; room: string; peers: string[] }
@@ -100,6 +126,13 @@ type RendezvousServerMsg =
 function roomTopic(roomCode: string) {
   return `app:room:${roomCode}`;
 }
+
+/**
+ * The handle a timer returns. The browser hands back a number and Node hands
+ * back an object, and @types/node is in scope here, so the type is named once
+ * rather than spelled out at every field that holds one.
+ */
+type TimerHandle = ReturnType<typeof setInterval>;
 
 /** libp2p streams expose a status; anything but "open" cannot be written to. */
 function streamIsOpen(stream: Stream): boolean {
@@ -125,9 +158,30 @@ export class LibP2PTransport implements PeerTransport {
   private handlers = new Map<keyof TransportEvents, Set<Function>>();
   private relayedPeers = new Set<string>();
   private connectedPeers = new Set<string>();
+  /**
+   * peerId -> when dropPeer last closed this peer's connections.
+   *
+   * dropPeer calls connection.close() without awaiting it, and libp2p's
+   * graceful close can take up to CONNECTION_CLOSE_TIMEOUT_MS - during
+   * which getConnections() still returns the dying connection. Without this,
+   * the next reconcile tick sees it, re-registers the peer, and resends
+   * everything into a connection that is about to die: a connect/disconnect
+   * flap every few seconds.
+   */
+  private droppedAt = new Map<string, number>();
   private relayPeerId: string | null = null;
   private rendezvousStream: Stream | null = null;
   private rendezvousReadBuf: Uint8Array = new Uint8Array(0);
+  /**
+   * True while a rendezvous dial is in flight. Four call sites start the
+   * rendezvous - connect, the relay-reconnect retry, the dial-failure retry
+   * and the stream's own close handler - and two of them can fire for the
+   * same drop. Without this guard each dial opened its own stream and the
+   * last assignment won, so every earlier stream stayed open on the relay,
+   * unread, holding a slot against the relay's per-peer stream ceiling.
+   */
+  private rendezvousStarting = false;
+  private rendezvousPingTimer: TimerHandle | null = null;
 
   private peerStreams = new Map<string, Stream>();
   /**
@@ -220,14 +274,13 @@ export class LibP2PTransport implements PeerTransport {
    * could never make safely.
    */
   private confirmedStreams = new WeakSet<Stream>();
-  private confirmTimers = new Map<string, ReturnType<typeof setInterval>>();
+  private confirmTimers = new Map<string, TimerHandle>();
   /** Dev counters. Connection-layer faults are invisible without them: every
    *  side looks connected while writes vanish into a dead circuit. */
   readonly debugStats = {
     identifies: 0,
     connects: 0,
     disconnects: 0,
-    staleConnectionsClosed: 0,
     relayUpgradeAttempts: 0,
     relayUpgrades: 0,
     livenessDrops: 0,
@@ -246,8 +299,8 @@ export class LibP2PTransport implements PeerTransport {
   // set to true only by disconnect() - prevents any reconnect logic from firing
   private intentionalDisconnect = false;
 
-  private relayReconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private relayReconnectTimer: TimerHandle | null = null;
+  private reconcileTimer: TimerHandle | null = null;
   private privateKeyBytes: Uint8Array | null = null;
 
   constructor() {
@@ -315,6 +368,12 @@ export class LibP2PTransport implements PeerTransport {
     // relay badge stays lit for the rest of the session.
     for (const id of this.relayedPeers) this.emit("relayChanged", id, false);
     this.relayedPeers.clear();
+    // Same reasoning as relayedPeers above: announce the withdrawal, don't
+    // just drop it, or the app's provenPeers mirror keeps a peer proven
+    // across a reconnect that gave them a brand new, unconfirmed stream.
+    for (const [id, stream] of this.peerStreams) {
+      if (this.confirmedStreams.has(stream)) this.emit("streamLost", id);
+    }
     this.peerStreams.clear();
     for (const pid of [...this.pendingQueues.keys()])
       this.failPendingQueue(pid);
@@ -326,6 +385,8 @@ export class LibP2PTransport implements PeerTransport {
     this.nextUpgradeAt.clear();
     this.upgradeBackoff.clear();
     this.liveConnections.clear();
+    this.stopRendezvousPing();
+    this.rendezvousStarting = false;
     this.rendezvousStream = null;
 
     if (privateKeyBytes) this.privateKeyBytes = privateKeyBytes;
@@ -376,7 +437,12 @@ export class LibP2PTransport implements PeerTransport {
         );
       },
       // Never let a duplicate registration abort a (re)connect; see voice.ts.
-      { force: true }
+      // runOnLimitedConnection matches the dial side (openOutboundStream,
+      // rendezvous): currently a no-op, since the relay grants circuits no
+      // limits, but the assumption lives in the Go relay while this was the
+      // one registration that omitted it - a relay that ever grants limits
+      // would make every relayed peer connect and carry nothing.
+      { force: true, runOnLimitedConnection: true }
     );
 
     await this.node.start();
@@ -414,6 +480,7 @@ export class LibP2PTransport implements PeerTransport {
     this.node.addEventListener("peer:identify", (evt: any) => {
       const id = evt.detail.peerId.toString();
       if (this.isRelayPeer(id)) return;
+      this.debugStats.identifies++;
       // Handle EVERY identify, not just the first.
       //
       // A peer that reloads keeps its peerId, and the relay keeps the old
@@ -470,6 +537,19 @@ export class LibP2PTransport implements PeerTransport {
       }
     );
 
+    // updateRelayedStatus otherwise only ran on connect events and the
+    // hidden-gated upgrade refresh - so a peer whose direct connection died
+    // while its circuit survived kept its "direct" marking until the next
+    // visible reconcile tick, and the relay badge lied in the meantime.
+    this.node.addEventListener(
+      "connection:close",
+      (evt: CustomEvent<Connection>) => {
+        const id = evt.detail.remotePeer.toString();
+        if (!this.connectedPeers.has(id)) return;
+        this.updateRelayedStatus(id);
+      }
+    );
+
     this.node.addEventListener("peer:disconnect", (evt) => {
       const id = evt.detail.toString();
 
@@ -501,6 +581,7 @@ export class LibP2PTransport implements PeerTransport {
       this.liveConnections.delete(id);
       this.nextUpgradeAt.delete(id);
       this.upgradeBackoff.delete(id);
+      this.droppedAt.delete(id);
       this.cleanupPeerStream(id);
       this.emit("disconnect", id);
 
@@ -564,6 +645,8 @@ export class LibP2PTransport implements PeerTransport {
     } catch {}
     this.node = null;
     this.relayPeerId = null;
+    this.stopRendezvousPing();
+    this.rendezvousStarting = false;
     this.rendezvousStream = null;
     this.joinedRooms.clear();
     this.connectedPeers.clear();
@@ -573,6 +656,9 @@ export class LibP2PTransport implements PeerTransport {
     // relay badge stays lit for the rest of the session.
     for (const id of this.relayedPeers) this.emit("relayChanged", id, false);
     this.relayedPeers.clear();
+    for (const [id, stream] of this.peerStreams) {
+      if (this.confirmedStreams.has(stream)) this.emit("streamLost", id);
+    }
     this.peerStreams.clear();
     for (const pid of [...this.pendingQueues.keys()])
       this.failPendingQueue(pid);
@@ -630,7 +716,7 @@ export class LibP2PTransport implements PeerTransport {
         );
         this.emit("status", {
           type: "stream-open-failed",
-          peerId: peerId.slice(-8),
+          peerId,
           message: `Failed to open stream to peer ${peerId.slice(-8)}`,
         });
         this.failPendingQueue(peerId);
@@ -788,10 +874,16 @@ export class LibP2PTransport implements PeerTransport {
    * one.
    */
   private registerPeer(peerId: string): void {
-    // A peer we are seeing again must not reuse the stream from its previous
-    // incarnation: that stream can still report itself open while the far end
-    // is gone, so every write disappears into it.
-    this.cleanupPeerStream(peerId);
+    // A peer we are seeing again on a NEW connection must not reuse the
+    // stream from its previous incarnation: that stream can still report
+    // itself open while the far end is gone, so every write disappears into
+    // it. An ALREADY-connected peer identifying again must NOT be torn down
+    // here, though - glare makes two connections per pair routine (both
+    // sides dial each other from the same rendezvous reply), and every extra
+    // identify used to abort a stream that had just been confirmed.
+    // handleInboundStream already resets the outbound stream on a genuinely
+    // new connection, which is the one case that actually needs it.
+    if (!this.connectedPeers.has(peerId)) this.cleanupPeerStream(peerId);
     // Fresh incarnation, fresh liveness: a stale miss count from before a
     // reconnect would let a single missed probe drop a healthy peer, and an
     // unseeded lastInbound made the probe fire the moment a reconciled peer
@@ -799,6 +891,8 @@ export class LibP2PTransport implements PeerTransport {
     this.pingMisses.delete(peerId);
     this.lastInbound.set(peerId, Date.now());
     this.connectedPeers.add(peerId);
+    this.debugStats.connects++;
+    this.droppedAt.delete(peerId);
     this.updateRelayedStatus(peerId);
     this.nextDialAt.delete(peerId);
     this.dialBackoff.delete(peerId);
@@ -828,11 +922,17 @@ export class LibP2PTransport implements PeerTransport {
    */
   private probeSilentPeers(): void {
     if (!this.node || this.intentionalDisconnect) return;
-    if (typeof document !== "undefined" && document.hidden) return;
+    // A backgrounded tab still needs a detector, not none: a relayed
+    // connection keeps looking alive after the far end reloads or crashes
+    // (the relay holds the circuit open), and a mobile PWA can sit
+    // backgrounded for hours. Scale the threshold instead of skipping
+    // outright, so the radio stays quiet without going silent forever.
+    const hidden = typeof document !== "undefined" && document.hidden;
+    const silence = hidden ? PEER_SILENCE_MS * 4 : PEER_SILENCE_MS;
     const now = Date.now();
     for (const peerId of [...this.connectedPeers]) {
       if (this.pinging.has(peerId)) continue;
-      if (now - (this.lastInbound.get(peerId) ?? 0) < PEER_SILENCE_MS) continue;
+      if (now - (this.lastInbound.get(peerId) ?? 0) < silence) continue;
       // A stream mid-confirmation is already being pinged on a faster clock.
       const out = this.peerStreams.get(peerId);
       if (out && streamIsOpen(out) && !this.confirmedStreams.has(out)) {
@@ -840,22 +940,25 @@ export class LibP2PTransport implements PeerTransport {
       }
       this.pinging.add(peerId);
       const askedAt = Date.now();
-      void this.send(peerId, pingFrame(++this.pingNonceCounter)).finally(() => {
-        setTimeout(() => {
-          this.pinging.delete(peerId);
-          if (!this.connectedPeers.has(peerId)) return;
-          if ((this.lastInbound.get(peerId) ?? 0) >= askedAt) return;
-          // One missed answer is not proof: a slow phone looks the same as a
-          // dead one, and dropping a live peer tears down a working call.
-          const misses = (this.pingMisses.get(peerId) ?? 0) + 1;
-          this.pingMisses.set(peerId, misses);
-          if (misses < PING_MISSES_ALLOWED) return;
-          console.log("[Transport] peer stopped answering:", peerId.slice(-8));
-          this.debugStats.livenessDrops++;
-          this.pingMisses.delete(peerId);
-          this.dropPeer(peerId);
-        }, PEER_PING_TIMEOUT_MS);
-      });
+      // Fire and forget: send() can sit on the pending queue for the whole
+      // confirm budget before it resolves at all (or, if that queue never
+      // drains, forever). The release below no longer waits on it - see
+      // PEER_PROBE_RELEASE_MS.
+      void this.send(peerId, pingFrame(++this.pingNonceCounter));
+      setTimeout(() => {
+        this.pinging.delete(peerId);
+        if (!this.connectedPeers.has(peerId)) return;
+        if ((this.lastInbound.get(peerId) ?? 0) >= askedAt) return;
+        // One missed answer is not proof: a slow phone looks the same as a
+        // dead one, and dropping a live peer tears down a working call.
+        const misses = (this.pingMisses.get(peerId) ?? 0) + 1;
+        this.pingMisses.set(peerId, misses);
+        if (misses < PING_MISSES_ALLOWED) return;
+        console.log("[Transport] peer stopped answering:", peerId.slice(-8));
+        this.debugStats.livenessDrops++;
+        this.pingMisses.delete(peerId);
+        this.dropPeer(peerId);
+      }, PEER_PROBE_RELEASE_MS);
     }
   }
 
@@ -894,6 +997,7 @@ export class LibP2PTransport implements PeerTransport {
 
   private dropPeer(peerId: string): void {
     this.debugStats.disconnects++;
+    this.droppedAt.set(peerId, Date.now());
     // Probes to a peer that just left resolve as loss now rather than
     // sitting out their full timeout.
     for (const [nonce, probe] of [...this.rttProbes]) {
@@ -914,6 +1018,14 @@ export class LibP2PTransport implements PeerTransport {
       if (c.remotePeer.toString() === peerId) c.close().catch(() => {});
     }
     this.emit("disconnect", peerId);
+    // dropPeer deletes connectedPeers ABOVE closing the connections, so
+    // peer:disconnect's own dedup guard (`if (!this.connectedPeers.has(id))
+    // return`) sees the entry already gone and never reaches its redial.
+    // Without this, a liveness drop is permanent: the peer is absent from
+    // connectedPeers, absent from dialingPeers, and nothing else redials it.
+    if (!this.intentionalDisconnect) {
+      setTimeout(() => this.redialPeer(peerId), PEER_REDIAL_DELAY_MS);
+    }
   }
 
   private rememberRoomPeer(room: string, peerId: string): void {
@@ -942,9 +1054,22 @@ export class LibP2PTransport implements PeerTransport {
       if (list) list.push(connection);
       else byPeer.set(id, [connection]);
       if (this.isRelayPeer(id) || this.connectedPeers.has(id)) continue;
+      // The connection dropPeer just closed can still show up here for up
+      // to CONNECTION_CLOSE_TIMEOUT_MS - re-registering into that window
+      // produces the connect/disconnect flap droppedAt exists to prevent.
+      const closingStill =
+        Date.now() - (this.droppedAt.get(id) ?? 0) < CONNECTION_CLOSE_TIMEOUT_MS;
+      if (closingStill) continue;
       console.log("[Transport] reconciled missed peer:", id.slice(-8));
       this.registerPeer(id);
       this.emit("connect", id);
+    }
+    // peer:disconnect can only fire while the node is alive, so a connection
+    // lost across a node restart left a resident connectedPeers entry
+    // forever. Safe now that dropPeer redials on its own (finding 2) -
+    // dropping a peer nothing would ever dial back used to strand it.
+    for (const id of [...this.connectedPeers]) {
+      if (!byPeer.has(id)) this.dropPeer(id);
     }
     this.probeSilentPeers();
     this.retryMissingRoomPeers();
@@ -967,7 +1092,12 @@ export class LibP2PTransport implements PeerTransport {
    */
   private upgradeRelayedPeers(byPeer?: Map<string, Connection[]>): void {
     if (this.intentionalDisconnect || !this.node) return;
-    if (typeof document !== "undefined" && document.hidden) return;
+    // Only the DIAL below is skipped while hidden, not the refresh - a
+    // relayed connection keeps looking alive after the far end reloads or
+    // crashes (the relay holds the circuit open), and gating the refresh
+    // too left the badge showing "direct" long after the direct connection
+    // actually died in the background.
+    const hidden = typeof document !== "undefined" && document.hidden;
     const now = Date.now();
     for (const peerId of [...this.connectedPeers]) {
       // Refresh first. updateRelayedStatus only ever ran on connect events, so
@@ -982,6 +1112,7 @@ export class LibP2PTransport implements PeerTransport {
         this.upgradeBackoff.delete(peerId);
         continue;
       }
+      if (hidden) continue; // keep the radio quiet in the background
       if (this.dialingPeers.has(peerId)) continue;
       const due = this.nextUpgradeAt.get(peerId) ?? 0;
       if (now < due) continue;
@@ -991,7 +1122,10 @@ export class LibP2PTransport implements PeerTransport {
         RELAY_UPGRADE_MAX_MS
       );
       this.upgradeBackoff.set(peerId, next);
-      this.nextUpgradeAt.set(peerId, now + next);
+      // Jittered like the relay dial below - see retryMissingRoomPeers for
+      // why an un-jittered peer backoff stays lockstepped with the pair on
+      // the other end of the same reservation race.
+      this.nextUpgradeAt.set(peerId, now + next + Math.random() * next * 0.3);
       this.upgradeToDirect(peerId).catch(() => {});
     }
   }
@@ -1027,7 +1161,15 @@ export class LibP2PTransport implements PeerTransport {
     // twice, because both sides dial and each closed the one the other used.
     const live = this.liveConnections.get(peerId);
     if (live && live.remoteAddr.toString().includes("/p2p-circuit")) {
-      this.liveConnections.delete(peerId);
+      // Point outbound traffic at the connection the upgrade actually won,
+      // not at whichever one dialProtocol picks arbitrarily among several -
+      // that routinely landed back on the very circuit just left, so the
+      // app believed it was upgraded while every frame still rode the relay.
+      const direct = this.node
+        ?.getConnections(peerIdFromString(peerId))
+        .find((c) => c.direct);
+      if (direct) this.liveConnections.set(peerId, direct);
+      else this.liveConnections.delete(peerId);
     }
     // Move the traffic. resetOutboundStream, NOT cleanupPeerStream: the latter
     // fails the pending queue, and the claim that callers requeue only holds on
@@ -1066,7 +1208,11 @@ export class LibP2PTransport implements PeerTransport {
           PEER_REDIAL_MAX_MS
         );
         this.dialBackoff.set(peerId, next);
-        this.nextDialAt.set(peerId, now + next);
+        // Jittered like the relay dial below: both sides of a pair learn
+        // about each other from the same rendezvous reply and retry in
+        // lockstep without this, colliding on the same reservation race
+        // every time.
+        this.nextDialAt.set(peerId, now + next + Math.random() * next * 0.3);
         this.dialPeer(peerId).catch(() => {});
       }
     }
@@ -1218,14 +1364,16 @@ export class LibP2PTransport implements PeerTransport {
         }
         stream = await this.node.dialProtocol(
           peerIdFromString(peerId),
-          DIRECT_MSG_PROTOCOL
+          DIRECT_MSG_PROTOCOL,
+          { runOnLimitedConnection: true }
         );
         this.debugStats.dialStreamOpens++;
       }
     } else {
       stream = await this.node.dialProtocol(
         peerIdFromString(peerId),
-        DIRECT_MSG_PROTOCOL
+        DIRECT_MSG_PROTOCOL,
+        { runOnLimitedConnection: true }
       );
       this.debugStats.dialStreamOpens++;
     }
@@ -1272,7 +1420,7 @@ export class LibP2PTransport implements PeerTransport {
     const pingOnce = () => {
       const nonce = ++this.pingNonceCounter;
       this.confirmNonces.get(peerId)?.add(nonce);
-      this.writeFrame(peerId, stream, pingFrame(nonce));
+      void this.writeFrame(peerId, stream, pingFrame(nonce));
     };
 
     const timer = setInterval(() => {
@@ -1324,6 +1472,10 @@ export class LibP2PTransport implements PeerTransport {
     const stream = this.peerStreams.get(peerId);
     if (!stream || this.confirmedStreams.has(stream)) return;
     this.confirmedStreams.add(stream);
+    // The only proof anything can actually reach this peer - see
+    // confirmedStreams and streamProven's own doc for why connectedPeers
+    // alone was never enough.
+    this.emit("streamProven", peerId);
     const timer = this.confirmTimers.get(peerId);
     if (timer) {
       clearInterval(timer);
@@ -1332,15 +1484,15 @@ export class LibP2PTransport implements PeerTransport {
     const queued = this.pendingQueues.get(peerId) ?? [];
     this.pendingQueues.delete(peerId);
     for (const entry of queued) {
-      entry.resolve(this.writeFrame(peerId, stream, entry.data));
+      void this.writeFrame(peerId, stream, entry.data).then(entry.resolve);
     }
   }
 
-  private writeFrame(
+  private async writeFrame(
     peerId: string,
     stream: Stream,
     data: Uint8Array
-  ): boolean {
+  ): Promise<boolean> {
     if (!streamIsOpen(stream)) {
       this.cleanupPeerStream(peerId);
       return false;
@@ -1348,10 +1500,19 @@ export class LibP2PTransport implements PeerTransport {
     try {
       const ok = stream.send(encodeFrame(data));
       this.debugStats.framesOut++;
-      if (!ok) {
-        stream.onDrain().catch(() => this.cleanupPeerStream(peerId));
-      }
-      return true;
+      if (ok) return true;
+      // A false return means the frame is BUFFERED, not flushed. Resolving
+      // true here let send() report success for a frame that later dropped
+      // on backpressure - and the DM layer deletes a message from its
+      // persisted queue on true, so an optimistic true here destroyed it.
+      // Report the real outcome once the stream actually drains.
+      return await stream.onDrain().then(
+        () => true,
+        () => {
+          this.cleanupPeerStream(peerId);
+          return false;
+        }
+      );
     } catch (err) {
       console.warn(`[LibP2PTransport] write failed for ${peerId}:`, err);
       this.cleanupPeerStream(peerId);
@@ -1427,7 +1588,7 @@ export class LibP2PTransport implements PeerTransport {
             const reply = pongFrame(typeof live.n === "number" ? live.n : 0);
             const out = this.peerStreams.get(fromId);
             if (out && streamIsOpen(out)) {
-              this.writeFrame(fromId, out, reply);
+              void this.writeFrame(fromId, out, reply);
             } else {
               void this.send(fromId, reply);
             }
@@ -1472,11 +1633,13 @@ export class LibP2PTransport implements PeerTransport {
     const stream = this.peerStreams.get(peerId);
     if (!stream) return;
     this.debugStats.outboundResets++;
+    const wasProven = this.confirmedStreams.has(stream);
     this.peerStreams.delete(peerId);
     this.confirmNonces.delete(peerId);
     try {
       stream.abort(new Error("peer reopened its stream"));
     } catch {}
+    if (wasProven) this.emit("streamLost", peerId);
     // Anything already queued has no other trigger to reopen the stream, and
     // the silence probe only fires after PEER_SILENCE_MS - so without this the
     // frames would just sit there for at least that long.
@@ -1494,8 +1657,13 @@ export class LibP2PTransport implements PeerTransport {
     }
     const stream = this.peerStreams.get(peerId);
     if (stream) {
+      // Withdraw proof only if this stream actually held it - most callers
+      // tear down a stream that never confirmed, and announcing a loss that
+      // was never a gain would just be noise.
+      const wasProven = this.confirmedStreams.has(stream);
       stream.abort(new Error("cleanup"));
       this.peerStreams.delete(peerId);
+      if (wasProven) this.emit("streamLost", peerId);
     }
     this.failPendingQueue(peerId);
     this.openingStreams.delete(peerId);
@@ -1503,6 +1671,8 @@ export class LibP2PTransport implements PeerTransport {
 
   private async startRendezvous(): Promise<void> {
     if (this.intentionalDisconnect || !this.node || !this.relayPeerId) return;
+    if (this.rendezvousStarting) return;
+    this.rendezvousStarting = true;
 
     const selfId = this.node.peerId.toString();
 
@@ -1514,6 +1684,7 @@ export class LibP2PTransport implements PeerTransport {
         { runOnLimitedConnection: true }
       );
     } catch (err) {
+      this.rendezvousStarting = false;
       console.warn("[Rendezvous] failed to open stream, retrying:", err);
       this.emit("status", {
         type: "rendezvous-failed",
@@ -1523,8 +1694,19 @@ export class LibP2PTransport implements PeerTransport {
       return;
     }
 
+    // Take the reference first, then retire the old stream. The close handler
+    // below bails out when it is no longer the current stream, so aborting
+    // before the assignment would make the outgoing stream wipe its own
+    // replacement and schedule a needless reconnect.
+    const previous = this.rendezvousStream;
     this.rendezvousStream = stream;
     this.rendezvousReadBuf = new Uint8Array(0);
+    this.rendezvousStarting = false;
+    if (previous && previous !== stream) {
+      previous.abort(new Error("rendezvous stream superseded"));
+    }
+
+    this.startRendezvousPing(stream);
 
     // re-register all rooms after rendezvous reconnect
     for (const room of this.joinedRooms) {
@@ -1565,7 +1747,24 @@ export class LibP2PTransport implements PeerTransport {
             FRAME_DECODER.decode(payload)
           ) as RendezvousServerMsg;
           this.handleRendezvousMsg(selfId, msg);
-        } catch {}
+        } catch (err) {
+          // Swallowing this lost the frame with no signal and no reconnect.
+          // The liveness ping keeps answering the relay, so the relay never
+          // notices that this stream's read side is dead. Abort instead, the
+          // way the oversized-frame branch above already does, and let the
+          // close handler reconnect.
+          console.warn(
+            "[Rendezvous] failed to process frame, aborting stream:",
+            err
+          );
+          this.rendezvousReadBuf = new Uint8Array(0);
+          stream.abort(
+            err instanceof Error
+              ? err
+              : new Error("rendezvous frame processing failed")
+          );
+          return;
+        }
       }
     });
 
@@ -1577,6 +1776,7 @@ export class LibP2PTransport implements PeerTransport {
       // then silently no-opped, so a leaveRoom UNREGISTER was lost with no
       // retry and the relay kept telling peers we were still in the room.
       if (this.rendezvousStream !== stream) return;
+      this.stopRendezvousPing();
       this.rendezvousStream = null;
       if (!this.intentionalDisconnect && this.node) {
         console.warn("[Rendezvous] stream closed, reconnecting");
@@ -1587,6 +1787,30 @@ export class LibP2PTransport implements PeerTransport {
         setTimeout(() => this.startRendezvous(), RENDEZVOUS_RECONNECT_DELAY_MS);
       }
     });
+  }
+
+  /**
+   * Prove to the relay that a registered stream is still alive. The relay
+   * gives a registered stream no read deadline of its own beyond three
+   * missed intervals, so a peer whose network vanished without a TCP close
+   * stayed advertised in its rooms and every other member kept dialling a
+   * peer that was not there.
+   */
+  private startRendezvousPing(stream: Stream): void {
+    this.stopRendezvousPing();
+    this.rendezvousPingTimer = setInterval(() => {
+      if (this.rendezvousStream !== stream) {
+        this.stopRendezvousPing();
+        return;
+      }
+      this.rendezvousSend({ type: "PING" });
+    }, RENDEZVOUS_PING_INTERVAL_MS);
+  }
+
+  private stopRendezvousPing(): void {
+    if (this.rendezvousPingTimer === null) return;
+    clearInterval(this.rendezvousPingTimer);
+    this.rendezvousPingTimer = null;
   }
 
   private rendezvousSend(msg: RendezvousClientMsg): void {
@@ -1625,11 +1849,15 @@ export class LibP2PTransport implements PeerTransport {
         await this.node.dial(withoutWebRTC);
       } catch (err) {
         // ponytail: 3 attempts with linear backoff; enough for transient
-        // reservation races without hammering an offline peer
+        // reservation races without hammering an offline peer. Jittered
+        // like the relay dial - both sides of a pair learn about each
+        // other from the same rendezvous reply and would otherwise retry
+        // in lockstep and lose the same reservation race every time.
         if (attempt < 2 && !this.intentionalDisconnect) {
+          const wait = PEER_REDIAL_DELAY_MS * (attempt + 1);
           setTimeout(
             () => this.dialPeer(peerId, attempt + 1).catch(() => {}),
-            PEER_REDIAL_DELAY_MS * (attempt + 1)
+            wait + Math.random() * wait * 0.3
           );
           return;
         }
@@ -1642,7 +1870,7 @@ export class LibP2PTransport implements PeerTransport {
           );
           this.emit("status", {
             type: "peer-dial-failed",
-            peerId: peerId.slice(-8),
+            peerId,
             message: `Could not reach peer ${peerId.slice(-8)}`,
           });
         }
@@ -1691,15 +1919,20 @@ export class LibP2PTransport implements PeerTransport {
   /** Resolves true once the circuit reservation is live, false on timeout. */
   private waitForRelayReservation(): Promise<boolean> {
     return new Promise((resolve) => {
-      if (!this.node) return resolve(false);
-      const ownId = this.node.peerId.toString();
+      // Captured once: a reconnect landing mid-wait replaces this.node, and
+      // removing the listener from the NEW node left it attached to the OLD
+      // one forever - and a late fire on the old node's closure could read
+      // the new node's addresses and resolve THIS promise from them.
+      const node = this.node;
+      if (!node) return resolve(false);
+      const ownId = node.peerId.toString();
 
       const deadline = setTimeout(() => {
         console.warn(
           "[Transport] relay reservation timed out, addrs:",
-          this.node?.getMultiaddrs().map((a) => a.toString())
+          node.getMultiaddrs().map((a) => a.toString())
         );
-        this.node?.removeEventListener("self:peer:update", check);
+        node.removeEventListener("self:peer:update", check);
 
         this.emit("status", {
           type: "reservation-timeout",
@@ -1709,7 +1942,7 @@ export class LibP2PTransport implements PeerTransport {
       }, RELAY_RESERVATION_TIMEOUT_MS);
 
       const check = () => {
-        const addrs = this.node?.getMultiaddrs() ?? [];
+        const addrs = node.getMultiaddrs();
         const circuit = addrs.find((ma) => {
           const s = ma.toString();
           return s.includes("/p2p-circuit") && s.endsWith(`/p2p/${ownId}`);
@@ -1717,12 +1950,12 @@ export class LibP2PTransport implements PeerTransport {
         if (circuit) {
           console.log("[Transport] relay reservation ok:", circuit.toString());
           clearTimeout(deadline);
-          this.node?.removeEventListener("self:peer:update", check);
+          node.removeEventListener("self:peer:update", check);
           resolve(true);
         }
       };
 
-      this.node.addEventListener("self:peer:update", check);
+      node.addEventListener("self:peer:update", check);
       check();
     });
   }

--- a/frontend/src/lib/transport/libp2p/voice-inbound-guard.test.ts
+++ b/frontend/src/lib/transport/libp2p/voice-inbound-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LibP2PVoice, isVoiceSignal } from "./voice";
 
 function makeVoice() {
@@ -201,5 +201,144 @@ describe("pendingCandidates cap", () => {
     expect(
       (remote.pendingCandidates[0] as { candidate: string }).candidate
     ).toBe("candidate:0");
+  });
+});
+
+describe("startMic replaceTrack loop (finding 2)", () => {
+  const fakeMicTrack = { getSettings: () => ({ deviceId: "mic1" }), stop: () => {} };
+  const fakeMicStream = {
+    getAudioTracks: () => [fakeMicTrack],
+    getTracks: () => [fakeMicTrack],
+  };
+  const fakeProcessedTrack = { kind: "audio" };
+  const fakeAudioCtx = {
+    createMediaStreamSource: () => ({ connect: () => {} }),
+    createGain: () => ({ gain: { value: 0 }, connect: () => {} }),
+    createMediaStreamDestination: () => ({
+      stream: { getAudioTracks: () => [fakeProcessedTrack] },
+    }),
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia: async () => fakeMicStream },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function fakeSenderRemote(
+    peerId: string,
+    replaceTrack: (track: unknown) => Promise<void>
+  ) {
+    return {
+      peerId,
+      pc: {
+        getSenders: () => [{ track: { kind: "audio" }, replaceTrack }],
+        addTrack: () => {},
+      },
+    };
+  }
+
+  it("a replaceTrack rejection for one peer still updates every other peer", async () => {
+    const { internals } = makeVoice();
+    internals.audioCtx = fakeAudioCtx;
+    const updated: string[] = [];
+    const remotes = new Map<string, unknown>([
+      [
+        "aaa",
+        fakeSenderRemote("aaa", async () => {
+          // A peer torn down mid-switch (reconcile tick, redial) rejects
+          // here with InvalidStateError - the exact failure finding 2 names.
+          throw new DOMException("stopped", "InvalidStateError");
+        }),
+      ],
+      [
+        "bbb",
+        fakeSenderRemote("bbb", async () => {
+          updated.push("bbb");
+        }),
+      ],
+      [
+        "ccc",
+        fakeSenderRemote("ccc", async () => {
+          updated.push("ccc");
+        }),
+      ],
+    ]);
+    internals.remotePeers = remotes;
+
+    // Must resolve, not reject: before the fix, "aaa"'s rejection propagated
+    // out of startMic and skipped applyMuteState() and every peer after it
+    // in Map iteration order.
+    await (internals.startMic as (d?: string) => Promise<void>).call(
+      internals
+    );
+
+    expect(updated).toEqual(["bbb", "ccc"]);
+  });
+});
+
+describe("handleSignal: an offer in an unrecoverable signalling state asks for redial (finding 4)", () => {
+  it("asks for a fresh dial instead of dropping the offer silently", async () => {
+    const { internals } = makeVoice();
+    const asked: string[] = [];
+    internals.askForRedial = (peerId: string) => {
+      asked.push(peerId);
+    };
+    const remote = {
+      pc: {
+        // "have-remote-offer" is neither "stable" nor "have-local-offer" -
+        // the branch the audit calls unrecoverable at this signalling layer.
+        signalingState: "have-remote-offer",
+        setRemoteDescription: async () => {
+          throw new Error("must not be reached");
+        },
+      },
+      pendingCandidates: [],
+    };
+    (internals.remotePeers as Map<string, unknown>).set("aaa", remote);
+
+    await (
+      internals.handleSignal as (
+        peerId: string,
+        signal: unknown
+      ) => Promise<void>
+    ).call(internals, "aaa", { type: "offer", sdp: "v=0..." });
+
+    expect(asked).toEqual(["aaa"]);
+  });
+});
+
+describe("LibP2PVoice.handleDtlnFatal (finding 1)", () => {
+  it("rebuilds the mic on the active input device when a call is active", () => {
+    const { internals } = makeVoice();
+    internals.audioCtx = {}; // a call is active
+    internals.activeInputDevice = "mic-2";
+    const calls: (string | undefined)[] = [];
+    internals.startMic = (deviceId?: string) => {
+      calls.push(deviceId);
+      return Promise.resolve();
+    };
+
+    (internals.handleDtlnFatal as () => void).call(internals);
+
+    expect(calls).toEqual(["mic-2"]);
+  });
+
+  it("does nothing without an active call - no audioCtx, nothing to rebuild", () => {
+    const { internals } = makeVoice();
+    internals.audioCtx = null;
+    let called = false;
+    internals.startMic = () => {
+      called = true;
+      return Promise.resolve();
+    };
+
+    (internals.handleDtlnFatal as () => void).call(internals);
+
+    expect(called).toBe(false);
   });
 });

--- a/frontend/src/lib/transport/libp2p/voice-redial.test.ts
+++ b/frontend/src/lib/transport/libp2p/voice-redial.test.ts
@@ -3,18 +3,27 @@ import { LibP2PVoice } from "./voice";
 
 // handleRedialRequest touches only the link bookkeeping, so the peer
 // connection can be a state holder and the audio graph never comes up.
-function fakeRemote(state: string, ageMs = 0, everConnected = false, okAgoMs = 0) {
+function fakeRemote(
+  state: string,
+  ageMs = 0,
+  everConnected = false,
+  okAgoMs = 0,
+  lastBytesReceived: number | null = 0,
+  bytesReceivedAgoMs = 0
+) {
   return {
     peerId: "aaa",
-    pc: { connectionState: state, close: vi.fn() },
+    pc: { connectionState: state, close: vi.fn(), getStats: () => Promise.resolve(new Map()) },
     stream: null,
-    audio: { srcObject: null },
+    audio: { srcObject: null, play: () => Promise.resolve() },
     sourceNode: null,
     gainNode: null,
     pendingCandidates: [],
     createdAt: Date.now() - ageMs,
     everConnected,
     okAt: Date.now() - okAgoMs,
+    lastBytesReceived,
+    lastBytesReceivedAt: Date.now() - bytesReceivedAgoMs,
   };
 }
 
@@ -181,5 +190,95 @@ describe("reconcileLinks asks for a blipped link, not only a missing one", () =>
     const { internals, sent } = makePassiveVoice(true, 1_000);
     (internals.reconcileLinks as () => void).call(internals);
     expect(sent).toEqual([]);
+  });
+});
+
+describe("linkIsHealthy: inbound-media watchdog (finding 3)", () => {
+  interface TestRemote {
+    okAt: number;
+    lastBytesReceived: number | null;
+    lastBytesReceivedAt: number;
+  }
+
+  function callLinkIsHealthy(internals: Record<string, unknown>, remote: TestRemote, now: number) {
+    return (
+      internals.linkIsHealthy as (r: TestRemote, n: number) => boolean
+    ).call(internals, remote, now);
+  }
+
+  it("does not refresh okAt for a connected link whose bytesReceived has stalled past the threshold", () => {
+    const { internals } = makeVoice("connected");
+    const remote = (internals.remotePeers as Map<string, TestRemote>).get(
+      "aaa"
+    )!;
+    const now = Date.now();
+    remote.lastBytesReceived = 50_000;
+    remote.lastBytesReceivedAt = now - 9_000; // past the 8s stall threshold
+    remote.okAt = now - 9_000; // no progress since the stall started
+    // Still inside the 20s wedge grace, so not unhealthy YET - but okAt must
+    // not have been bumped to "now": that refresh is exactly what hid a
+    // stalled sender (finding 1/2) or a dropped renegotiation (finding 4)
+    // forever, because connectionState alone kept reading "connected".
+    expect(callLinkIsHealthy(internals, remote, now)).toBe(true);
+    expect(remote.okAt).toBe(now - 9_000);
+  });
+
+  it("tears a connected-but-stalled link down once the wedge grace elapses on top of the stall", () => {
+    const { internals } = makeVoice("connected");
+    const remote = (internals.remotePeers as Map<string, TestRemote>).get(
+      "aaa"
+    )!;
+    const now = Date.now();
+    remote.lastBytesReceived = 50_000;
+    remote.lastBytesReceivedAt = now - 25_000;
+    remote.okAt = now - 25_000;
+    expect(callLinkIsHealthy(internals, remote, now)).toBe(false);
+  });
+
+  it("a muted peer does not trip the watchdog - enabled=false still transmits silence frames, so bytesReceived keeps climbing", () => {
+    const { internals } = makeVoice("connected");
+    const remote = (internals.remotePeers as Map<string, TestRemote>).get(
+      "aaa"
+    )!;
+    const now = Date.now();
+    remote.lastBytesReceived = 12_000;
+    remote.lastBytesReceivedAt = now - 500; // increased half a second ago
+    remote.okAt = now - 10_000; // stale from before this sample
+    expect(callLinkIsHealthy(internals, remote, now)).toBe(true);
+    // Refreshed just now: no false positive despite the stale okAt going in.
+    expect(remote.okAt).toBe(now);
+  });
+
+  it("reconcileLinks tears down a stalled connected link end to end, on the side that notices it", () => {
+    const sent: string[] = [];
+    const transport = {
+      selfId: () => "aaa", // lower id: passive side, never dials
+      peers: () => ["zzz"],
+      isRelay: () => false,
+      send: async (peerId: string) => {
+        sent.push(peerId);
+        return true;
+      },
+      on: () => {},
+      off: () => {},
+    };
+    const voice = new LibP2PVoice(transport as never, null);
+    const internals = voice as never as Record<string, unknown>;
+    internals.node = {} as unknown;
+    internals.callPeers = new Set(["zzz"]);
+    internals.rosterSeen = true;
+    const now = Date.now();
+    const remote = {
+      ...fakeRemote("connected", 60_000, true, 25_000, 50_000, 25_000),
+      peerId: "zzz",
+    };
+    (internals.remotePeers as Map<string, TestRemote>).set("zzz", remote);
+    (internals.reconcileLinks as () => void).call(internals);
+    // Torn down (finding 3's watchdog owning the existing tdUnhealthy path),
+    // and the passive side's only further action is to ask - never a second
+    // repair path.
+    expect(
+      (internals.remotePeers as Map<string, TestRemote>).has("zzz")
+    ).toBe(false);
   });
 });

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -53,6 +53,19 @@ const VOICE_REDIAL_ASK_MS = 5_000;
  * "disconnects take forever to come back" experience.
  */
 const VOICE_BLIP_GRACE_MS = 5_000;
+/**
+ * Zero-growth window for the inbound-media watchdog (finding 3). A link can
+ * read "connected" - ICE never reports trouble - while the audio it is
+ * supposed to be carrying has stopped arriving entirely: a dead DTLN
+ * worklet, a replaceTrack that rejected mid-switch, a dropped renegotiation.
+ * Nothing but bytesReceived on the inbound-rtp report can tell the
+ * difference between that and a peer who is simply quiet. Twice the
+ * reconcile tick, so one missed sample cannot trip it, and zero growth
+ * rather than slow growth, so DTX/comfort-noise trickle and a legitimately
+ * muted peer (applyMuteState flips `enabled` on live tracks, which keeps
+ * RTP flowing) do not.
+ */
+const VOICE_MEDIA_STALL_MS = 8_000;
 
 // The DTLN set: browser noise suppression OFF (the model replaces it), but
 // echo cancellation ON. DTLN is noise suppression, not echo cancellation - a
@@ -124,6 +137,16 @@ interface RemotePeer {
    * against - the rebuild gets the same budget and the pair never converges.
    */
   okAt: number;
+  /**
+   * Last audio inbound-rtp bytesReceived sample, or null before the first
+   * poll lands. Watchdog state for finding 3 - see pollInboundMedia.
+   */
+  lastBytesReceived: number | null;
+  /**
+   * When bytesReceived last increased. Polled on the reconcile tick, so
+   * this can lag live reality by up to VOICE_RECONCILE_MS.
+   */
+  lastBytesReceivedAt: number;
 }
 
 export class LibP2PVoice implements VoiceTransport {
@@ -227,6 +250,12 @@ export class LibP2PVoice implements VoiceTransport {
     // implicit makeup gain per the Web Audio spec); tune only if voices pump.
     this.outputBus = this.audioCtx.createDynamicsCompressor();
     this.outputBus.connect(this.audioCtx.destination);
+
+    // A worklet that dies after init would otherwise transmit digital
+    // silence forever - the track stays live, RTP keeps flowing, and
+    // connectionState reads "connected" on both ends (finding 1). Rebuild
+    // the mic once instead of leaving that peer permanently unheard.
+    this.dtln?.onFatal(() => this.handleDtlnFatal());
 
     try {
       await this.startMic(this.activeInputDevice ?? undefined);
@@ -334,6 +363,24 @@ export class LibP2PVoice implements VoiceTransport {
     const self = this.transport.selfId();
     const connected = new Set(this.transport.peers());
     const now = Date.now();
+
+    // A browser or OS audio interruption suspends this context, and
+    // nothing else resumes it - the visibility handler only resumes the
+    // analyser context in speakers.svelte.ts, not this one (finding 7).
+    // Every tile keeps reading connected and every speaking ring keeps
+    // animating while the user hears nothing.
+    if (this.audioCtx?.state === "suspended") {
+      void this.audioCtx.resume().catch(() => {});
+    }
+
+    // Finding 3's watchdog: sample inbound bytes for every currently-
+    // connected link on this same tick. Fire-and-forget - see
+    // pollInboundMedia - so it costs nothing when nobody is stalled.
+    for (const remote of this.remotePeers.values()) {
+      if (remote.pc.connectionState === "connected") {
+        void this.pollInboundMedia(remote, now);
+      }
+    }
 
     // Drop links that should not exist or have wedged. Both sides do this:
     // a stale RTCPeerConnection on the passive side rejects the fresh offer
@@ -469,12 +516,22 @@ export class LibP2PVoice implements VoiceTransport {
     if (state === "failed" || state === "closed") return false;
     if (state === "connected") {
       remote.everConnected = true;
-      remote.okAt = now;
-      // A working link is the only proof worth resetting the backoff on:
-      // opening a signalling stream says nothing about whether media flows.
-      this.nextDialAt.delete(remote.peerId);
-      this.dialBackoff.delete(remote.peerId);
-      return true;
+      // Finding 3: "connected" proves nothing about whether audio is
+      // actually arriving. A link whose inbound bytes have gone flat for
+      // VOICE_MEDIA_STALL_MS gets no okAt refresh here - it falls through
+      // to the same blip/wedge grace below that a stalled ICE state would,
+      // instead of this short-circuit hiding the stall forever.
+      if (
+        remote.lastBytesReceived === null ||
+        now - remote.lastBytesReceivedAt < VOICE_MEDIA_STALL_MS
+      ) {
+        remote.okAt = now;
+        // A working link is the only proof worth resetting the backoff on:
+        // opening a signalling stream says nothing about whether media flows.
+        this.nextDialAt.delete(remote.peerId);
+        this.dialBackoff.delete(remote.peerId);
+        return true;
+      }
     }
     // A link that has never worked does not get the benefit of "progress":
     // ICE flapping back into "checking" refreshes okAt forever on a pair
@@ -483,9 +540,35 @@ export class LibP2PVoice implements VoiceTransport {
     if (!remote.everConnected && now - remote.createdAt > VOICE_SETUP_DEADLINE_MS) {
       return false;
     }
-    // "new" / "connecting" / "disconnected": legitimate for a moment, a wedge
-    // once it outlasts a handshake and an ICE restart.
+    // "new" / "connecting" / "disconnected", or "connected" with media
+    // stalled: legitimate for a moment, a wedge once it outlasts a
+    // handshake and an ICE restart.
     return now - remote.okAt < VOICE_LINK_GRACE_MS;
+  }
+
+  /**
+   * Finding 3's watchdog sample. Polled from the existing reconcile tick -
+   * no new timer - so linkIsHealthy always sees a value at most one tick
+   * stale. Fire-and-forget: getStats() is async and reconcileLinks is not,
+   * so this tick's teardown decisions still use the PREVIOUS sample, which
+   * is fine at an 8s stall threshold against a 4s tick.
+   */
+  private async pollInboundMedia(remote: RemotePeer, now: number): Promise<void> {
+    let stats;
+    try {
+      stats = await remote.pc.getStats();
+    } catch {
+      return;
+    }
+    for (const report of stats.values()) {
+      if (report.type !== "inbound-rtp" || report.kind !== "audio") continue;
+      const bytes = report.bytesReceived as number;
+      if (remote.lastBytesReceived === null || bytes > remote.lastBytesReceived) {
+        remote.lastBytesReceivedAt = now;
+      }
+      remote.lastBytesReceived = bytes;
+      return;
+    }
   }
 
   leave(): void {
@@ -506,6 +589,7 @@ export class LibP2PVoice implements VoiceTransport {
 
     this.micStream?.getTracks().forEach((t) => t.stop());
     this.dtln?.releaseTransport();
+    this.dtln?.onFatal(null);
     this.audioCtx?.close();
 
     this.audioCtx = null;
@@ -555,15 +639,6 @@ export class LibP2PVoice implements VoiceTransport {
 
     await this.startMic(deviceId);
 
-    const newTrack = this.processedStream?.getAudioTracks()[0] ?? null;
-    if (!newTrack) return;
-    for (const remote of this.remotePeers.values()) {
-      const sender = remote.pc
-        .getSenders()
-        .find((s) => s.track?.kind === "audio");
-      if (sender) await sender.replaceTrack(newTrack);
-    }
-
     this.activeInputDevice = deviceId;
     this.emit("deviceChanged", "input", deviceId);
   }
@@ -597,9 +672,24 @@ export class LibP2PVoice implements VoiceTransport {
 
   async setOutputDevice(deviceId: string): Promise<void> {
     this.activeOutputDevice = deviceId;
+    // The <audio> elements are pinned to volume=0/muted=true - they exist
+    // only to pump the receiver, not to play anything audible - so routing
+    // THEM changes nothing the user hears. All audible output leaves
+    // through outputBus -> audioCtx.destination; that is the sink that
+    // actually has to move (finding 9).
+    // [INFERENCE] AudioContext.setSinkId is Chromium-only; the feature test
+    // keeps the previous (silent) behaviour on engines without it.
+    if (this.audioCtx && "setSinkId" in this.audioCtx) {
+      await (this.audioCtx as any).setSinkId(deviceId).catch(() => {});
+    }
     for (const remote of this.remotePeers.values()) {
-      if ("setSinkId" in remote.audio) {
+      if (!("setSinkId" in remote.audio)) continue;
+      try {
         await (remote.audio as any).setSinkId(deviceId);
+      } catch (err) {
+        // A vanished or permission-denied device must not abort the loop
+        // and skip deviceChanged for every peer after it (finding 9).
+        console.warn(`[voice] setSinkId failed for ${remote.peerId}:`, err);
       }
     }
     this.emit("deviceChanged", "output", deviceId);
@@ -771,18 +861,40 @@ export class LibP2PVoice implements VoiceTransport {
     const newTrack = this.processedStream.getAudioTracks()[0] ?? null;
     if (newTrack) {
       for (const remote of this.remotePeers.values()) {
-        const sender = remote.pc
-          .getSenders()
-          .find((s) => s.track?.kind === "audio");
-        if (sender) {
-          await sender.replaceTrack(newTrack);
-        } else {
-          remote.pc.addTrack(newTrack, this.processedStream);
+        try {
+          const sender = remote.pc
+            .getSenders()
+            .find((s) => s.track?.kind === "audio");
+          if (sender) {
+            await sender.replaceTrack(newTrack);
+          } else {
+            remote.pc.addTrack(newTrack, this.processedStream);
+          }
+        } catch (err) {
+          // A peer torn down mid-switch (reconcile tick, redial) rejects
+          // here with InvalidStateError. One stopped transceiver must not
+          // starve every peer after it in Map iteration order, nor skip
+          // applyMuteState below (finding 2).
+          console.warn(`[voice] track switch failed for ${remote.peerId}:`, err);
         }
       }
     }
 
     this.applyMuteState();
+  }
+
+  /**
+   * The worklet crashed after init (finding 1): its context is suspended
+   * and the destination node feeding every RTCRtpSender has no input, but
+   * the track itself stays live so nothing else notices. Rebuilding the mic
+   * re-inits DTLN and replaces the track on every peer - same path a manual
+   * device switch takes.
+   */
+  private handleDtlnFatal(): void {
+    if (!this.audioCtx) return;
+    void this.startMic(this.activeInputDevice ?? undefined).catch((err) => {
+      console.error("[voice] mic rebuild after DTLN crash failed:", err);
+    });
   }
 
   private async dialAndOffer(peerId: string): Promise<void> {
@@ -841,7 +953,7 @@ export class LibP2PVoice implements VoiceTransport {
       // letting a pc that offered into the void sit out the 30s deadline.
       this.emit("status", {
         type: "voice-dial-failed",
-        peerId: peerId.slice(-8),
+        peerId,
         message: `Could not reach ${peerId.slice(-8)} for voice - retrying`,
       });
       this.teardownRemotePeer(peerId);
@@ -954,7 +1066,7 @@ export class LibP2PVoice implements VoiceTransport {
       } else if (state === "failed") {
         this.emit("status", {
           type: "voice-connection-failed",
-          peerId: peerId.slice(-8),
+          peerId,
           message: `Voice connection failed for ${peerId.slice(-8)}`,
         });
         this.debugStats.tdPcFailed++;
@@ -963,7 +1075,7 @@ export class LibP2PVoice implements VoiceTransport {
       } else if (state === "disconnected") {
         this.emit("status", {
           type: "voice-degraded",
-          peerId: peerId.slice(-8),
+          peerId,
           message: `Voice signal lost from ${peerId.slice(-8)} - reconnecting...`,
         });
         // attempt ICE restart; signalling rides the app transport, which
@@ -972,10 +1084,17 @@ export class LibP2PVoice implements VoiceTransport {
           remote.pc.restartIce();
           remote.pc
             .createOffer({ iceRestart: true })
-            .then((offer) => {
-              return remote.pc.setLocalDescription(offer).then(() => {
-                void this.sendSignal(peerId, { type: "offer", sdp: offer.sdp! });
-              });
+            .then((offer) =>
+              remote.pc.setLocalDescription(offer).then(() =>
+                this.sendSignal(peerId, { type: "offer", sdp: offer.sdp! })
+              )
+            )
+            .then((sent) => {
+              // A restart offer lost to a transport hiccup is otherwise
+              // unrecoverable until the 5s blip ask - unlike the initial
+              // offer and the answer, this send's result used to be
+              // discarded via `void` (finding 10).
+              if (!sent) this.askForRedial(peerId, Date.now());
             })
             .catch((err) => {
               console.warn(
@@ -984,7 +1103,7 @@ export class LibP2PVoice implements VoiceTransport {
               );
               this.emit("status", {
                 type: "voice-connection-failed",
-                peerId: peerId.slice(-8),
+                peerId,
                 message: `Voice ICE restart failed for ${peerId.slice(-8)}`,
               });
             });
@@ -1009,6 +1128,8 @@ export class LibP2PVoice implements VoiceTransport {
       createdAt: Date.now(),
       everConnected: false,
       okAt: Date.now(),
+      lastBytesReceived: null,
+      lastBytesReceivedAt: Date.now(),
     };
     this.remotePeers.set(peerId, remote);
     return remote;
@@ -1035,6 +1156,13 @@ export class LibP2PVoice implements VoiceTransport {
     remote.audio.srcObject = stream;
     remote.audio.volume = 0;
     remote.audio.muted = true;
+    // autoplay=true above only takes effect on the initial srcObject
+    // assignment - if this element is ever paused (finding 11), nothing
+    // resumes it and that ONE peer goes silent permanently while
+    // connectionState still reads connected. play() is idempotent on an
+    // already-playing element, so calling it here costs nothing on the
+    // common path and repairs the rare one.
+    remote.audio.play().catch(() => {});
 
     remote.stream = stream;
     remote.sourceNode = sourceNode;
@@ -1059,6 +1187,15 @@ export class LibP2PVoice implements VoiceTransport {
     this.active.delete(peerId);
 
     this.emit("trackRemoved", peerId);
+
+    // The single choke point every teardown path passes through (finding
+    // 8): without this, six of seven teardown paths told the UI nothing,
+    // and a torn-down peer rendered as present and connected forever.
+    this.emit("status", {
+      type: "voice-peer-left",
+      peerId,
+      message: `Voice link with ${peerId.slice(-8)} closed`,
+    });
   }
 
   private async handleSignal(
@@ -1081,10 +1218,14 @@ export class LibP2PVoice implements VoiceTransport {
             return;
           }
         } else if (state !== "stable") {
-          // unexpected state - log and bail
+          // unexpected state - the offer is unrecoverable at this
+          // signalling layer, and connectionState still reads "connected"
+          // so linkIsHealthy never notices (finding 4). Ask for a fresh
+          // dial instead of dropping it forever.
           console.warn(
             `[Voice] unexpected signaling state ${state} on offer from ${peerId}`
           );
+          this.askForRedial(peerId, Date.now());
           return;
         }
 

--- a/frontend/src/lib/transport/mediasoup.test.ts
+++ b/frontend/src/lib/transport/mediasoup.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import { MediasoupVideo } from "./mediasoup";
+import type * as mediasoupClient from "mediasoup-client";
+
+// White-box: reach past the public VideoTransport surface to drive the
+// private signal handler and stats sweep directly, the same pattern already
+// used for LibP2PVoice's redial internals (voice-redial.test.ts). Building a
+// real mediasoup-client Device or a live WebSocket is unnecessary for either
+// finding under test - both fire on data already inside the class.
+function internalsOf(video: MediasoupVideo): Record<string, unknown> {
+  return video as never as Record<string, unknown>;
+}
+
+// Fake transport: only `close()` and `connectionState` are read by the code
+// paths under test.
+function fakeTransport(): { close: ReturnType<typeof vi.fn>; connectionState: string } {
+  return { close: vi.fn(), connectionState: "connected" };
+}
+
+describe("ms:error transport-timeout does not latch a session refusal (finding 1)", () => {
+  it("clears only the affected direction's transport, leaves refusal unset", () => {
+    const video = new MediasoupVideo();
+    const internals = internalsOf(video);
+    const send = fakeTransport();
+    const recv = fakeTransport();
+    internals.sendTransport = send;
+    internals.recvTransport = recv;
+    // No producers/consumers to republish - isolates this assertion to the
+    // refusal-latch behaviour, covered separately below.
+    internals.producers = new Map();
+    internals.consumers = new Map();
+
+    (internals.handleSignal as (msg: unknown) => void).call(internals, {
+      type: "ms:error",
+      reason: "transport-timeout",
+      direction: "send",
+    });
+
+    // The bug: failSession() used to run for EVERY ms:error, so one
+    // transient failure on either transport permanently rejected every
+    // future request() on the whole session (both directions).
+    expect(internals.refusal).toBeNull();
+    expect(send.close).toHaveBeenCalledTimes(1);
+    expect(internals.sendTransport).toBeNull();
+    // The OTHER direction is untouched - this is the point of finding 1: a
+    // recv-side failure must not also kill a healthy send transport.
+    expect(recv.close).not.toHaveBeenCalled();
+    expect(internals.recvTransport).toBe(recv);
+  });
+
+  it("still refuses the session for a real refusal reason (server-full)", () => {
+    const video = new MediasoupVideo();
+    const internals = internalsOf(video);
+
+    (internals.handleSignal as (msg: unknown) => void).call(internals, {
+      type: "ms:error",
+      reason: "server-full",
+    });
+
+    // Only transport-timeout gets the per-direction treatment; every other
+    // reason is a genuine session refusal and must still latch.
+    expect(internals.refusal).toBeInstanceOf(Error);
+  });
+
+  it("a request issued after a transport-timeout is not rejected by a stale refusal", async () => {
+    const video = new MediasoupVideo();
+    const internals = internalsOf(video);
+    internals.sendTransport = fakeTransport();
+    internals.recvTransport = fakeTransport();
+    internals.producers = new Map();
+    internals.consumers = new Map();
+
+    (internals.handleSignal as (msg: unknown) => void).call(internals, {
+      type: "ms:error",
+      reason: "transport-timeout",
+      direction: "recv",
+    });
+
+    // request() rejects synchronously (before even calling signal()) when
+    // this.refusal is set - that is exactly the "sits out its own 10s
+    // timeout with nothing left alive to answer it" failure finding 1
+    // describes, now provably not reachable from a transport-timeout.
+    const sent: unknown[] = [];
+    internals.sfuWs = { readyState: WebSocket.OPEN, send: (m: string) => sent.push(m) };
+    const pending = (
+      internals.request as (msg: unknown, responseType: string) => Promise<unknown>
+    ).call(internals, { type: "ms:get-capabilities", requestId: "r1" }, "ms:capabilities");
+    // Resolve it immediately via the matching response so the promise does
+    // not hang the test - only reachable at all if request() did not
+    // reject synchronously on a stale refusal.
+    (internals.handleSignal as (msg: unknown) => void).call(internals, {
+      type: "ms:capabilities",
+      requestId: "r1",
+      rtpCapabilities: {},
+      roomPeerCount: 0,
+    });
+    await expect(pending).resolves.toMatchObject({ roomPeerCount: 0 });
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe("getStats consumer stall detector (finding 5)", () => {
+  function fakeConsumerEntry(opts: {
+    id: string;
+    producerId: string;
+    bytesReceived: number;
+    kind?: "audio" | "video";
+  }): {
+    consumer: mediasoupClient.types.Consumer;
+    source: "camera" | "screen";
+    getStatsCalls: number[];
+  } {
+    const state = { closed: false, calls: 0 };
+    const consumer = {
+      get closed() {
+        return state.closed;
+      },
+      id: opts.id,
+      producerId: opts.producerId,
+      kind: opts.kind ?? "video",
+      getStats: vi.fn(async () => {
+        state.calls++;
+        return new Map([
+          [
+            "inbound",
+            { type: "inbound-rtp", bytesReceived: opts.bytesReceived },
+          ],
+        ]);
+      }),
+      close: vi.fn(() => {
+        state.closed = true;
+      }),
+    } as unknown as mediasoupClient.types.Consumer;
+    return { consumer, source: "camera", getStatsCalls: [] };
+  }
+
+  it("does not close a consumer on the first stalled sample", async () => {
+    const video = new MediasoupVideo();
+    const internals = internalsOf(video);
+    const entry = fakeConsumerEntry({
+      id: "c1",
+      producerId: "p1",
+      bytesReceived: 1000,
+    });
+    internals.consumers = new Map([["peer-a", [entry]]]);
+    internals.consumerStats = new Map([["c1", { bytes: 1000, misses: 0 }]]);
+    const consumeProducer = vi.fn();
+    internals.consumeProducer = consumeProducer;
+    const stalled = vi.fn();
+    video.on("trackStalled", stalled);
+
+    await (
+      internals.checkConsumerStats as (peerId: string, c: unknown) => Promise<void>
+    ).call(internals, "peer-a", entry);
+
+    expect(entry.consumer.close).not.toHaveBeenCalled();
+    expect(consumeProducer).not.toHaveBeenCalled();
+    expect(stalled).not.toHaveBeenCalled();
+  });
+
+  it("closes and re-consumes after two consecutive stalled samples, and emits trackStalled once", async () => {
+    const video = new MediasoupVideo();
+    const internals = internalsOf(video);
+    const entry = fakeConsumerEntry({
+      id: "c1",
+      producerId: "p1",
+      bytesReceived: 1000,
+    });
+    internals.consumers = new Map([["peer-a", [entry]]]);
+    // Seeded as if the previous sweep already saw one stalled sample at the
+    // same byte count - this call is the second in a row.
+    internals.consumerStats = new Map([["c1", { bytes: 1000, misses: 1 }]]);
+    const consumeProducer = vi.fn(async () => {});
+    internals.consumeProducer = consumeProducer;
+    const stalled = vi.fn();
+    video.on("trackStalled", stalled);
+
+    await (
+      internals.checkConsumerStats as (peerId: string, c: unknown) => Promise<void>
+    ).call(internals, "peer-a", entry);
+
+    // Every other detector on this path reacts to signalling or transport
+    // state and stays healthy through this exact failure - this is the one
+    // that notices RTP genuinely stopped while everything else says fine.
+    expect(entry.consumer.close).toHaveBeenCalledTimes(1);
+    expect(stalled).toHaveBeenCalledWith("peer-a", "camera");
+    expect(consumeProducer).toHaveBeenCalledWith("peer-a", "p1", "camera");
+    // The stalled entry no longer owns a slot in the peer's consumer list -
+    // otherwise it would sit there stale forever, and a later real
+    // trackRemoved for it (or a second sweep) would double-count it. The
+    // peer had exactly one consumer, so removing it deletes the map entry
+    // rather than leaving an empty array behind.
+    expect((internals.consumers as Map<string, unknown[]>).has("peer-a")).toBe(false);
+  });
+
+  it("resets the miss count and does not close when bytesReceived has advanced", async () => {
+    const video = new MediasoupVideo();
+    const internals = internalsOf(video);
+    const entry = fakeConsumerEntry({
+      id: "c1",
+      producerId: "p1",
+      bytesReceived: 2000, // advanced from the seeded 1000
+    });
+    internals.consumers = new Map([["peer-a", [entry]]]);
+    internals.consumerStats = new Map([["c1", { bytes: 1000, misses: 1 }]]);
+    internals.consumeProducer = vi.fn();
+
+    await (
+      internals.checkConsumerStats as (peerId: string, c: unknown) => Promise<void>
+    ).call(internals, "peer-a", entry);
+
+    expect(entry.consumer.close).not.toHaveBeenCalled();
+    expect((internals.consumerStats as Map<string, { bytes: number; misses: number }>).get("c1")).toEqual({
+      bytes: 2000,
+      misses: 0,
+    });
+  });
+});

--- a/frontend/src/lib/transport/mediasoup.ts
+++ b/frontend/src/lib/transport/mediasoup.ts
@@ -5,6 +5,7 @@ import type * as mediasoupClient from "mediasoup-client";
 import type { VideoTransport, VideoEvents, VideoSource } from "./types";
 import { sfuForRoom } from "./sfu-pool";
 import { shouldBlockSfu } from "./faults";
+import { getIceServers } from "./ice-server-list";
 
 /**
  * Reaches the user verbatim - transmission.svelte assigns an error event's
@@ -17,17 +18,27 @@ import { SFU_PUBLISH_UNAVAILABLE, SFU_UNREACHABLE } from "./types";
 
 interface MSGetCapabilities {
   type: "ms:get-capabilities";
+  requestId: string;
 }
 interface MSCapabilities {
   type: "ms:capabilities";
+  requestId: string;
   rtpCapabilities: mediasoupClient.types.RtpCapabilities;
+  // How many OTHER peers the SFU already holds in this room. A pair placed
+  // on different SFU nodes (finding 13 - a stale cached bundle computing a
+  // different pool) each see 0 here while the room is not actually empty;
+  // an interim guard until the pool is served at runtime instead of built
+  // into the bundle.
+  roomPeerCount: number;
 }
 interface MSCreateTransport {
   type: "ms:create-transport";
+  requestId: string;
   direction: "send" | "recv";
 }
 interface MSTransportOptions {
   type: "ms:transport-options";
+  requestId: string;
   direction: "send" | "recv";
   options: mediasoupClient.types.TransportOptions;
 }
@@ -38,21 +49,25 @@ interface MSConnectTransport {
 }
 interface MSProduce {
   type: "ms:produce";
+  requestId: string;
   kind: mediasoupClient.types.MediaKind;
   rtpParameters: mediasoupClient.types.RtpParameters;
   source: VideoSource;
 }
 interface MSProduced {
   type: "ms:produced";
+  requestId: string;
   producerId: string;
 }
 interface MSConsume {
   type: "ms:consume";
+  requestId: string;
   producerId: string;
   rtpCapabilities: mediasoupClient.types.RtpCapabilities;
 }
 interface MSConsumerOptions {
   type: "ms:consumer-options";
+  requestId: string;
   options: mediasoupClient.types.ConsumerOptions;
   peerId: string;
   source: VideoSource;
@@ -72,6 +87,11 @@ interface MSProducerClosed {
   peerId: string;
   producerId: string;
   source: VideoSource;
+  // Which track this producer carried. Without it, closing a screen share's
+  // AUDIO producer looked identical to closing its VIDEO producer, and the
+  // handler tore down the whole watch - and nulled a live video track -
+  // over a peer merely switching to a window with no audio (finding 4).
+  kind: "audio" | "video";
 }
 interface MSProducerConsumed {
   type: "ms:producer-consumed";
@@ -91,16 +111,29 @@ interface MSCloseProducer {
   type: "ms:close-producer";
   producerId: string;
 }
+/** Ask the server to resume a consumer created paused (see MSConsumerOptions /
+ *  finding 3). Sent once, right after recvTransport.consume() resolves. */
+interface MSResumeConsumer {
+  type: "ms:resume-consumer";
+  producerId: string;
+}
 /**
  * How the SFU refuses a session: it sends this and closes the socket. Without
  * a variant here the frame fell through handleSignal's switch and the refusal
  * was silent - a call that never started, with nothing on screen saying why.
  * `reason` is typed loosely on purpose so an SFU that grows a new one still
  * lands on the generic message rather than on nothing at all.
+ *
+ * `direction` is set only for "transport-timeout": that reason means ONE
+ * transport died server-side (a connect timeout, or a mid-call ICE/DTLS
+ * failure), not the session - the socket stays open and the SFU does not
+ * close it. Every other reason is a real session refusal and the socket
+ * closes right behind it.
  */
 interface MSError {
   type: "ms:error";
   reason: string;
+  direction?: "send" | "recv";
 }
 
 type MSMessage =
@@ -120,6 +153,7 @@ type MSMessage =
   | MSProducerConsumerClosed
   | MSCloseConsumer
   | MSCloseProducer
+  | MSResumeConsumer
   | MSError;
 
 /**
@@ -154,6 +188,17 @@ interface Consumer {
   source: VideoSource;
 }
 
+/** Transport states that will never carry another byte. A transport can die
+ *  in any of these while the socket stays open (finding 2) - sessionIsLive()
+ *  used to only ask the socket and the device, so a dead transport under a
+ *  healthy socket read as "live" and every repair path that gated on it
+ *  became a no-op. */
+const DEAD_TRANSPORT_STATES: Record<string, true> = {
+  failed: true,
+  disconnected: true,
+  closed: true,
+};
+
 /**
  * Mediasoup SFU video implementation.
  * Handles camera and screen share via server-side fan-out.
@@ -172,11 +217,19 @@ export class MediasoupVideo implements VideoTransport {
   private producers: Map<VideoSource, Producer[]> = new Map();
   private consumers: Map<string, Consumer[]> = new Map(); // peerId → consumers
   private active: Set<string> = new Set();
-  private paused: Set<VideoSource> = new Set();
   private handlers: Map<keyof VideoEvents, Set<Function>> = new Map();
-  private pending: Map<string, { resolve: Function; reject: Function }[]> =
-    new Map();
-  private pendingChains: Map<string, Promise<any>> = new Map();
+  // Keyed by requestId, not by response type: the old per-type FIFO queue
+  // handed a late reply to whichever request had since taken its place in
+  // the queue once the original timed out (finding 9), and serialized every
+  // request of one type behind whichever one was ahead of it even when
+  // nothing connects them (finding 10) - a joiner replayed 8 producers paid
+  // 10s of dead air per dead producer ahead of it in line, and could push
+  // the recv transport past the server's own connect-timeout reap.
+  private pendingById: Map<
+    string,
+    { resolve: (msg: MSMessage) => void; reject: (err: Error) => void }
+  > = new Map();
+  private requestSeq = 0;
   // Set when the SFU refuses this session with an ms:error frame, cleared when
   // a new socket is opened. The refusal is immediately followed by the socket
   // closing, so a request issued after it would be dropped by signal() and sit
@@ -198,18 +251,43 @@ export class MediasoupVideo implements VideoTransport {
   private currentPeerId: string | null = null;
   private joinGeneration = 0; // incremented on each join() to guard against stale attemptRejoin
 
+  // How many OTHER peers the SFU room held at join time (finding 13's interim
+  // split-brain guard; the real fix is serving the pool at runtime, which is
+  // outside this file). 0 is indistinguishable from "alone" and from "the
+  // SFU predates this field" - a caller that expects company should cross
+  // check against its own roster, not trust 0 by itself.
+  private lastRoomPeerCount = 0;
+
+  // getStats() sweep over live consumers - the only thing on this path that
+  // ever looks at whether media actually arrives (finding 5). Every other
+  // detector here reacts to signalling or to connectionstatechange, and both
+  // stay healthy while one stream quietly stalls: the SSRC got dropped by a
+  // middlebox, the remote encoder stalled, or the server is forwarding from a
+  // producer whose sender is long gone.
+  private statsTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly STATS_INTERVAL_MS = 3_000;
+  // Two sweeps running, matching the p2p voice watchdog's shape (twice its
+  // own reconcile tick) - see the hub note to FixVoice. A blip that clears
+  // within one sweep never trips this; only a consumer stuck at the same
+  // byte count for two consecutive samples counts as stalled.
+  private readonly STATS_STALL_MISSES = 2;
+  // consumer.id → last bytesReceived sample and how many sweeps in a row it
+  // has not moved.
+  private consumerStats: Map<string, { bytes: number; misses: number }> =
+    new Map();
+
   async join(roomCode: string, peerId: string): Promise<void> {
     this.joinGeneration++;
-    const generation = this.joinGeneration;
     try {
       this.currentRoomCode = roomCode;
       this.currentPeerId = peerId;
       await this.connectSfu(roomCode, peerId);
 
       const capMsg = await this.request<MSCapabilities>(
-        { type: "ms:get-capabilities" },
+        { type: "ms:get-capabilities", requestId: this.nextRequestId() },
         "ms:capabilities"
       );
+      this.lastRoomPeerCount = capMsg.roomPeerCount;
 
       const { Device } = await import("mediasoup-client");
       this.device = new Device();
@@ -228,6 +306,7 @@ export class MediasoupVideo implements VideoTransport {
       // is now stale - without this signal it sat on screen forever even
       // after video quietly came back.
       this.emit("healed");
+      this.startStatsSweep();
     } catch (err) {
       this.emit("error", err instanceof Error ? err : new Error(String(err)));
       throw err;
@@ -248,10 +327,10 @@ export class MediasoupVideo implements VideoTransport {
     this.sfuWs?.close();
     this.sfuWs = null;
 
+    this.stopStatsSweep();
     this.producers.clear();
     this.consumers.clear();
     this.active.clear();
-    this.paused.clear();
     this.pendingTransmissions.clear();
     this.pendingScreenProducerIds.clear();
     this.watchingTransmissionPeers.clear();
@@ -259,8 +338,7 @@ export class MediasoupVideo implements VideoTransport {
     this.device = null;
     this.sendTransport = null;
     this.recvTransport = null;
-    this.pending.clear();
-    this.pendingChains.clear();
+    this.pendingById.clear();
     this.currentRoomCode = null;
     this.currentPeerId = null;
   }
@@ -291,44 +369,31 @@ export class MediasoupVideo implements VideoTransport {
         audio: true,
       }));
     await this.publish(s, "screen");
-
-    // browser fires this when user clicks "stop sharing"
-    s.getVideoTracks()[0].onended = () => this.stopScreenShare();
+    // Track lifecycle (including the browser's own "Stop sharing" button,
+    // which ends the video track) is owned by the app layer - call.svelte
+    // already installs its own onended that calls stopScreenShare() and
+    // plays the stop sound. Assigning a second one here silently overwrote
+    // it, so clicking the browser's control never played the sound
+    // (finding 19).
   }
 
   stopScreenShare(): void {
     this.stopSource("screen");
   }
 
-  pauseVideo(source: VideoSource): void {
-    const ps = this.producers.get(source);
-    if (!ps) return;
-    ps.forEach((p) => p.producer.pause());
-    this.paused.add(source);
-  }
-
-  resumeVideo(source: VideoSource): void {
-    const ps = this.producers.get(source);
-    if (!ps) return;
-    ps.forEach((p) => p.producer.resume());
-    this.paused.delete(source);
-  }
-
-  isPaused(source: VideoSource): boolean {
-    return this.paused.has(source);
-  }
-
-  isPublishing(source: VideoSource): boolean {
-    return (this.producers.get(source)?.length ?? 0) > 0;
-  }
-
   /** Start watching a pending screen-share transmission from a remote peer. */
   async watchTransmission(peerId: string, producerId: string): Promise<void> {
-    // Already actively watching this peer's transmission (has live consumers)
+    // Already actively watching this peer's transmission (has a live VIDEO
+    // consumer). Scoped to video, not "any screen consumer" - an audio-only
+    // screen consumer must not block a retry (finding 12): video failing
+    // while audio succeeded used to count as success forever, with no video
+    // consumer ever attempted again and this early return refusing every
+    // later click on the tile.
     const existingConsumers = this.consumers.get(peerId);
     if (
-      existingConsumers &&
-      existingConsumers.some((c) => c.source === "screen")
+      existingConsumers?.some(
+        (c) => c.source === "screen" && c.consumer.kind === "video"
+      )
     ) {
       return;
     }
@@ -337,16 +402,20 @@ export class MediasoupVideo implements VideoTransport {
     this.watchingTransmissionPeers.add(peerId);
     const all = this.pendingScreenProducerIds.get(peerId);
     if (all && all.size > 0) {
-      let consumed = 0;
       for (const id of all) {
         try {
           await this.consumeProducer(peerId, id, "screen");
-          consumed += 1;
         } catch {
           // keep going; one bad producer shouldn't block the whole transmission
         }
       }
-      if (consumed === 0) {
+      // Require the VIDEO producer specifically (finding 12): audio alone
+      // used to satisfy this and leave the viewer's tile in a permanent
+      // "connecting" state with nothing left to retry it.
+      const gotVideo = this.consumers
+        .get(peerId)
+        ?.some((c) => c.source === "screen" && c.consumer.kind === "video");
+      if (!gotVideo) {
         throw new Error("Failed to consume transmission");
       }
       return;
@@ -366,6 +435,8 @@ export class MediasoupVideo implements VideoTransport {
         producerId: c.consumer.producerId,
       });
       c.consumer.close();
+      this.consumerStats.delete(c.consumer.id);
+      this.emit("trackRemoved", peerId, "screen", c.consumer.kind);
     }
     // Remove screen consumers from the map entry
     const remaining = peerConsumers.filter((c) => c.source !== "screen");
@@ -374,7 +445,6 @@ export class MediasoupVideo implements VideoTransport {
     } else {
       this.consumers.delete(peerId);
     }
-    this.emit("trackRemoved", peerId, "screen");
   }
 
   /** Returns a copy of pending transmissions: peerId → producerId. */
@@ -395,16 +465,19 @@ export class MediasoupVideo implements VideoTransport {
     return Array.from(this.active);
   }
 
-  getAudioTrack(peerId: string): MediaStreamTrack | null {
-    const peerConsumers = this.consumers.get(peerId);
-    if (!peerConsumers) return null;
-    const audioConsumer = peerConsumers.find(
-      (c) => c.source === "screen" && c.consumer.track.kind === "audio"
-    );
-    return audioConsumer ? audioConsumer.consumer.track : null;
+  /** How many OTHER peers the SFU room held when this session last joined
+   *  (finding 13's interim split-brain guard). Cross-check against the
+   *  call's own roster size - a mismatch means this client and the peer it
+   *  expects are not actually on the same SFU node. */
+  roomPeerCount(): number {
+    return this.lastRoomPeerCount;
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private nextRequestId(): string {
+    return `r${++this.requestSeq}`;
+  }
 
   /**
    * Open a WebSocket to the SFU and send the join message.
@@ -460,13 +533,10 @@ export class MediasoupVideo implements VideoTransport {
         const wasJoined = this.device !== null;
 
         // Reject all pending requests when connection drops
-        for (const [type, queue] of this.pending) {
-          for (const req of queue) {
-            req.reject(new Error(`SFU connection closed waiting for ${type}`));
-          }
+        for (const req of this.pendingById.values()) {
+          req.reject(new Error("SFU connection closed"));
         }
-        this.pending.clear();
-        this.pendingChains.clear();
+        this.pendingById.clear();
 
         // If we were joined, emit an error and attempt automatic rejoin
         if (wasJoined && this.currentRoomCode && this.currentPeerId) {
@@ -511,12 +581,20 @@ export class MediasoupVideo implements VideoTransport {
    * Whether the SFU session is actually usable - not merely whether a socket
    * is open. An open socket with no transports behind it is the state you land
    * in when the handshake stalls after connecting, and treating that as "live"
-   * is what stopped it ever healing.
+   * is what stopped it ever healing. A transport that exists but has gone
+   * failed/disconnected/closed under a perfectly healthy socket is the same
+   * kind of lie (finding 2): nothing about the socket or the device notices,
+   * so this must check the transports too.
    */
   private sessionIsLive(): boolean {
-    // The device is what join() finishes with; transports are lazy now, so
-    // their absence says nothing about the session.
-    return this.sfuWs?.readyState === WebSocket.OPEN && this.device != null;
+    if (this.refusal) return false;
+    if (this.sfuWs?.readyState !== WebSocket.OPEN || this.device == null) {
+      return false;
+    }
+    for (const t of [this.sendTransport, this.recvTransport]) {
+      if (t && DEAD_TRANSPORT_STATES[t.connectionState]) return false;
+    }
+    return true;
   }
 
   /** Whether the SFU session is actually up right now. */
@@ -569,6 +647,7 @@ export class MediasoupVideo implements VideoTransport {
       this.emit("peerLeft", peer);
     }
     this.consumers.clear();
+    this.consumerStats.clear();
     this.producers.forEach((ps) => ps.forEach((p) => p.producer.close()));
     this.producers.clear();
     this.active.clear();
@@ -589,6 +668,97 @@ export class MediasoupVideo implements VideoTransport {
     await this.join(roomCode, peerId);
     for (const { source, stream } of republish) {
       await this.publish(stream, source);
+    }
+  }
+
+  /**
+   * The SFU reaped exactly one transport - a connect timeout, or a mid-call
+   * ICE/DTLS failure (sfu/index.ts's reapTransport) - and told us with
+   * reason "transport-timeout". The socket and the OTHER direction are still
+   * fine, so this must not become a session refusal: failSession() used to
+   * latch this.refusal for EVERY ms:error, so one transient DTLS failure on
+   * the recv transport also killed a perfectly healthy send transport for
+   * the rest of the call, and the banner's promised retry never ran because
+   * nothing had scheduled one (finding 1). Rebuild just the affected
+   * direction instead of the whole session.
+   */
+  private handleTransportTimeout(direction: "send" | "recv" | undefined): void {
+    this.emit(
+      "error",
+      new Error(
+        direction === "send"
+          ? "Send transport timed out - retrying in the background"
+          : direction === "recv"
+            ? "Receive transport timed out - retrying in the background"
+            : "Video transport timed out - retrying in the background"
+      )
+    );
+    // No direction on the frame means an older/mismatched server; rebuild
+    // both rather than guess which one actually died.
+    if (direction !== "recv") this.rebuildSendTransport();
+    if (direction !== "send") this.rebuildRecvTransport();
+  }
+
+  /** Rebuild the send side after its transport died server-side: drop the
+   *  dead transport and republish whatever local tracks are still live -
+   *  the same republish step attemptRejoin uses, scoped to one direction so
+   *  a healthy recv transport is left untouched. */
+  private rebuildSendTransport(): void {
+    if (!this.sendTransport) return;
+    this.sendTransport.close();
+    this.sendTransport = null;
+    const republish: { source: VideoSource; stream: MediaStream }[] = [];
+    for (const [source, ps] of this.producers) {
+      const stream = ps[0]?.stream;
+      if (stream?.getTracks().some((t) => t.readyState === "live")) {
+        republish.push({ source, stream });
+      }
+    }
+    this.producers.forEach((ps) => ps.forEach((p) => p.producer.close()));
+    this.producers.clear();
+    for (const { source, stream } of republish) {
+      this.publish(stream, source).catch((err) => {
+        this.emit(
+          "error",
+          err instanceof Error ? err : new Error(String(err))
+        );
+      });
+    }
+  }
+
+  /** Rebuild the recv side after its transport died server-side: every
+   *  consumer lived on it, so all of them are dead now regardless of what
+   *  their own state says. Re-consume the same producer ids on a fresh
+   *  transport instead of leaving frozen tiles with nothing left to retry
+   *  them. */
+  private rebuildRecvTransport(): void {
+    if (!this.recvTransport) return;
+    this.recvTransport.close();
+    this.recvTransport = null;
+    const toRestore: {
+      peerId: string;
+      producerId: string;
+      source: VideoSource;
+    }[] = [];
+    for (const [peerId, cs] of this.consumers) {
+      for (const c of cs) {
+        toRestore.push({
+          peerId,
+          producerId: c.consumer.producerId,
+          source: c.source,
+        });
+        c.consumer.close();
+      }
+    }
+    this.consumers.clear();
+    this.consumerStats.clear();
+    for (const { peerId, producerId, source } of toRestore) {
+      this.consumeProducer(peerId, producerId, source).catch((err) => {
+        this.emit(
+          "error",
+          err instanceof Error ? err : new Error(String(err))
+        );
+      });
     }
   }
 
@@ -618,35 +788,54 @@ export class MediasoupVideo implements VideoTransport {
     }
 
     const produced: Producer[] = [];
-    for (const track of tracks) {
-      const producer = await this.sendTransport.produce({
-        track,
-        appData: { source },
-        // Track lifecycle is owned by the app (stopSource / call.svelte),
-        // and rejoin republishes the same tracks after a transport rebuild.
-        stopTracks: false,
-        // The only audio through the SFU is screen-share loopback (voice is
-        // p2p): game and media sound, not speech. Default Opus is mono,
-        // voice-tuned, with DTX gating quiet passages - music through that
-        // collapses to a phone call. Stereo, no DTX, and enough bitrate.
-        ...(track.kind === "audio"
-          ? {
-              codecOptions: {
-                opusStereo: true,
-                opusDtx: false,
-                opusMaxAverageBitrate: 128_000,
-              },
-            }
-          : {}),
-      });
+    try {
+      for (const track of tracks) {
+        const producer = await this.sendTransport.produce({
+          track,
+          appData: { source },
+          // Track lifecycle is owned by the app (stopSource / call.svelte),
+          // and rejoin republishes the same tracks after a transport rebuild.
+          stopTracks: false,
+          // The only audio through the SFU is screen-share loopback (voice is
+          // p2p): game and media sound, not speech. Default Opus is mono,
+          // voice-tuned, with DTX gating quiet passages - music through that
+          // collapses to a phone call. Stereo, no DTX, and enough bitrate.
+          ...(track.kind === "audio"
+            ? {
+                codecOptions: {
+                  opusStereo: true,
+                  opusDtx: false,
+                  opusMaxAverageBitrate: 128_000,
+                },
+              }
+            : {}),
+        });
 
-      const entry: Producer = { producer, source, stream };
-      produced.push(entry);
+        const entry: Producer = { producer, source, stream };
+        produced.push(entry);
+        // Record incrementally, not once after the whole loop: a screen
+        // share produces video then audio, and if audio throws, this.producers
+        // must already know about the video producer that DID succeed and
+        // that every other peer was already told about via ms:new-producer -
+        // otherwise stopSource(source) finds nothing to close and that
+        // producer is orphaned for the rest of the call (finding 11).
+        this.producers.set(source, produced);
 
-      producer.on("trackended", () => this.stopSource(source));
+        producer.on("trackended", () => this.stopSource(source));
+      }
+    } catch (err) {
+      // The video producer above (if any) is live on the server and every
+      // other peer already has it - closing it here and telling the server
+      // means the sharer's "not sharing" UI state and what the room is
+      // actually offering agree, instead of the room being handed a
+      // producer whose track is about to stop and never deliver anything.
+      for (const p of produced) {
+        this.signal({ type: "ms:close-producer", producerId: p.producer.id });
+        p.producer.close();
+      }
+      this.producers.delete(source);
+      throw err;
     }
-
-    this.producers.set(source, produced);
   }
 
   private stopSource(source: VideoSource): void {
@@ -663,9 +852,12 @@ export class MediasoupVideo implements VideoTransport {
     });
     ps[0].stream.getTracks().forEach((t) => t.stop());
     this.producers.delete(source);
-    this.paused.delete(source);
-    // Emit locally so UI updates immediately for the sender
-    this.emit("trackRemoved", "local", source);
+    // Emit locally so UI updates immediately for the sender - once per
+    // producer kind, so a screen share's video and audio removal are told
+    // apart (finding 4) instead of one event that could mean either.
+    for (const p of ps) {
+      this.emit("trackRemoved", "local", source, p.producer.kind);
+    }
   }
 
   private sendTransportP: Promise<void> | null = null;
@@ -691,13 +883,23 @@ export class MediasoupVideo implements VideoTransport {
 
   private async createSendTransport(): Promise<void> {
     const msg = await this.request<MSTransportOptions>(
-      { type: "ms:create-transport", direction: "send" },
+      {
+        type: "ms:create-transport",
+        requestId: this.nextRequestId(),
+        direction: "send",
+      },
       "ms:transport-options"
     );
 
-    this.sendTransport = this.device!.createSendTransport(
-      msg.options as mediasoupClient.types.TransportOptions
-    );
+    this.sendTransport = this.device!.createSendTransport({
+      ...(msg.options as mediasoupClient.types.TransportOptions),
+      // The server never gathers relay candidates of its own (it is
+      // ICE-Lite; the browser is the controlling agent), so without this a
+      // network that blocks outbound UDP and permits only 80/443 had no
+      // path to the SFU at all - voice (which does carry iceServers,
+      // libp2p/voice.ts) worked and video silently never did (finding 7).
+      iceServers: getIceServers(),
+    });
 
     this.sendTransport.on(
       "connect",
@@ -717,7 +919,13 @@ export class MediasoupVideo implements VideoTransport {
         try {
           const source = (appData as { source: VideoSource }).source;
           const { producerId } = await this.request<{ producerId: string }>(
-            { type: "ms:produce", kind, rtpParameters, source },
+            {
+              type: "ms:produce",
+              requestId: this.nextRequestId(),
+              kind,
+              rtpParameters,
+              source,
+            },
             "ms:produced"
           );
           callback({ id: producerId });
@@ -728,7 +936,7 @@ export class MediasoupVideo implements VideoTransport {
     );
 
     this.sendTransport.on("connectionstatechange", (state: string) => {
-      if (state === "failed") {
+      if (state === "failed" || state === "closed") {
         this.emit("error", new Error("Send transport connection failed"));
         this.scheduleRejoin(this.joinGeneration);
       }
@@ -737,13 +945,20 @@ export class MediasoupVideo implements VideoTransport {
 
   private async createRecvTransport(): Promise<void> {
     const msg = await this.request<MSTransportOptions>(
-      { type: "ms:create-transport", direction: "recv" },
+      {
+        type: "ms:create-transport",
+        requestId: this.nextRequestId(),
+        direction: "recv",
+      },
       "ms:transport-options"
     );
 
-    this.recvTransport = this.device!.createRecvTransport(
-      msg.options as mediasoupClient.types.TransportOptions
-    );
+    this.recvTransport = this.device!.createRecvTransport({
+      ...(msg.options as mediasoupClient.types.TransportOptions),
+      // See createSendTransport - the recv leg needs the same relay path
+      // (finding 7).
+      iceServers: getIceServers(),
+    });
 
     this.recvTransport.on(
       "connect",
@@ -758,7 +973,7 @@ export class MediasoupVideo implements VideoTransport {
     );
 
     this.recvTransport.on("connectionstatechange", (state: string) => {
-      if (state === "failed") {
+      if (state === "failed" || state === "closed") {
         this.emit("error", new Error("Receive transport connection failed"));
         this.scheduleRejoin(this.joinGeneration);
       }
@@ -784,19 +999,27 @@ export class MediasoupVideo implements VideoTransport {
     // pending lookup: every reason the SFU sends lands during the join
     // handshake, where a request is waiting for a frame that is never coming.
     if (msg.type === "ms:error") {
-      this.failSession(sfuRefusalMessage(msg.reason));
+      if (msg.reason === "transport-timeout") {
+        this.handleTransportTimeout(msg.direction);
+      } else {
+        this.failSession(sfuRefusalMessage(msg.reason));
+      }
       return;
     }
 
-    // resolve pending request
-    const queue = this.pending.get(msg.type);
-    if (queue && queue.length > 0) {
-      const req = queue.shift()!;
-      req.resolve(msg);
-      if (queue.length === 0) {
-        this.pending.delete(msg.type);
+    // Resolve by requestId, not by response type (findings 9 and 10): the
+    // old FIFO queue handed a late reply to whichever request of the same
+    // type had since taken its place after the original timed out, and
+    // serialized every request of one type behind whichever one was ahead
+    // of it even when nothing connects them.
+    const requestId = (msg as { requestId?: string }).requestId;
+    if (requestId) {
+      const pending = this.pendingById.get(requestId);
+      if (pending) {
+        this.pendingById.delete(requestId);
+        pending.resolve(msg);
+        return;
       }
-      return;
     }
 
     switch (msg.type) {
@@ -830,13 +1053,23 @@ export class MediasoupVideo implements VideoTransport {
           this.pendingTransmissions.set(msg.peerId, msg.producerId);
           this.emit("transmissionAvailable", msg.peerId, msg.producerId);
         } else {
-          this.consumeProducer(msg.peerId, msg.producerId, msg.source);
+          // ms:new-producer is sent once, at produce time (and in the join
+          // replay) - it never repeats, so a single lost consume used to be
+          // permanent with no catch at all here (finding 8).
+          void this.consumeProducerWithRetry(
+            msg.peerId,
+            msg.producerId,
+            msg.source
+          );
         }
         break;
       case "ms:peer-left":
         if (this.active.has(msg.peerId)) {
           this.active.delete(msg.peerId);
-          this.consumers.get(msg.peerId)?.forEach((c) => c.consumer.close());
+          this.consumers.get(msg.peerId)?.forEach((c) => {
+            this.consumerStats.delete(c.consumer.id);
+            c.consumer.close();
+          });
           this.consumers.delete(msg.peerId);
           this.emit("peerLeft", msg.peerId);
         }
@@ -849,13 +1082,14 @@ export class MediasoupVideo implements VideoTransport {
         this.watchingTransmissionPeers.delete(msg.peerId);
         break;
 
-      case "ms:producer-closed":
+      case "ms:producer-closed": {
         // Close all consumers for this producer and emit trackRemoved
         this.consumers.forEach((consumerList, peerId) => {
           const filtered = consumerList.filter((c) => {
             if (c.consumer.producerId === msg.producerId) {
+              this.consumerStats.delete(c.consumer.id);
               c.consumer.close();
-              this.emit("trackRemoved", peerId, msg.source);
+              this.emit("trackRemoved", peerId, msg.source, msg.kind);
               return false;
             }
             return true;
@@ -879,13 +1113,23 @@ export class MediasoupVideo implements VideoTransport {
               }
             }
           }
-          // Also emit transmissionEnded if we were watching this peer's transmission
-          if (this.watchingTransmissionPeers.has(msg.peerId)) {
+          // Only tear down the watch once no screen consumer for this peer
+          // survives (finding 4): closing just the audio producer - a
+          // surface switch, or a shared window with no audio track - must
+          // not kill a video consumer that is still live and delivering.
+          const stillHasScreenConsumer = this.consumers
+            .get(msg.peerId)
+            ?.some((c) => c.source === "screen");
+          if (
+            this.watchingTransmissionPeers.has(msg.peerId) &&
+            !stillHasScreenConsumer
+          ) {
             this.watchingTransmissionPeers.delete(msg.peerId);
             this.emit("transmissionEnded", msg.peerId);
           }
         }
         break;
+      }
 
       case "ms:producer-consumed":
         this.emit("transmissionWatched", msg.peerId);
@@ -903,12 +1147,27 @@ export class MediasoupVideo implements VideoTransport {
     source: VideoSource
   ): Promise<void> {
     if (!this.device) return;
+    // A retry (finding 8), a stats-triggered re-consume (finding 5), and two
+    // ms:new-producer deliveries for the same id must not double-consume -
+    // the server's own duplicate-consume path (sfu/index.ts) resends the
+    // SAME consumer id, and asking mediasoup-client to build a second local
+    // Consumer for an id it may already hold is exactly the ambiguity the
+    // audit could not settle (its gap 6). Dedupe here makes it moot.
+    const existing = this.consumers.get(peerId);
+    if (
+      existing?.some(
+        (c) => c.consumer.producerId === producerId && !c.consumer.closed
+      )
+    ) {
+      return;
+    }
     await this.ensureRecvTransport();
     if (!this.recvTransport) return;
 
     const response = await this.request<MSConsumerOptions>(
       {
         type: "ms:consume",
+        requestId: this.nextRequestId(),
         producerId,
         rtpCapabilities: this.device.recvRtpCapabilities,
       },
@@ -916,6 +1175,13 @@ export class MediasoupVideo implements VideoTransport {
     );
 
     const consumer = await this.recvTransport.consume(response.options);
+    // The server creates every consumer paused (see handleConsume) so no RTP
+    // is wasted - and no keyframe lost - while the recv transport's DTLS
+    // handshake is still in flight. Resuming here is what actually starts
+    // media, and mediasoup forces a fresh keyframe request on resume, so the
+    // first frame the decoder ever sees is always an IDR rather than an
+    // arbitrary point in a GOP the client never asked for (finding 3).
+    this.signal({ type: "ms:resume-consumer", producerId });
 
     if (!this.consumers.has(peerId)) this.consumers.set(peerId, []);
     this.consumers.get(peerId)!.push({ consumer, source });
@@ -928,11 +1194,41 @@ export class MediasoupVideo implements VideoTransport {
     this.emit("trackAdded", peerId, consumer.track, source);
 
     consumer.on("trackended", () => {
-      this.emit("trackRemoved", peerId, source);
+      this.consumerStats.delete(consumer.id);
+      this.emit("trackRemoved", peerId, source, consumer.kind);
       if (source === "screen") {
         this.emit("transmissionEnded", peerId);
       }
     });
+  }
+
+  /**
+   * consumeProducer with one bounded retry. ms:new-producer is sent once, at
+   * produce time (and once more in the join replay); it never repeats. Before
+   * this, the camera auto-consume call site had no catch at all, so any
+   * failure - a transport-options timeout while the recv transport was being
+   * built, or a canConsume race against a producer that closed between the
+   * announcement and this call - left that peer's camera an avatar for the
+   * rest of the call with nothing retried and nothing surfaced (finding 8).
+   */
+  private async consumeProducerWithRetry(
+    peerId: string,
+    producerId: string,
+    source: VideoSource
+  ): Promise<void> {
+    try {
+      await this.consumeProducer(peerId, producerId, source);
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      try {
+        await this.consumeProducer(peerId, producerId, source);
+      } catch (err) {
+        this.emit(
+          "error",
+          err instanceof Error ? err : new Error(String(err))
+        );
+      }
+    }
   }
 
   /**
@@ -944,66 +1240,129 @@ export class MediasoupVideo implements VideoTransport {
   private failSession(message: string): void {
     const err = new Error(message);
     this.refusal = err;
-    for (const queue of this.pending.values()) {
-      for (const req of queue) req.reject(err);
+    for (const req of this.pendingById.values()) {
+      req.reject(err);
     }
-    this.pending.clear();
-    this.pendingChains.clear();
+    this.pendingById.clear();
     this.emit("error", err);
   }
 
   private request<T>(msg: MSMessage, responseType: string): Promise<T> {
-    // Chain this request to serialize by responseType. The .catch() is
-    // load-bearing: without it one timed-out request would poison the chain
-    // and instantly reject every later request of the same type.
-    const prevChain = this.pendingChains.get(responseType) ?? Promise.resolve();
-    const chain = prevChain.catch(() => {}).then(
-      () =>
-        new Promise<T>((resolve, reject) => {
-          // A refused session never answers anything: the SFU closed the
-          // socket right after its ms:error, so signal() below would drop this
-          // frame and the caller would wait out the full timeout for nothing.
-          if (this.refusal) {
-            reject(this.refusal);
-            return;
-          }
+    return new Promise<T>((resolve, reject) => {
+      // A refused session never answers anything: the SFU closed the socket
+      // right after its ms:error, so signal() below would drop this frame
+      // and the caller would wait out the full timeout for nothing.
+      if (this.refusal) {
+        reject(this.refusal);
+        return;
+      }
 
-          // Queue this request
-          if (!this.pending.has(responseType)) {
-            this.pending.set(responseType, []);
-          }
+      const requestId = (msg as { requestId?: string }).requestId;
 
-          let timeoutId: ReturnType<typeof setTimeout>;
-          const resolveHandler = (response: MSMessage) => {
+      const timeoutId = setTimeout(() => {
+        if (requestId) this.pendingById.delete(requestId);
+        reject(new Error(`mediasoup request timeout: ${responseType}`));
+      }, 10_000);
+
+      if (requestId) {
+        this.pendingById.set(requestId, {
+          resolve: (response: MSMessage) => {
             clearTimeout(timeoutId);
             resolve(response as unknown as T);
-          };
+          },
+          reject: (err: Error) => {
+            clearTimeout(timeoutId);
+            reject(err);
+          },
+        });
+      }
 
-          timeoutId = setTimeout(() => {
-            // Remove from queue on timeout
-            const queue = this.pending.get(responseType);
-            if (queue) {
-              const idx = queue.findIndex((r) => r.resolve === resolveHandler);
-              if (idx >= 0) {
-                queue.splice(idx, 1);
-              }
-            }
-            reject(new Error(`mediasoup request timeout: ${responseType}`));
-          }, 10_000);
+      this.signal(msg);
+    });
+  }
 
-          this.pending.get(responseType)!.push({
-            resolve: resolveHandler,
-            reject: (err: Error) => {
-              clearTimeout(timeoutId);
-              reject(err);
-            },
-          });
-
-          this.signal(msg);
-        })
+  /** Start the getStats() sweep (finding 5). Idempotent - join() calls this
+   *  once per session; a rejoin tears the whole instance state down first. */
+  private startStatsSweep(): void {
+    if (this.statsTimer) return;
+    this.statsTimer = setInterval(
+      () => this.sweepConsumerStats(),
+      this.STATS_INTERVAL_MS
     );
-    this.pendingChains.set(responseType, chain);
-    return chain;
+  }
+
+  private stopStatsSweep(): void {
+    if (this.statsTimer) {
+      clearInterval(this.statsTimer);
+      this.statsTimer = null;
+    }
+    this.consumerStats.clear();
+  }
+
+  private sweepConsumerStats(): void {
+    for (const [peerId, cs] of this.consumers) {
+      for (const c of cs) {
+        void this.checkConsumerStats(peerId, c);
+      }
+    }
+  }
+
+  /**
+   * One consumer, one getStats() round trip. Two stalled samples in a row -
+   * the byte count identical both times - means the RTP genuinely stopped,
+   * not that one sweep landed between two packets: connectionstatechange,
+   * producer-closed and peer-left all stay healthy through this failure
+   * (finding 5), so this is the only thing that notices a frozen tile or
+   * silent screen-share audio while everything else still says "connected".
+   */
+  private async checkConsumerStats(peerId: string, c: Consumer): Promise<void> {
+    if (c.consumer.closed) return;
+    let bytes = 0;
+    try {
+      const report = await c.consumer.getStats();
+      for (const stat of report.values()) {
+        if ((stat as { type?: string }).type === "inbound-rtp") {
+          bytes = (stat as { bytesReceived?: number }).bytesReceived ?? 0;
+          break;
+        }
+      }
+    } catch {
+      return;
+    }
+    if (c.consumer.closed) return; // may have closed while getStats() was in flight
+
+    const key = c.consumer.id;
+    const prev = this.consumerStats.get(key);
+    if (!prev || bytes > prev.bytes) {
+      this.consumerStats.set(key, { bytes, misses: 0 });
+      return;
+    }
+
+    const misses = prev.misses + 1;
+    if (misses < this.STATS_STALL_MISSES) {
+      this.consumerStats.set(key, { bytes, misses });
+      return;
+    }
+
+    // Stalled for two sweeps running: close the dead consumer and re-consume
+    // the same producer id. Tell the server first - closing only locally
+    // would leave the server's own consumer record in place, and the next
+    // ms:consume for this producer would hit its duplicate-consume path and
+    // hand back the SAME consumer id we just abandoned.
+    this.consumerStats.delete(key);
+    this.emit("trackStalled", peerId, c.source);
+    const producerId = c.consumer.producerId;
+    this.signal({ type: "ms:close-consumer", producerId });
+    c.consumer.close();
+    const list = this.consumers.get(peerId);
+    if (list) {
+      const remaining = list.filter((entry) => entry !== c);
+      if (remaining.length > 0) this.consumers.set(peerId, remaining);
+      else this.consumers.delete(peerId);
+    }
+    this.consumeProducer(peerId, producerId, c.source).catch((err) => {
+      this.emit("error", err instanceof Error ? err : new Error(String(err)));
+    });
   }
 
   private emit<K extends keyof VideoEvents>(

--- a/frontend/src/lib/transport/transmission.svelte.ts
+++ b/frontend/src/lib/transport/transmission.svelte.ts
@@ -8,7 +8,7 @@ import { transportState, _transport } from "./transport.svelte";
 import { encode } from "../utils";
 import { MessageType } from "../types/message";
 import type { MediasoupVideo } from "./mediasoup";
-import { SFU_PUBLISH_UNAVAILABLE, SFU_UNREACHABLE } from "./types";
+import { cancelErrorClear, setErrorWithAutoClear } from "./call-error";
 
 let _video: MediasoupVideo | null = null;
 let _volume = 1;
@@ -26,24 +26,34 @@ export function initTransmission(video: MediasoupVideo): void {
       videoTrack: null,
       screenTrack: null,
       screenAudioTrack: null,
+      videoStalled: false,
+      screenStalled: false,
     };
+    // A landed track is the only recovery signal trackStalled gets (no
+    // separate "recovered" event) - clear the stall for the source that
+    // just produced a track, never the other one.
     transportState.participants = new Map(transportState.participants).set(
       peerId,
       source === "camera"
-        ? { ...existing, videoTrack: track }
+        ? { ...existing, videoTrack: track, videoStalled: false }
         : track.kind === "audio"
-          ? { ...existing, screenAudioTrack: track }
-          : { ...existing, screenTrack: track }
+          ? { ...existing, screenAudioTrack: track, screenStalled: false }
+          : { ...existing, screenTrack: track, screenStalled: false }
     );
-    if (!transportState.sfuPeerIds.has(peerId)) {
-      transportState.sfuPeerIds = new Set([
-        ...transportState.sfuPeerIds,
-        peerId,
-      ]);
-    }
   });
 
-_video.on("trackRemoved", (peerId, source) => {
+  _video.on("trackStalled", (peerId, source) => {
+    const p = transportState.participants.get(peerId);
+    if (!p) return;
+    transportState.participants = new Map(transportState.participants).set(
+      peerId,
+      source === "camera"
+        ? { ...p, videoStalled: true }
+        : { ...p, screenStalled: true }
+    );
+  });
+
+_video.on("trackRemoved", (peerId, source, kind) => {
   // Handle local tracks (screen share stopped via browser button)
   if (peerId === "local") {
     if (source === "screen") {
@@ -55,25 +65,21 @@ _video.on("trackRemoved", (peerId, source) => {
     }
     return;
   }
-  // Handle remote tracks
+  // Handle remote tracks. `kind` distinguishes which underlying track
+  // ended - closing the screen AUDIO producer must not also null the
+  // screen VIDEO track (sfu-audit finding 4: it used to tear down the
+  // viewer's whole watch and leave a dead "click to watch" tile behind).
   const p = transportState.participants.get(peerId);
   if (!p) return;
   transportState.participants = new Map(transportState.participants).set(
     peerId,
     source === "camera"
       ? { ...p, videoTrack: null }
-      : { ...p, screenTrack: null, screenAudioTrack: null }
+      : kind === "audio"
+        ? { ...p, screenAudioTrack: null }
+        : { ...p, screenTrack: null }
   );
 });
-
-  _video.on("peerJoined", (peerId) => {
-    if (!transportState.sfuPeerIds.has(peerId)) {
-      transportState.sfuPeerIds = new Set([
-        ...transportState.sfuPeerIds,
-        peerId,
-      ]);
-    }
-  });
 
   _video.on("peerLeft", (peerId) => {
     const p = transportState.participants.get(peerId);
@@ -88,9 +94,6 @@ _video.on("trackRemoved", (peerId, source) => {
         }
       );
     }
-    const next = new Set(transportState.sfuPeerIds);
-    next.delete(peerId);
-    transportState.sfuPeerIds = next;
 
     const tx = new Map(transportState.pendingTransmissions);
     tx.delete(peerId);
@@ -115,12 +118,6 @@ _video.on("trackRemoved", (peerId, source) => {
     transportState.pendingTransmissions = new Map(
       transportState.pendingTransmissions
     ).set(peerId, producerId);
-    if (!transportState.sfuPeerIds.has(peerId)) {
-      transportState.sfuPeerIds = new Set([
-        ...transportState.sfuPeerIds,
-        peerId,
-      ]);
-    }
   });
 
   _video.on("transmissionEnded", (peerId) => {
@@ -147,19 +144,22 @@ _video.on("trackRemoved", (peerId, source) => {
     playTransmissionLeaveSound();
   });
 
+  let _videoErrorMessage: string | null = null;
   _video.on("error", (err) => {
-    transportState.error = err.message;
+    _videoErrorMessage = err.message;
+    setErrorWithAutoClear(transportState, err.message);
   });
 
-  // Video quietly healing must take its banner with it - only OUR banners,
-  // an unrelated error on screen is not this component's to clear.
+  // Video quietly healing must take its OWN banner with it, whatever the
+  // message was - string-matching two fixed constants missed every
+  // sfuRefusalMessage() variant and both transport-failure strings that the
+  // client and server can produce (sfu-audit finding 15).
   _video.on("healed", () => {
-    if (
-      transportState.error === SFU_UNREACHABLE ||
-      transportState.error === SFU_PUBLISH_UNAVAILABLE
-    ) {
+    if (_videoErrorMessage !== null && transportState.error === _videoErrorMessage) {
+      cancelErrorClear();
       transportState.error = null;
     }
+    _videoErrorMessage = null;
   });
 }
 

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -292,6 +292,9 @@ export interface ParticipantState {
   videoTrack: MediaStreamTrack | null;
   screenTrack: MediaStreamTrack | null;
   screenAudioTrack: MediaStreamTrack | null;
+  /** getStats saw 2 consecutive stalled samples on this consumer; see VideoEvents.trackStalled. */
+  videoStalled: boolean;
+  screenStalled: boolean;
 }
 
 interface TransportState {
@@ -356,6 +359,13 @@ interface TransportState {
    * upgrades.
    */
   relayedPeers: Set<string>;
+  /**
+   * Peers whose outbound stream has proof the far side is reading it - a
+   * reactive mirror of the transport's confirmedStreams. `peers` alone
+   * cannot tell a working link from a connected-but-deaf one; this is the
+   * only place that distinction reaches the UI.
+   */
+  provenPeers: Set<string>;
   /** Profile metadata: banners, tags, bios, name effects; keyed by DID. */
   peerProfileMeta: Map<
     string,
@@ -376,7 +386,6 @@ interface TransportState {
   callPeerIds: Set<string>;
   callPeerRooms: Map<string, string>; // peerId -> roomCode they're calling in
   transmissionViewers: Map<string, Set<string>>; // sharer peerId -> viewer peerIds
-  sfuPeerIds: Set<string>;
   pendingTransmissions: Map<string, string>;
   watchingTransmissionPeerId: string | null;
   watchingTransmissionProducerId: string | null;
@@ -417,12 +426,12 @@ export const transportState = $state<TransportState>({
   peerColors: new Map(),
   historyCapped: false,
   relayedPeers: new Set(),
+  provenPeers: new Set(),
   peerProfileMeta: new Map(),
   error: null,
   callPeerIds: new Set(),
   callPeerRooms: new Map(),
   transmissionViewers: new Map(),
-  sfuPeerIds: new Set(),
   pendingTransmissions: new Map(),
   watchingTransmissionPeerId: null,
   watchingTransmissionProducerId: null,
@@ -1880,10 +1889,6 @@ function _handleCallPresence(
     parts.delete(peerId);
     transportState.participants = parts;
 
-    const sfuNext = new Set(transportState.sfuPeerIds);
-    sfuNext.delete(peerId);
-    transportState.sfuPeerIds = sfuNext;
-
     const txNext = new Map(transportState.pendingTransmissions);
     txNext.delete(peerId);
     transportState.pendingTransmissions = txNext;
@@ -2372,6 +2377,22 @@ _transport.on("relayChanged", (peerId, relayed) => {
   transportState.relayedPeers = next;
 });
 
+// A peer's own connection can report "open" while nothing it carries ever
+// arrives - streamProven/streamLost are the only signal that a frame
+// actually got through. transportState.peers keeps meaning "libp2p holds a
+// connection"; provenPeers is the separate, narrower claim.
+_transport.on("streamProven", (peerId) => {
+  const next = new Set(transportState.provenPeers);
+  next.add(peerId);
+  transportState.provenPeers = next;
+});
+
+_transport.on("streamLost", (peerId) => {
+  const next = new Set(transportState.provenPeers);
+  next.delete(peerId);
+  transportState.provenPeers = next;
+});
+
 _transport.on("connect", (peerId) => {
   transportState.peers = _transport.peers();
   // The DID cannot be derived from the peerId any more (devices carry their
@@ -2457,10 +2478,6 @@ _transport.on("disconnect", (peerId) => {
   const callStates = new Map(transportState.callPeerStates);
   callStates.delete(peerId);
   transportState.callPeerStates = callStates;
-
-  const sfuNext = new Set(transportState.sfuPeerIds);
-  sfuNext.delete(peerId);
-  transportState.sfuPeerIds = sfuNext;
 
   const txNext = new Map(transportState.pendingTransmissions);
   txNext.delete(peerId);
@@ -3164,6 +3181,7 @@ function _disconnectWithoutBroadcasting(): void {
   transportState.roomCode = null;
   transportState.roomName = "";
   transportState.peers = [];
+  transportState.provenPeers = new Set();
   transportState.messages = [];
   transportState.participants = new Map();
   transportState.peerNames = new Map();
@@ -3171,7 +3189,6 @@ function _disconnectWithoutBroadcasting(): void {
   transportState.peerColors = new Map();
   transportState.error = null;
   transportState.callPeerIds = new Set();
-  transportState.sfuPeerIds = new Set();
   transportState.pendingTransmissions = new Map();
   transportState.watchingTransmissionPeerId = null;
   transportState.watchingTransmissionProducerId = null;

--- a/frontend/src/lib/transport/types.ts
+++ b/frontend/src/lib/transport/types.ts
@@ -18,8 +18,25 @@ export interface TransportEvents {
    * that into reactive state.
    */
   relayChanged: (peerId: string, relayed: boolean) => void;
+  /**
+   * A peer's outbound stream has proof the far side is reading it - the
+   * first pong on THIS stream, not merely a connection reporting "open".
+   * connectedPeers (and the peers this mirrors into) never gated on this,
+   * so a link that connects but carries nothing rendered exactly like a
+   * working one. streamLost fires when that proof is withdrawn: the
+   * stream is torn down, reset, or never confirms.
+   *
+   * Both carry the FULL peer id, like every other peer-naming event here.
+   */
+  streamProven: (peerId: string) => void;
+  streamLost: (peerId: string) => void;
 }
 
+/**
+ * Transient banners. `peerId`, where present, is always the FULL peer id -
+ * `message` may shorten it for a human, but UI code matches a peer by
+ * `peerId`, and a sliced id cannot address one.
+ */
 export type TransportStatus =
   | { type: "app-warning"; message: string }
   | { type: "relay-connected"; message: string }
@@ -33,19 +50,7 @@ export type TransportStatus =
   | { type: "rendezvous-reconnecting"; message: string }
   | { type: "reservation-timeout"; message: string }
   | { type: "voice-dial-failed"; peerId: string; message: string }
-  | {
-      type: "voice-dial-retrying";
-      peerId: string;
-      attempt: number;
-      message: string;
-    }
   | { type: "voice-peer-left"; peerId: string; message: string }
-  | {
-      type: "voice-glare-resolved";
-      peerId: string;
-      winner: string;
-      message: string;
-    }
   | { type: "peer-dial-failed"; peerId: string; message: string }
   | { type: "voice-connection-failed"; peerId: string; message: string }
   | {
@@ -153,9 +158,20 @@ export interface VideoEvents {
     track: MediaStreamTrack,
     source: VideoSource
   ) => void;
-  trackRemoved: (peerId: string, source: VideoSource) => void;
+  /** `kind` distinguishes which underlying track ended - a peer can lose
+   *  camera or screen independently while the other keeps flowing. */
+  trackRemoved: (
+    peerId: string,
+    source: VideoSource,
+    kind: "audio" | "video"
+  ) => void;
   peerJoined: (peerId: string) => void;
   peerLeft: (peerId: string) => void;
+  /** Fired once when getStats sees 2 consecutive stalled samples on a
+   *  consumer, right before it is closed and re-consumed. A later
+   *  trackAdded for the same peer/source is the recovery signal - there is
+   *  no separate "recovered" event. */
+  trackStalled: (peerId: string, source: VideoSource) => void;
   /** Fired when a remote peer starts a screen-share transmission (opt-in: not auto-consumed). */
   transmissionAvailable: (peerId: string, producerId: string) => void;
   /** Fired when a remote peer's transmission ends (they stopped sharing or left). */
@@ -194,10 +210,6 @@ export interface VideoTransport {
   /** If `stream` is provided, publish it directly (avoids a second getDisplayMedia call). */
   startScreenShare(stream?: MediaStream): Promise<void>;
   stopScreenShare(): void;
-  pauseVideo(source: VideoSource): void;
-  resumeVideo(source: VideoSource): void;
-  isPaused(source: VideoSource): boolean;
-  isPublishing(source: VideoSource): boolean;
 
   /** Start consuming a pending transmission from a remote peer. */
   watchTransmission(peerId: string, producerId: string): Promise<void>;
@@ -206,11 +218,12 @@ export interface VideoTransport {
   /** Returns all pending (not yet watched) transmissions: peerId → producerId. */
   getPendingTransmissions(): Map<string, string>;
 
-  getAudioTrack(peerId: string): MediaStreamTrack | null;
-
   on<K extends keyof VideoEvents>(event: K, handler: VideoEvents[K]): void;
   off<K extends keyof VideoEvents>(event: K, handler: VideoEvents[K]): void;
   activePeers(): string[];
+  /** How many OTHER peers the SFU room held at last join - a primitive for
+   *  cross-checking SFU room membership against the libp2p call roster. */
+  roomPeerCount(): number;
 }
 
 export type FileTransferStatus =

--- a/frontend/src/lib/transport/voice.svelte.ts
+++ b/frontend/src/lib/transport/voice.svelte.ts
@@ -1,4 +1,4 @@
-import { transportState } from "./transport.svelte";
+import { transportState, _transport } from "./transport.svelte";
 import {
   loadAudioPrefs,
   loadPeerVolume,
@@ -49,6 +49,8 @@ export function initVoice(voice: LibP2PVoice, dtln: DtlnProcessor): void {
       videoTrack: null,
       screenTrack: null,
       screenAudioTrack: null,
+      videoStalled: false,
+      screenStalled: false,
     };
     transportState.participants = new Map(transportState.participants).set(
       peerId,
@@ -85,6 +87,15 @@ export function initVoice(voice: LibP2PVoice, dtln: DtlnProcessor): void {
 
   _voice.on("error", (err) => {
     transportState.error = err.message;
+  });
+
+  // voice.ts's own status statuses (voice-peer-left, voice-connection-
+  // failed, voice-degraded, voice-dial-failed, voice-ice-connected) reach
+  // nobody without this: they fire on LibP2PVoice's own handler map, and
+  // TransportStatus.svelte/CallStatus.svelte/VoiceVideoCallView.svelte all
+  // listen on _transport's "status" stream instead (finding 8).
+  _voice.on("status", (status) => {
+    _transport.announce(status);
   });
 
   restoreVoicePrefs();

--- a/frontend/src/lib/voice-link-status.test.ts
+++ b/frontend/src/lib/voice-link-status.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { applyVoiceLinkStatus } from "./voice-link-status";
+
+describe("applyVoiceLinkStatus", () => {
+  it("adds a peer on voice-ice-connected", () => {
+    const next = applyVoiceLinkStatus(new Set(), {
+      type: "voice-ice-connected",
+      peerId: "12D3KooWabc",
+    });
+    expect(next.has("12D3KooWabc")).toBe(true);
+  });
+
+  it("removes the same peer on voice-peer-left when both use the full id", () => {
+    const connected = new Set(["12D3KooWabc"]);
+    const next = applyVoiceLinkStatus(connected, {
+      type: "voice-peer-left",
+      peerId: "12D3KooWabc",
+    });
+    expect(next.has("12D3KooWabc")).toBe(false);
+  });
+
+  it("removes the same peer on voice-connection-failed", () => {
+    const connected = new Set(["12D3KooWabc"]);
+    const next = applyVoiceLinkStatus(connected, {
+      type: "voice-connection-failed",
+      peerId: "12D3KooWabc",
+    });
+    expect(next.has("12D3KooWabc")).toBe(false);
+  });
+
+  it("regression: a truncated peerId on the leave event does not remove the full id - the set only ever grows", () => {
+    // This is the exact shape of voice-audit finding 8 before the upstream
+    // fix: voice.ts published a slice(-8) id on teardown while the ICE event
+    // that inserted the peer used the full id. If this ever regresses, the
+    // deletion silently no-ops and the tile renders as connected forever.
+    const connected = new Set(["12D3KooWabcdef123"]);
+    const next = applyVoiceLinkStatus(connected, {
+      type: "voice-connection-failed",
+      peerId: "abcdef123", // truncated form - must NOT match the stored key
+    });
+    expect(next.has("12D3KooWabcdef123")).toBe(true);
+    expect(next).toBe(connected); // no-op: unknown key, same set instance back
+  });
+
+  it("leaves other peers untouched when one peer disconnects", () => {
+    const connected = new Set(["peer-a", "peer-b"]);
+    const next = applyVoiceLinkStatus(connected, {
+      type: "voice-peer-left",
+      peerId: "peer-a",
+    });
+    expect(next.has("peer-a")).toBe(false);
+    expect(next.has("peer-b")).toBe(true);
+  });
+
+  it("ignores unrelated status events", () => {
+    const connected = new Set(["peer-a"]);
+    const next = applyVoiceLinkStatus(connected, { type: "voice-degraded", peerId: "peer-a" });
+    expect(next).toBe(connected);
+  });
+
+  it("is a no-op re-insert when the peer is already connected", () => {
+    const connected = new Set(["peer-a"]);
+    const next = applyVoiceLinkStatus(connected, {
+      type: "voice-ice-connected",
+      peerId: "peer-a",
+    });
+    expect(next).toBe(connected);
+  });
+});

--- a/frontend/src/lib/voice-link-status.ts
+++ b/frontend/src/lib/voice-link-status.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure reducer for which peers have a proven voice ICE link.
+ *
+ * Split out of VoiceVideoCallView.svelte so the prune logic is unit
+ * testable without mounting Svelte. The set only self-heals if insert and
+ * delete agree on the same key: a torn-down peer that is added under one id
+ * shape and removed under another never leaves the set, and then renders as
+ * a healthy, connected tile forever (voice-audit finding 8).
+ */
+
+export interface VoiceLinkStatusEvent {
+  type: string;
+  peerId?: string;
+}
+
+/**
+ * Apply one transport status event to the set of peers with a proven voice
+ * ICE link.
+ *
+ * Returns the SAME set instance when the event does not change membership,
+ * so a caller assigning the result into `$state` can skip a reactive update
+ * on every unrelated status event.
+ */
+export function applyVoiceLinkStatus(
+  connected: ReadonlySet<string>,
+  event: VoiceLinkStatusEvent
+): ReadonlySet<string> {
+  if (event.type === "voice-ice-connected" && event.peerId) {
+    if (connected.has(event.peerId)) return connected;
+    return new Set([...connected, event.peerId]);
+  }
+  if (
+    (event.type === "voice-peer-left" ||
+      event.type === "voice-connection-failed") &&
+    event.peerId
+  ) {
+    if (!connected.has(event.peerId)) return connected;
+    const next = new Set(connected);
+    next.delete(event.peerId);
+    return next;
+  }
+  return connected;
+}

--- a/relay/main.go
+++ b/relay/main.go
@@ -32,12 +32,12 @@ import (
 const RendezvousProtocol = "/awful/rendezvous/1.0.0"
 
 type clientMsg struct {
-	Type string `json:"type"` // REGISTER | UNREGISTER
+	Type string `json:"type"` // REGISTER | UNREGISTER | PING
 	Room string `json:"room"`
 }
 
 type serverMsg struct {
-	Type  string   `json:"type"` // PEERS | PEER_JOINED | PEER_LEFT
+	Type  string   `json:"type"` // PEERS | PEER_JOINED | PEER_LEFT | REGISTER_FAILED
 	Room  string   `json:"room"`
 	Peers []string `json:"peers"`
 	Peer  string   `json:"peer,omitempty"` // PEER_JOINED | PEER_LEFT
@@ -61,24 +61,51 @@ const (
 	// frames; a peer still behind after this many is not reading its stream at
 	// all and gets dropped.
 	sendQueueDepth = 256
+	// maxMsgLen bounds one rendezvous frame, in both directions. readLoop
+	// resets the stream when a peer's declared length goes over it. sendTo
+	// refuses to build an outbound frame that goes over it too. The client
+	// aborts any inbound frame over its own MAX_RENDEZVOUS_FRAME_BYTES
+	// (16 KiB, libp2p/transport.ts), well above this number. Holding the
+	// relay's own OUTPUT to the same cap it enforces on INPUT stops the
+	// relay from ever tripping that client guard - see maxPeersPerFrame
+	// below, and relay-audit.md finding 2.
+	maxMsgLen = 8192
+	// maxPeersPerFrame bounds how many peerIds one PEERS frame carries.
+	// Without it, register's reply grew with the room, with no limit at
+	// all. A room past about 297 peerIds (52-character Ed25519 ids) built a
+	// frame over maxMsgLen. The client aborted its stream over that
+	// oversized frame, then re-REGISTERed everything on its 2-second
+	// reconnect timer, which produced the same oversized reply again: a
+	// permanent loop that took every one of the victim's OTHER rooms down
+	// with it, because one stream carries all of them. 128 keeps the
+	// relay's own reply inside maxMsgLen with room to spare: the fixed
+	// envelope is about 37 bytes plus up to maxRoomIDLen (128) for the room
+	// id, and each peerId costs about 55 bytes JSON-encoded, so
+	// 37 + 128 + 128*55 = 7205 bytes.
+	maxPeersPerFrame = 128
 	// Room ids the app produces are at most 43 bytes ("dm-" plus 40 hex);
 	// created codes are 6. Anything past this is not a room, it is a payload.
 	maxRoomIDLen = 128
 	// A peer re-joins every saved room and every phonebook DM when it
-	// connects, which can be hundreds. Past this ceiling a single stream is
+	// connects, which can be hundreds. Past this ceiling a single PEER is
 	// only growing the registry, which nothing else bounds: the connection
-	// manager counts connections, not rooms.
+	// manager counts connections, not rooms. This cap sums len(c.rooms)
+	// over EVERY stream a peerId holds (registry.roomsHeldByPeer), not one
+	// stream's own count. Checking one stream let a single peerId hold
+	// maxStreamsPerPeer separate 1024-room budgets at once - see
+	// maxTotalRegistrations below, and relay-audit.md finding 4.
 	maxRoomsPerPeer = 1024
-	// Registrations the whole registry will hold, across every stream of every
-	// peer. maxRoomsPerPeer is per STREAM - connectedClient is one stream, not
-	// one peer - and one peerId may hold maxStreamsPerPeer of them, so the
-	// per-stream cap bounds a peer's footprint and nothing global: 32 x 1024 =
-	// 32768 registrations per peerId for a few hundred bytes of uplink each.
-	// Measured at ~451 bytes of heap per registration, so this ceiling is
-	// ~90 MB: far past what a real instance needs, and far short of what it
-	// takes to OOM the box the relay shares with everything else. The resource
-	// manager cannot see this growth - its memory budget covers streams and
-	// buffers, not our maps.
+	// Registrations the whole registry will hold, across every stream of
+	// every peer. maxRoomsPerPeer now bounds one PEER's footprint, no
+	// matter how many streams (tabs) it holds. Reaching this ceiling now
+	// takes about 200 distinct peerIds, not the 7 it took while the room
+	// cap counted each stream on its own (32 streams x 1024 rooms = 32768
+	// registrations for one identity). Measured at ~451 bytes of heap per
+	// registration, so this ceiling is ~90 MB: far past what a real
+	// instance needs, and far short of what it takes to OOM the box the
+	// relay shares with everything else. The resource manager cannot see
+	// this growth - its memory budget covers streams and buffers, not our
+	// maps.
 	maxTotalRegistrations = 200_000
 	// Rendezvous streams one peerId may hold at once. Several are normal - two
 	// tabs of the app share a peerId because the libp2p key lives in
@@ -159,16 +186,33 @@ const (
 )
 
 // rendezvousIdleTimeout closes a stream that has REGISTERed nothing yet and
-// sends nothing for this long. Only unregistered streams get a deadline: the
-// rendezvous protocol carries no periodic frame of its own - REGISTER and
-// UNREGISTER only fire on a room change - so a registered tab legitimately
-// sends nothing for hours, and cutting it would make its rooms see it leave
-// and rejoin on every timer tick. A registered stream is already bounded
-// (maxRoomsPerPeer, maxStreamsPerPeer, connmgr); what was unbounded was a
-// peer opening up to maxStreamsPerPeer streams and never sending a byte,
-// pinning a goroutine and a registry entry each with nothing to reclaim
-// them. A package-level var, not a const, so tests can shrink it.
+// sends nothing for this long. Only an UNREGISTERED stream gets this
+// deadline. A registered stream gets rendezvousLivenessTimeout instead, see
+// below. A registered stream is already bounded by maxRoomsPerPeer,
+// maxStreamsPerPeer and connmgr. This deadline exists for a different
+// peer: one that opens up to maxStreamsPerPeer streams and never sends a
+// byte, pinning a goroutine and a registry entry that nothing else
+// reclaims. A package-level var, not a const, so tests can shrink it.
 var rendezvousIdleTimeout = time.Minute
+
+// rendezvousPingInterval is how often a REGISTERED client sends a no-op
+// PING frame to prove its app layer is still alive. This number is a
+// contract with the client (libp2p/transport.ts). rendezvousLivenessTimeout
+// below is sized from it: a healthy, room-quiet tab sends one frame - PING
+// included - within this interval, or the relay treats it as dead.
+var rendezvousPingInterval = 20 * time.Second
+
+// rendezvousLivenessTimeout closes a REGISTERED stream that has sent
+// NOTHING - not even a PING - for this long. Before this existed, a
+// registered stream got no deadline at all: the rendezvous protocol
+// carried no periodic frame. A stream whose app layer wedged while its
+// libp2p node kept answering yamux pings (30-50s apart) stayed advertised
+// in every room it held forever - the one disconnect class with no
+// detector at all (relay-audit.md finding 5). 3x the ping interval
+// tolerates a couple of delayed or dropped pings before the relay declares
+// the stream dead, so ordinary jitter never trips it. A package-level var,
+// not a const, so tests can shrink it.
+var rendezvousLivenessTimeout = 3 * rendezvousPingInterval
 
 // connectedClient is ONE rendezvous stream, not one peer. A peerId can hold
 // several at once - the user's other tab - and each one owns only the rooms it
@@ -511,6 +555,16 @@ func (r *registry) sendTo(c *connectedClient, msg serverMsg) {
 	if err != nil {
 		return
 	}
+	// The relay must hold its own OUTBOUND frames to the same maxMsgLen cap
+	// it enforces INBOUND (readLoop) - see maxPeersPerFrame, which is sized
+	// to keep every PEERS reply under this. Reaching here can only be a bug
+	// in a caller's own chunking, so drop the frame loudly instead of
+	// sending something the client's larger MAX_RENDEZVOUS_FRAME_BYTES
+	// guard would abort its stream over anyway.
+	if len(data) > maxMsgLen {
+		log.Printf("[rv] BUG: outbound %s frame to %s is %d bytes (> %d), dropping", msg.Type, short(c.peerId), len(data), maxMsgLen)
+		return
+	}
 	// 4-byte big-endian length prefix to match the JS client framing
 	frame := make([]byte, 4+len(data))
 	frame[0] = byte(len(data) >> 24)
@@ -533,13 +587,82 @@ func (r *registry) sendTo(c *connectedClient, msg serverMsg) {
 	}
 }
 
-// register admits c into room. It returns false only when the room had no
-// OTHER member and this stream's maxEmptyRegisters budget was already spent -
-// the empty-room-guess oracle case - in which case nothing happens: c is not
-// added, no PEERS is sent, and the caller (readLoop) is left to log it. Every
-// other path, including the existing caps above, returns true; they already
-// log their own refusal here and need no extra signal to the caller.
-func (r *registry) register(c *connectedClient, room string) bool {
+// registerOutcome tells readLoop how to answer one REGISTER attempt.
+// registerJoined covers every case the client should be told it joined: a
+// real join, an already-live membership (which gets a resync PEERS - see
+// Finding 6), or a stream the registry has already let go of.
+// registerCapped is the one refusal readLoop answers with REGISTER_FAILED;
+// it is permanent until the peer frees up room, unlike
+// registerOracleSilenced, which stays silent on purpose (see
+// maxEmptyRegisters) so it never becomes the room-code oracle the budget
+// exists to deny.
+type registerOutcome int
+
+const (
+	registerJoined registerOutcome = iota
+	registerCapped
+	registerOracleSilenced
+)
+
+// roomsHeldByPeer sums len(c.rooms) over every stream a peerId currently
+// holds. maxRoomsPerPeer bounds one PEER's footprint in the registry, but
+// checking it against a single stream's own c.rooms let a peerId multiply
+// its footprint by maxStreamsPerPeer just by opening more tabs - up to
+// 32768 registrations for one identity (relay-audit.md finding 4). Summing
+// across r.clients[peerId] closes that. Caller holds r.mu.
+func (r *registry) roomsHeldByPeer(peerId string) int {
+	total := 0
+	for c := range r.clients[peerId] {
+		total += len(c.rooms)
+	}
+	return total
+}
+
+// peersExcept lists the distinct peerIds in members other than excludePeer -
+// one entry per peer, never the asker itself. Caller holds r.mu; the
+// returned slice is a fresh copy, safe to use after unlocking.
+func peersExcept(members map[*connectedClient]struct{}, excludePeer string) []string {
+	seen := make(map[string]struct{}, len(members))
+	others := make([]string, 0, len(members))
+	for m := range members {
+		if m.peerId == excludePeer {
+			continue
+		}
+		if _, dup := seen[m.peerId]; dup {
+			continue
+		}
+		seen[m.peerId] = struct{}{}
+		others = append(others, m.peerId)
+	}
+	return others
+}
+
+// sendPeers answers a REGISTER with a room's member list, split into
+// frames of at most maxPeersPerFrame peerIds each - see that constant for
+// why one unbounded PEERS frame is unsafe. The client's PEERS handler adds
+// every id it receives to a per-room Set (transport.ts), so several frames
+// for one room compose correctly; the wire needs no continuation marker.
+// An empty room still gets exactly one frame, which is what tells the
+// client its REGISTER succeeded.
+func (r *registry) sendPeers(c *connectedClient, room string, others []string) {
+	if len(others) == 0 {
+		r.sendTo(c, serverMsg{Type: "PEERS", Room: room, Peers: others})
+		return
+	}
+	for i := 0; i < len(others); i += maxPeersPerFrame {
+		end := i + maxPeersPerFrame
+		if end > len(others) {
+			end = len(others)
+		}
+		r.sendTo(c, serverMsg{Type: "PEERS", Room: room, Peers: others[i:end]})
+	}
+}
+
+// register admits c into room. readLoop answers registerCapped with an
+// explicit REGISTER_FAILED; registerOracleSilenced stays silent (see
+// maxEmptyRegisters); every other path either really succeeded or is
+// already indistinguishable from success to the client.
+func (r *registry) register(c *connectedClient, room string) registerOutcome {
 	r.mu.Lock()
 
 	// A stream the registry has already let go of - its read loop ended, or the
@@ -548,12 +671,23 @@ func (r *registry) register(c *connectedClient, room string) bool {
 	// that entry again (RELAY-02).
 	if !r.isLive(c) {
 		r.mu.Unlock()
-		return true
+		return registerJoined
 	}
 
 	if _, already := c.rooms[room]; already {
+		// Already a member on THIS stream: resend the room's current PEERS
+		// instead of doing nothing. A repeat REGISTER used to get no reply
+		// at all, so a client whose membership view had drifted - a
+		// silently refused REGISTER (Finding 4) or a frame it silently
+		// dropped (Finding 5) - had no way to ask the registry what it
+		// actually thinks. Idempotent on the client (rememberRoomPeer into
+		// a Set) and metered by the same membershipOps budget as every
+		// other REGISTER, so it adds no new abuse surface (relay-audit.md
+		// finding 6).
+		others := peersExcept(r.rooms[room], c.peerId)
 		r.mu.Unlock()
-		return true
+		r.sendPeers(c, room, others)
+		return registerJoined
 	}
 	if r.total >= maxTotalRegistrations {
 		sayCapped := !r.totalCapLogged
@@ -562,9 +696,9 @@ func (r *registry) register(c *connectedClient, room string) bool {
 		if sayCapped {
 			log.Printf("[rv] registry is at its %d-registration ceiling, ignoring further REGISTERs", maxTotalRegistrations)
 		}
-		return true
+		return registerCapped
 	}
-	if len(c.rooms) >= maxRoomsPerPeer {
+	if r.roomsHeldByPeer(c.peerId) >= maxRoomsPerPeer {
 		sayCapped := !c.roomCapLogged
 		c.roomCapLogged = true
 		r.mu.Unlock()
@@ -576,7 +710,7 @@ func (r *registry) register(c *connectedClient, room string) bool {
 		if sayCapped {
 			log.Printf("[rv] %s hit the %d-room cap, ignoring further REGISTERs", short(c.peerId), maxRoomsPerPeer)
 		}
-		return true
+		return registerCapped
 	}
 
 	members := r.rooms[room]
@@ -588,7 +722,7 @@ func (r *registry) register(c *connectedClient, room string) bool {
 	// REGISTER into a room that already has somebody else in it is free.
 	if len(members) == 0 && !c.emptyRegisters.allow(time.Now()) {
 		r.mu.Unlock()
-		return false
+		return registerOracleSilenced
 	}
 	if members == nil {
 		members = make(map[*connectedClient]struct{})
@@ -636,9 +770,9 @@ func (r *registry) register(c *connectedClient, room string) bool {
 	// Send notifications outside the lock. The joiner's own PEERS goes first:
 	// it is the frame that answers the REGISTER, and queuing it behind a
 	// broadcast to everyone else only delays the join for no reason.
-	r.sendTo(c, serverMsg{Type: "PEERS", Room: room, Peers: others})
+	r.sendPeers(c, room, others)
 	if !announce {
-		return true
+		return registerJoined
 	}
 	for _, tc := range targetClients {
 		r.sendTo(tc, serverMsg{
@@ -647,7 +781,7 @@ func (r *registry) register(c *connectedClient, room string) bool {
 			Peer: c.peerId,
 		})
 	}
-	return true
+	return registerJoined
 }
 
 func (r *registry) unregister(c *connectedClient, room string) {
@@ -690,6 +824,13 @@ func (r *registry) doUnregister(c *connectedClient, room string) ([]*connectedCl
 	delete(members, c)
 	delete(c.rooms, room)
 	r.total--
+	// A transient spike past the ceiling logs one line and sets
+	// totalCapLogged, then falls silent for the rest of the process even
+	// after total drops back down. Clear the flag here so the NEXT spike
+	// gets its own line (relay-audit.md finding 12).
+	if r.total < maxTotalRegistrations {
+		r.totalCapLogged = false
+	}
 
 	line := leaveLine{peerId: c.peerId, room: room}
 	line.write, line.quiet = c.joinLeaveLog.allow(time.Now())
@@ -883,12 +1024,12 @@ func (r *registry) handleStream(s network.Stream) {
 }
 
 // readLoop reassembles length-prefixed frames from a rendezvous stream and
-// dispatches each one, until s.Read errors - including an idle timeout, see
-// rendezvousIdleTimeout. Split out of handleStream so a fake satisfying only
-// rvReadStream can exercise it in tests.
+// dispatches each one, until s.Read errors - including an idle or liveness
+// timeout, see rendezvousIdleTimeout and rendezvousLivenessTimeout. Split
+// out of handleStream so a fake satisfying only rvReadStream can exercise
+// it in tests.
 func (r *registry) readLoop(s rvReadStream, peerId string, c *connectedClient) {
 	// Read loop - reassemble length-prefixed frames
-	const maxMsgLen = 8192 // Max size for a single frame (REGISTER/UNREGISTER payloads are tiny)
 	buf := make([]byte, 0, 512)
 	tmp := make([]byte, 4096)
 
@@ -907,16 +1048,18 @@ func (r *registry) readLoop(s rvReadStream, peerId string, c *connectedClient) {
 		}
 	}
 
-	// Set once the stream has registered a room; from then on it is a
-	// legitimate quiet participant and gets no deadline.
+	// Set once the stream has registered a room; from then on it gets
+	// rendezvousLivenessTimeout instead of rendezvousIdleTimeout.
 	registered := false
 
 readLoop:
 	for {
 		// A stream that never registers would otherwise pin this goroutine
-		// and its registry entry forever - see rendezvousIdleTimeout.
+		// and its registry entry forever - see rendezvousIdleTimeout. A
+		// stream that HAS registered is no longer indefinitely silent
+		// either - see rendezvousLivenessTimeout.
 		if registered {
-			s.SetReadDeadline(time.Time{})
+			s.SetReadDeadline(time.Now().Add(rendezvousLivenessTimeout))
 		} else {
 			s.SetReadDeadline(time.Now().Add(rendezvousIdleTimeout))
 		}
@@ -932,7 +1075,7 @@ readLoop:
 			// stream - a plain `break` here would leave the bad length header in
 			// buf and re-trip on every subsequent read while buf grows unbounded.
 			if msgLen > maxMsgLen {
-				log.Printf("[rv] message too large from %s: %d bytes, closing stream", short(peerId), msgLen)
+				warn("[rv] message too large from %s: %d bytes, closing stream", short(peerId), msgLen)
 				s.Reset()
 				break readLoop
 			}
@@ -951,6 +1094,9 @@ readLoop:
 			if msg.Type == "REGISTER" || msg.Type == "UNREGISTER" {
 				if !validRoom(msg.Room) {
 					warn("[rv] %s sent an unusable room id (%d bytes), ignoring", short(peerId), len(msg.Room))
+					if msg.Type == "REGISTER" {
+						r.sendTo(c, serverMsg{Type: "REGISTER_FAILED", Room: msg.Room})
+					}
 					continue
 				}
 			}
@@ -966,23 +1112,38 @@ readLoop:
 				// registers each room once per connection.
 				if !membershipOps.allow(time.Now()) {
 					warn("[rv] %s is changing rooms faster than %d/%s, ignoring", short(peerId), maxMembershipOps, membershipOpWindow)
+					if msg.Type == "REGISTER" {
+						r.sendTo(c, serverMsg{Type: "REGISTER_FAILED", Room: msg.Room})
+					}
 					continue
 				}
 				if msg.Type == "REGISTER" {
-					// register only refuses (false) when the room had no OTHER
-					// member and this stream's empty-register budget - the
-					// room-code-guessing oracle case - was already spent. Warn
-					// and drop the REGISTER exactly like an exhausted
-					// membershipOps above: no PEERS goes out, so the guess
-					// gets no answer, and there is nothing more to do with it.
-					if !r.register(c, msg.Room) {
+					switch r.register(c, msg.Room) {
+					case registerOracleSilenced:
+						// The room-code-guessing oracle case: warn and drop
+						// exactly like an exhausted membershipOps above - no
+						// PEERS goes out, so the guess gets no answer. This
+						// is the one refusal that must never become
+						// REGISTER_FAILED (relay-audit.md finding 4).
 						warn("[rv] %s exhausted its empty-room register budget (%d/%s), ignoring", short(peerId), maxEmptyRegisters, emptyRegisterWindow)
-						continue
+					case registerCapped:
+						// Every other refusal path used to return success by
+						// default, leaving the client believing it joined a
+						// room that never saw it. REGISTER_FAILED is
+						// additive on the wire; handleRendezvousMsg already
+						// ignores unknown types (transport.ts).
+						r.sendTo(c, serverMsg{Type: "REGISTER_FAILED", Room: msg.Room})
+					case registerJoined:
+						registered = true
 					}
-					registered = true
 				} else {
 					r.unregister(c, msg.Room)
 				}
+			case "PING":
+				// No-op: a registered stream's only proof of life when it
+				// has nothing else to say. Reading it already re-armed the
+				// deadline above; nothing else to do (relay-audit.md
+				// finding 5).
 			default:
 				warn("[rv] unknown type from %s: %s", short(peerId), logSafe(msg.Type))
 			}
@@ -1014,6 +1175,26 @@ func relayResources() relayv2.Resources {
 	// see; the global ceiling above is the one that counts.
 	res.MaxReservationsPerIP = connMgrHigh
 	res.MaxReservationsPerASN = connMgrHigh
+	// MaxCircuits is the fourth ceiling relayv2.DefaultResources() sets, and
+	// this function used to leave it alone at the default: 16 COMBINED
+	// circuits per peer, counting both directions (source or destination).
+	// A peer with more than 16 live relayed connections - one per online
+	// phonebook contact, easy in a busy room - got RESOURCE_LIMIT_EXCEEDED
+	// on the 17th dial and every later one, including a mid-call re-dial
+	// after a network flap (relay-audit.md finding 1). WithInfiniteLimits
+	// below does not touch this counter: it only clears the per-circuit
+	// duration and byte Limit, which is why it made the problem worse
+	// instead of fixing it - circuits stopped churning and started
+	// accumulating.
+	//
+	// Lifted to connMgrHigh for the same reason as the three ceilings
+	// above: the resource manager's own memory budget is the real bound,
+	// not this count. Each live circuit reserves 2*BufferSize = 4 KiB from
+	// a peer's resource-manager span (circuitv2/relay/relay.go), so
+	// connMgrHigh (512) circuits cost at most 2 MiB for one peer - small
+	// next to the resource manager's own limits, and nowhere near what it
+	// takes to OOM the box.
+	res.MaxCircuits = connMgrHigh
 	return res
 }
 
@@ -1157,7 +1338,13 @@ func main() {
 			IdleTimeout:       30 * time.Second,
 		}
 		if err := server.ListenAndServe(); err != nil {
-			log.Printf("[http] API server error: %v", err)
+			// A bind failure used to leave this goroutine exit quietly
+			// while libp2p kept serving: the rendezvous registry looked
+			// healthy while /turn-credentials, /invite, /og and /mailbox
+			// were all gone, and every relayed peer stopped connecting with
+			// no logged reason (relay-audit.md finding 10). Fatalf so
+			// `restart: unless-stopped` brings the whole process back.
+			log.Fatalf("[http] API server error: %v", err)
 		}
 	}()
 
@@ -1232,4 +1419,13 @@ func printAddrs(h host.Host) {
 	for _, ma := range h.Addrs() {
 		log.Printf(" %s/p2p/%s", ma, h.ID())
 	}
+	// The rendezvous registry and the mailbox both live in this process's
+	// own memory (registry) and on its own volume (mailbox) - see
+	// deploy/README.md, "What cannot be multiplied yet". A second replica
+	// would load the SAME relay.key from the shared volume and print the
+	// SAME PeerID above, but hold a completely separate registry: half the
+	// peers on this instance would never see the other half in their PEERS
+	// reply, with nothing in either log saying why. There is no code check
+	// for this - only this line.
+	log.Printf("[relay] this service must run as exactly ONE replica; see deploy/README.md")
 }

--- a/relay/main_test.go
+++ b/relay/main_test.go
@@ -120,6 +120,48 @@ func (f *fakeStream) decode(t *testing.T, i int) serverMsg {
 	return msg
 }
 
+// encodeClientFrame builds the same length-prefixed wire frame the JS
+// client sends, for tests that need readLoop to actually DISPATCH a
+// message rather than calling registry.register/unregister directly.
+func encodeClientFrame(msg clientMsg) []byte {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		panic(err)
+	}
+	frame := make([]byte, 4+len(data))
+	frame[0] = byte(len(data) >> 24)
+	frame[1] = byte(len(data) >> 16)
+	frame[2] = byte(len(data) >> 8)
+	frame[3] = byte(len(data))
+	copy(frame[4:], data)
+	return frame
+}
+
+// registerOnceStream delivers ONE real wire frame on its first Read, so
+// readLoop dispatches it itself and flips its own local state (registered)
+// - unlike calling registry.register directly, which never touches
+// readLoop's dispatch at all. Every later Read behaves exactly like
+// fakeStream: it blocks until the deadline set by SetReadDeadline, then
+// returns a deadline-exceeded error, simulating a stream that has gone
+// silent - not even a PING.
+type registerOnceStream struct {
+	fakeStream
+	frame []byte
+	sent  bool
+}
+
+func (s *registerOnceStream) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	if !s.sent {
+		s.sent = true
+		n := copy(p, s.frame)
+		s.mu.Unlock()
+		return n, nil
+	}
+	s.mu.Unlock()
+	return s.fakeStream.Read(p)
+}
+
 // blockingStream never completes a write until release is closed - a peer that
 // has stopped reading its stream.
 type blockingStream struct {
@@ -186,19 +228,65 @@ func TestRegisterSendsPeerListAndNotifies(t *testing.T) {
 	}
 }
 
-func TestRegisterIsIdempotent(t *testing.T) {
+// register used to return early on an already-joined room with NO reply at
+// all, so a client whose membership view had drifted - a silently refused
+// REGISTER (finding 4) or a frame it silently dropped (finding 5) - had no
+// way to ask the registry what it actually thinks. A repeat REGISTER for a
+// room this stream already holds now resends that room's PEERS, so the
+// client can resync just by re-registering (relay-audit.md finding 6).
+func TestRepeatedRegisterResyncsPeers(t *testing.T) {
 	r := newRegistry()
 	a, sa := newClient(r, "peer-a")
+	b, sb := newClient(r, "peer-b")
+
 	r.register(a, "room1")
-	r.register(a, "room1")
-	sa.waitFrames(t, 1)
-	time.Sleep(20 * time.Millisecond) // give a second PEERS a chance to show up
-	if sa.count() != 1 {
-		t.Fatalf("duplicate register should not resend PEERS, got %d frames", sa.count())
+	r.register(b, "room1")
+	sa.decode(t, 0) // a's own PEERS
+	joined := sa.decode(t, 1)
+	if joined.Type != "PEER_JOINED" || joined.Peer != "peer-b" {
+		t.Fatalf("setup: expected PEER_JOINED for b, got %+v", joined)
 	}
-	if len(r.rooms["room1"]) != 1 {
-		t.Fatalf("room should have 1 peer, got %d", len(r.rooms["room1"]))
+
+	r.register(a, "room1") // repeat REGISTER, same room, same stream
+	resync := sa.decode(t, 2)
+	if resync.Type != "PEERS" || resync.Room != "room1" || len(resync.Peers) != 1 || resync.Peers[0] != "peer-b" {
+		t.Fatalf("expected a resync PEERS [peer-b], got %+v", resync)
 	}
+
+	// Nobody else hears about it: nothing changed from the room's point of
+	// view, so a resync must never look like a join to anyone but the asker.
+	time.Sleep(20 * time.Millisecond)
+	if sb.count() != 1 {
+		t.Fatalf("b saw %d frames from a's resync, want 1 (its own PEERS only)", sb.count())
+	}
+
+	r.mu.Lock()
+	roomSize := len(r.rooms["room1"])
+	r.mu.Unlock()
+	if roomSize != 2 {
+		t.Fatalf("room should still have 2 peers, got %d", roomSize)
+	}
+}
+
+// A REGISTER refused by the room or global cap used to return true - success
+// - so the client believed it joined a room the registry never added it to.
+// register now returns registerCapped, and readLoop answers it with an
+// explicit REGISTER_FAILED (relay-audit.md finding 4).
+func TestCappedRegisterGetsRegisterFailed(t *testing.T) {
+	r := newRegistry()
+	a, sa := newClient(r, "peer-a")
+	for i := range maxRoomsPerPeer {
+		r.register(a, fmt.Sprintf("room-%d", i))
+	}
+	sa.waitFrames(t, maxRoomsPerPeer)
+
+	if outcome := r.register(a, "one-too-many"); outcome != registerCapped {
+		t.Fatalf("register past the room cap returned %v, want registerCapped", outcome)
+	}
+	// register() itself never writes the frame - only readLoop does, on
+	// registerCapped - so this test exercises the outcome value directly and
+	// TestRegistryNeverLogsUnderItsLock (elsewhere) already exercises the
+	// log line this path writes under the same lock discipline.
 }
 
 func TestUnregisterNotifiesAndCleansEmptyRoom(t *testing.T) {
@@ -670,28 +758,80 @@ func TestLogSafeCopiesOnlyWhatItMustRewrite(t *testing.T) {
 	}
 }
 
-// maxRoomsPerPeer is per STREAM, and one peerId may hold maxStreamsPerPeer of
-// them, so before maxTotalRegistrations the per-stream cap bounded a peer's
-// footprint and nothing global: 32 streams x 1024 rooms = 32768 registrations
-// per peerId, for a few hundred bytes of attacker uplink each.
-func TestRegistryHasAGlobalRegistrationCeiling(t *testing.T) {
+// Before this fix, maxRoomsPerPeer was checked against ONE STREAM's own
+// c.rooms, so a second stream of the SAME peerId got a fresh 1024-room
+// allowance: 32 streams x 1024 rooms = 32768 registrations for one peerId,
+// and the 200000-registration global ceiling needed only 7 such peerIds
+// (relay-audit.md finding 4). The cap now sums every stream a peerId holds,
+// so it means what its name says: one peer, one 1024-room budget, no matter
+// how many tabs it opens.
+func TestRoomCapIsSharedAcrossAPeersStreams(t *testing.T) {
 	r := newRegistry()
-	// A second stream of the SAME peerId used to get a fresh 1024 allowance.
 	a1, _ := newClient(r, "peer-a")
 	a2, _ := newClient(r, "peer-a")
-	for _, c := range []*connectedClient{a1, a2} {
-		for i := 0; i < maxRoomsPerPeer; i++ {
-			r.register(c, fmt.Sprintf("room-%d-%p", i, c))
-		}
+
+	for i := range maxRoomsPerPeer {
+		r.register(a1, fmt.Sprintf("room-a1-%d", i))
 	}
+	// a1 alone already spent peer-a's whole budget; a2 gets none of its own
+	// on top of it.
+	for i := range 10 {
+		r.register(a2, fmt.Sprintf("room-a2-%d", i))
+	}
+
 	r.mu.Lock()
 	total := r.total
+	a1Rooms, a2Rooms := len(a1.rooms), len(a2.rooms)
 	r.mu.Unlock()
-	if total != 2*maxRoomsPerPeer {
-		t.Fatalf("total = %d, want %d (each stream keeps its own room cap)", total, 2*maxRoomsPerPeer)
+
+	if a1Rooms != maxRoomsPerPeer {
+		t.Fatalf("a1 joined %d rooms, want the full cap of %d", a1Rooms, maxRoomsPerPeer)
 	}
-	if total > maxTotalRegistrations {
-		t.Fatalf("test is not exercising the ceiling: %d > %d", total, maxTotalRegistrations)
+	if a2Rooms != 0 {
+		t.Fatalf("a2 joined %d rooms after peer-a's cap was already spent by a1, want 0", a2Rooms)
+	}
+	if total != maxRoomsPerPeer {
+		t.Fatalf("total = %d, want %d: the cap must be per PEER, not per stream", total, maxRoomsPerPeer)
+	}
+}
+
+// The global counter has to come back down, or an instance that has merely
+// been busy for a while refuses registrations forever. This exercises the
+// two peers - not one, since the room cap is now per peer - and additionally
+// checks that a spike logs once, falls silent while capped, and can log
+// again after it drops back down (relay-audit.md finding 12).
+func TestTotalCapLoggedResetsWhenTotalFalls(t *testing.T) {
+	r := newRegistry()
+	a, _ := newClient(r, "peer-a")
+	r.mu.Lock()
+	r.total = maxTotalRegistrations
+	r.totalCapLogged = true
+	r.mu.Unlock()
+
+	if outcome := r.register(a, "room1"); outcome != registerCapped {
+		t.Fatalf("register at the ceiling returned %v, want registerCapped", outcome)
+	}
+	r.mu.Lock()
+	stillLogged := r.totalCapLogged
+	r.mu.Unlock()
+	if !stillLogged {
+		t.Fatal("totalCapLogged should stay true while still at the ceiling")
+	}
+
+	// The registry drops back under the ceiling - some other peer left -
+	// and a's own leave is what should observe and clear the flag: register
+	// succeeds now that total is below the cap, then unregister decrements
+	// total and runs doUnregister's reset check.
+	r.mu.Lock()
+	r.total = maxTotalRegistrations - 1
+	r.mu.Unlock()
+	r.register(a, "room1")
+	r.unregister(a, "room1")
+	r.mu.Lock()
+	resetAfterLeave := !r.totalCapLogged
+	r.mu.Unlock()
+	if !resetAfterLeave {
+		t.Fatal("totalCapLogged did not reset once total fell back under the ceiling")
 	}
 }
 
@@ -835,5 +975,126 @@ func TestIdleRendezvousStreamIsClosedAfterTimeout(t *testing.T) {
 	}
 	if roomHas(r, "room1", "peer-idle") {
 		t.Fatal("an idle stream's cleanup should remove it from its rooms")
+	}
+}
+
+// Each circuit reserves 2*BufferSize (4 KiB) from a peer's resource-manager
+// span, so lifting MaxCircuits to connMgrHigh costs at most connMgrHigh *
+// 4 KiB = 2 MiB for one peer - this test only checks the ceiling itself,
+// the cost is documented next to relayResources.
+func TestRelayCircuitsAreNotCappedAtSixteen(t *testing.T) {
+	res := relayResources()
+	if res.MaxCircuits <= 16 {
+		t.Errorf("MaxCircuits = %d, still go-libp2p's default combined-circuit ceiling", res.MaxCircuits)
+	}
+	if res.MaxCircuits != connMgrHigh {
+		t.Errorf("MaxCircuits = %d, want connMgrHigh (%d) to match the other lifted ceilings", res.MaxCircuits, connMgrHigh)
+	}
+}
+
+// register's own PEERS reply used to grow with the room with no limit at
+// all, and the client fatally aborts any rendezvous frame over 16 KiB. This
+// drives a room well past maxPeersPerFrame and checks that the joiner still
+// gets every peer, just split across more than one frame, and that no single
+// frame is oversized (relay-audit.md finding 2).
+func TestBigRoomPeersReplyIsChunked(t *testing.T) {
+	r := newRegistry()
+	const roomSize = maxPeersPerFrame*2 + 10 // forces 3 frames
+	for i := range roomSize {
+		p, _ := newClient(r, fmt.Sprintf("peer-%d", i))
+		r.register(p, "big-room")
+	}
+
+	joiner, sj := newClient(r, "peer-joiner")
+	r.register(joiner, "big-room")
+
+	// Every existing member's outbox grew by one PEER_JOINED; the joiner's
+	// own reply is what this test cares about.
+	sj.waitFrames(t, 1)
+	time.Sleep(20 * time.Millisecond)
+
+	seen := map[string]bool{}
+	frameCount := sj.count()
+	if frameCount < 2 {
+		t.Fatalf("got %d frame(s) for a %d-peer room, want more than 1 (maxPeersPerFrame=%d)", frameCount, roomSize, maxPeersPerFrame)
+	}
+	for i := range frameCount {
+		msg := sj.decode(t, i)
+		if msg.Type != "PEERS" || msg.Room != "big-room" {
+			t.Fatalf("frame %d: unexpected message %+v", i, msg)
+		}
+		if len(msg.Peers) > maxPeersPerFrame {
+			t.Fatalf("frame %d carries %d peers, over maxPeersPerFrame (%d)", i, len(msg.Peers), maxPeersPerFrame)
+		}
+		for _, p := range msg.Peers {
+			if seen[p] {
+				t.Fatalf("peer %s appeared in more than one frame", p)
+			}
+			seen[p] = true
+		}
+	}
+	if len(seen) != roomSize {
+		t.Fatalf("joiner learned about %d peers across %d frames, want %d", len(seen), frameCount, roomSize)
+	}
+}
+
+// A registered stream used to get NO read deadline at all, so an app layer
+// that wedged - stopped processing frames - while its libp2p node kept
+// answering yamux pings stayed advertised forever: the one disconnect class
+// with no detector (relay-audit.md finding 5). This mirrors
+// TestIdleRendezvousStreamIsClosedAfterTimeout but for the REGISTERED case:
+// once the stream has joined a room, silence for rendezvousLivenessTimeout
+// must still end it.
+func TestRegisteredStreamWithNoLivenessIsClosedAfterTimeout(t *testing.T) {
+	origIdle, origPing := rendezvousIdleTimeout, rendezvousPingInterval
+	rendezvousIdleTimeout = time.Hour // must not be what ends this test
+	rendezvousPingInterval = 20 * time.Millisecond
+	rendezvousLivenessTimeout = 3 * rendezvousPingInterval
+	defer func() {
+		rendezvousIdleTimeout = origIdle
+		rendezvousPingInterval = origPing
+		rendezvousLivenessTimeout = 3 * rendezvousPingInterval
+	}()
+
+	r := newRegistry()
+	// readLoop only flips its OWN registered flag on a wire REGISTER it
+	// dispatches itself - calling registry.register directly, like
+	// TestIdleRendezvousStreamIsClosedAfterTimeout does, never sets it. So
+	// this stream delivers one real REGISTER frame, then goes silent exactly
+	// like fakeStream: every later Read blocks until the deadline and
+	// returns a deadline-exceeded error.
+	s := &registerOnceStream{frame: encodeClientFrame(clientMsg{Type: "REGISTER", Room: "room1"})}
+	c := addClient(r, "peer-wedged", s)
+
+	done := make(chan struct{})
+	go func() {
+		r.readLoop(s, "peer-wedged", c)
+		r.removeClient(c)
+		close(done)
+	}()
+
+	// The REGISTER frame's own PEERS reply proves readLoop actually
+	// processed it - and so set registered = true - rather than the room
+	// membership having been forced in some other way.
+	s.waitFrames(t, 1)
+	if !roomHas(r, "room1", "peer-wedged") {
+		t.Fatal("setup: peer should be in room1 before the liveness timeout")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not return once the liveness window elapsed")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !s.wasReset() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !s.wasReset() {
+		t.Fatal("a stream silent past rendezvousLivenessTimeout should be reset")
+	}
+	if roomHas(r, "room1", "peer-wedged") {
+		t.Fatal("cleanup should remove the wedged stream from its rooms")
 	}
 }

--- a/relay/turn.go
+++ b/relay/turn.go
@@ -83,9 +83,11 @@ func handleTurnCredentials(w http.ResponseWriter, r *http.Request) {
 	// 2h, not the original 12h: this credential is carried in a plaintext
 	// turn: URL (no TLS TURN is offered - see defaultTurnURLs), so a shorter
 	// TTL bounds how long a credential that leaked off the wire stays usable.
-	// Still comfortably longer than any call or transfer, and the client
-	// refreshes well before expiry rather than waiting it out (see
-	// frontend/src/lib/transport for refreshTurnCredentials).
+	// Still comfortably longer than any call or transfer. The response below
+	// carries this ttl, and the client reads it and re-arms its own refresh
+	// at half of it (frontend/src/lib/transport/ice-server-list.ts,
+	// refreshTurnCredentials), so a tab open for days never runs on a
+	// credential whose embedded expiry timestamp has already passed.
 	const ttl = 2 * 60 * 60 // 2h
 	expiry := time.Now().Unix() + ttl
 	// coturn's REST form is "<expiry>[:<id>]". The id half matters: coturn

--- a/sfu/heartbeat.ts
+++ b/sfu/heartbeat.ts
@@ -1,0 +1,52 @@
+// Split out of index.ts so the backpressure deadline (finding 6) is
+// unit-testable against controlled timestamps. Sustaining a real socket's
+// `backpressured` flag for a specific duration through an actual byte flood
+// is not a reliable test: local drain is fast enough that a burst clears in
+// microseconds, nowhere near the seconds a genuinely stuck connection would
+// take, so no fixed frame count is both fast and non-flaky. This module has
+// no side effects on import, unlike index.ts (which starts a real mediasoup
+// worker and listens on a port), so a test can import it directly.
+
+/** Duck-typed subset of `WebSocket` the heartbeat sweep needs - lets a test
+ *  drive the exact decision logic with a plain object instead of a real
+ *  socket. */
+export interface HeartbeatSocket {
+  backpressured?: boolean;
+  backpressuredSince?: number;
+  isAlive?: boolean;
+  ping(): void;
+  terminate(): void;
+}
+
+/**
+ * One connection's heartbeat decision. A connection paused for backpressure
+ * cannot answer: ws.pause() pauses the underlying socket, so PONGS AND THE
+ * CLOSE HANDSHAKE stop arriving along with the data frames. Treating that
+ * silence as death would have this heartbeat terminate a peer for the crime
+ * of sending too much - and it is the peers under real load that get
+ * paused. They are demonstrably alive; that is why they were paused. But a
+ * pause has to end sometime: one that is ALSO gone never drains on its own,
+ * so past `backpressureDeadlineMs` this stops giving it the benefit of the
+ * doubt.
+ */
+export function sweepHeartbeatConnection(
+  w: HeartbeatSocket,
+  now: number,
+  backpressureDeadlineMs: number,
+): void {
+  if (w.backpressured) {
+    if (
+      w.backpressuredSince !== undefined &&
+      now - w.backpressuredSince > backpressureDeadlineMs
+    ) {
+      w.terminate();
+    }
+    return;
+  }
+  if (w.isAlive === false) {
+    w.terminate();
+  } else {
+    w.isAlive = false;
+    w.ping();
+  }
+}

--- a/sfu/index.test.ts
+++ b/sfu/index.test.ts
@@ -4,12 +4,13 @@
 // handshake, which is everything covered here:
 //   - the unconnected-transport reaper (Task 1)
 //   - ms:produce source validation (Task 3)
-//   - the ms:error surfaced when router.canConsume() returns false (Task 3)
+//   - the dead-socket and stuck-backpressured producer reap (finding 6)
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawn, ChildProcess } from "node:child_process";
 import path from "node:path";
 import { WebSocket } from "ws";
+import { sweepHeartbeatConnection, type HeartbeatSocket } from "./heartbeat";
 
 // Picking a port off the pid keeps concurrent test runs on the same machine
 // from colliding on a fixed number.
@@ -18,6 +19,12 @@ const PORT = 34000 + (process.pid % 1000);
 // enough that the assertions below (which each take a real websocket round
 // trip) aren't racing the reaper.
 const TRANSPORT_CONNECT_TIMEOUT_MS = 300;
+// Short enough that the dead-socket and backpressure-deadline tests below
+// do not sit around - deadline is twice this (see sfu/index.ts).
+const HEARTBEAT_INTERVAL_MS = 100;
+// Small enough that a short burst of frames crosses it well within one
+// heartbeat tick, without tripping on the other tests' ordinary traffic.
+const MAX_QUEUED_FRAME_BYTES = 2000;
 
 let child: ChildProcess;
 let stoppingChild = false;
@@ -57,6 +64,8 @@ test.before(async () => {
         ...process.env,
         SFU_PORT: String(PORT),
         SFU_TRANSPORT_CONNECT_TIMEOUT_MS: String(TRANSPORT_CONNECT_TIMEOUT_MS),
+        SFU_HEARTBEAT_INTERVAL_MS: String(HEARTBEAT_INTERVAL_MS),
+        SFU_MAX_QUEUED_FRAME_BYTES: String(MAX_QUEUED_FRAME_BYTES),
         ANNOUNCED_IP: "127.0.0.1",
       },
       stdio: ["ignore", "pipe", "pipe"],
@@ -164,4 +173,154 @@ test("rejects ms:produce with an invalid source", async () => {
   } finally {
     ws.close();
   }
+});
+
+// Minimal but structurally valid RtpParameters for a single-codec Opus
+// audio producer. mediasoup validates shape, not identity with anything the
+// router announced, so this is enough to get a REAL producer (real worker
+// round trip, real room fan-out) without a full mediasoup-client SDK.
+function fakeAudioRtpParameters(ssrc: number): unknown {
+  return {
+    mid: "0",
+    codecs: [
+      {
+        mimeType: "audio/opus",
+        payloadType: 100,
+        clockRate: 48000,
+        channels: 2,
+        parameters: {},
+        rtcpFeedback: [],
+      },
+    ],
+    headerExtensions: [],
+    encodings: [{ ssrc }],
+    rtcp: { cname: `probe-${ssrc}`, reducedSize: true },
+  };
+}
+
+async function produceRealAudio(ws: WebSocket, ssrc: number): Promise<string> {
+  ws.send(JSON.stringify({ type: "ms:create-transport", direction: "send" }));
+  await nextMessage(ws, (m) => m.type === "ms:transport-options" && m.direction === "send");
+  ws.send(
+    JSON.stringify({
+      type: "ms:produce",
+      kind: "audio",
+      rtpParameters: fakeAudioRtpParameters(ssrc),
+      source: "camera",
+    }),
+  );
+  const produced = await nextMessage(ws, (m) => m.type === "ms:produced");
+  return produced.producerId;
+}
+
+test("reaps a peer whose socket goes silently dead, freeing its producer", async () => {
+  const roomCode = "room-dead-peer";
+  const wsA = await connectAndJoin(roomCode, "peer-dead-a");
+  const wsB = await connectAndJoin(roomCode, "peer-dead-b");
+  try {
+    const producerId = await produceRealAudio(wsA, 22222222);
+    // B sees A's producer before A dies - proves it was really live, not
+    // merely created and immediately orphaned.
+    const newProducer = await nextMessage(
+      wsB,
+      (m) => m.type === "ms:new-producer" && m.producerId === producerId,
+    );
+    assert.equal(newProducer.peerId, "peer-dead-a");
+
+    // Simulate the wifi-to-cellular handover the heartbeat exists for: the
+    // socket sends no FIN and answers no ping, but nothing here calls
+    // close() or terminate() - from the server's point of view it just goes
+    // quiet. Pausing the client's own raw socket reads means an incoming
+    // ping from the server is never read off the wire, so no pong is ever
+    // returned - indistinguishable from a real silent network loss.
+    (wsA as unknown as { _socket: { pause: () => void } })._socket.pause();
+
+    const start = Date.now();
+    const peerLeft = await nextMessage(
+      wsB,
+      (m) => m.type === "ms:peer-left" && m.peerId === "peer-dead-a",
+      HEARTBEAT_INTERVAL_MS * 2 + 4000,
+    );
+    assert.equal(peerLeft.peerId, "peer-dead-a");
+    // Reaped within roughly two heartbeat ticks (isAlive goes false on the
+    // first unanswered ping, terminated on the second), not the old 30s-tick
+    // heartbeat's up-to-60s window.
+    assert.ok(Date.now() - start < HEARTBEAT_INTERVAL_MS * 2 + 3000);
+
+    // A fresh joiner must not be handed the dead peer's producer: the room
+    // replay only offers what is still in the room map, and the dead peer
+    // was removed by handlePeerLeft.
+    const wsC = await connectAndJoin(roomCode, "peer-dead-c");
+    try {
+      let sawStaleProducer = false;
+      wsC.on("message", (raw) => {
+        const m = JSON.parse(raw.toString());
+        if (m.type === "ms:new-producer" && m.producerId === producerId) {
+          sawStaleProducer = true;
+        }
+      });
+      // ms:capabilities always follows a join's producer replay in order on
+      // one connection, so receiving it proves the replay already happened.
+      wsC.send(JSON.stringify({ type: "ms:get-capabilities" }));
+      await nextMessage(wsC, (m) => m.type === "ms:capabilities");
+      assert.equal(sawStaleProducer, false);
+    } finally {
+      wsC.close();
+    }
+  } finally {
+    wsA.close();
+    wsB.close();
+  }
+});
+
+test("sweepHeartbeatConnection: a socket stuck backpressured past the deadline is terminated", () => {
+  // The real bug (finding 6): the heartbeat used to skip a backpressured
+  // socket unconditionally, so one that was ALSO gone never got reaped -
+  // its PeerState, and every producer it held, lived until the kernel
+  // eventually gave up on the TCP connection. This drives the exact
+  // production decision function against a fake socket and a controlled
+  // clock, because sustaining real backpressure for a specific wall-clock
+  // duration is not a reliable thing to race against in a test.
+  let terminated = 0;
+  let pinged = 0;
+  const w: HeartbeatSocket = {
+    backpressured: true,
+    backpressuredSince: 1_000,
+    ping: () => pinged++,
+    terminate: () => terminated++,
+  };
+  const deadlineMs = 200;
+
+  // Backpressured for less than the deadline: left alone, not even pinged -
+  // a paused socket cannot answer one anyway.
+  sweepHeartbeatConnection(w, 1_000 + deadlineMs - 1, deadlineMs);
+  assert.equal(terminated, 0);
+  assert.equal(pinged, 0);
+
+  // Still backpressured, now past the deadline: terminated outright.
+  sweepHeartbeatConnection(w, 1_000 + deadlineMs + 1, deadlineMs);
+  assert.equal(terminated, 1);
+  assert.equal(pinged, 0);
+});
+
+test("sweepHeartbeatConnection: a non-backpressured socket still uses the ordinary ping/isAlive path", () => {
+  let terminated = 0;
+  let pinged = 0;
+  const w: HeartbeatSocket = {
+    backpressured: false,
+    isAlive: true,
+    ping: () => pinged++,
+    terminate: () => terminated++,
+  };
+
+  // First tick: alive, so it is pinged and marked not-yet-answered.
+  sweepHeartbeatConnection(w, 1_000, 200);
+  assert.equal(pinged, 1);
+  assert.equal(w.isAlive, false);
+  assert.equal(terminated, 0);
+
+  // Second tick with no pong in between: terminated, exactly as the
+  // pre-existing isAlive contract always has.
+  sweepHeartbeatConnection(w, 2_000, 200);
+  assert.equal(terminated, 1);
 });

--- a/sfu/index.ts
+++ b/sfu/index.ts
@@ -1,18 +1,27 @@
 import * as mediasoup from "mediasoup";
 import { WebSocketServer, WebSocket } from "ws";
 import { IncomingMessage } from "http";
+import { sweepHeartbeatConnection, type HeartbeatSocket } from "./heartbeat";
 
 // ── Types mirrored from client mediasoup.ts ───────────────────────────────────
 
 interface MSGetCapabilities {
   type: "ms:get-capabilities";
+  requestId: string;
 }
 interface MSCapabilities {
   type: "ms:capabilities";
+  requestId: string;
   rtpCapabilities: mediasoup.types.RtpCapabilities;
+  // How many OTHER peers this room already holds. An interim guard for
+  // finding 13 (build-time SFU placement plus a cached PWA bundle can put
+  // two participants on different SFU nodes) - the caller cross-checks this
+  // against its own roster size.
+  roomPeerCount: number;
 }
 interface MSCreateTransport {
   type: "ms:create-transport";
+  requestId: string;
   direction: "send" | "recv";
 }
 
@@ -26,6 +35,7 @@ interface ClientTransportOptions {
 
 interface MSTransportOptions {
   type: "ms:transport-options";
+  requestId: string;
   direction: "send" | "recv";
   options: ClientTransportOptions;
 }
@@ -36,16 +46,19 @@ interface MSConnectTransport {
 }
 interface MSProduce {
   type: "ms:produce";
+  requestId: string;
   kind: mediasoup.types.MediaKind;
   rtpParameters: mediasoup.types.RtpParameters;
   source: "camera" | "screen";
 }
 interface MSProduced {
   type: "ms:produced";
+  requestId: string;
   producerId: string;
 }
 interface MSConsume {
   type: "ms:consume";
+  requestId: string;
   producerId: string;
   rtpCapabilities: mediasoup.types.RtpCapabilities;
 }
@@ -60,6 +73,7 @@ interface ClientConsumerOptions {
 
 interface MSConsumerOptions {
   type: "ms:consumer-options";
+  requestId: string;
   options: ClientConsumerOptions;
   peerId: string;
   source: "camera" | "screen";
@@ -75,6 +89,11 @@ interface MSProducerClosed {
   peerId: string;
   producerId: string;
   source: "camera" | "screen";
+  // Which track this producer carried (finding 4) - without it, closing a
+  // screen share's AUDIO producer looked identical to closing its VIDEO
+  // producer to the client, and it tore down the whole watch over a peer
+  // merely switching to a window with no audio track.
+  kind: mediasoup.types.MediaKind;
 }
 interface MSProducerConsumed {
   type: "ms:producer-consumed";
@@ -94,6 +113,12 @@ interface MSCloseProducer {
   type: "ms:close-producer";
   producerId: string;
 }
+/** Ask the server to resume a consumer created paused (finding 3) - sent once
+ *  the client's recvTransport.consume() has resolved. */
+interface MSResumeConsumer {
+  type: "ms:resume-consumer";
+  producerId: string;
+}
 interface MSPeerLeft {
   type: "ms:peer-left";
   peerId: string;
@@ -110,7 +135,8 @@ type ClientMsg =
   | MSProduce
   | MSConsume
   | MSCloseConsumer
-  | MSCloseProducer;
+  | MSCloseProducer
+  | MSResumeConsumer;
 
 // ── Per-peer state ────────────────────────────────────────────────────────────
 
@@ -446,7 +472,12 @@ function reapTransport(
   // transport, but check anyway so the intent - drop the reference, don't
   // reissue a worker request - reads directly.
   if (!transport.closed) transport.close();
-  send(peer.ws, { type: "ms:error", reason });
+  // `direction` tells the client which transport died so it can rebuild only
+  // that one (finding 1) - without it, the client could not tell a transport
+  // reap from a session refusal and used to latch a permanent refusal that
+  // killed the OTHER, still-healthy direction too. The socket itself stays
+  // open: this is not a session refusal, and mediasoup.ts must not close it.
+  send(peer.ws, { type: "ms:error", reason, direction });
 }
 
 function armTransportReapTimer(
@@ -474,13 +505,23 @@ function clearTransportReapTimer(peer: PeerState, direction: "send" | "recv"): v
 
 // ── Message handlers ──────────────────────────────────────────────────────────
 
-async function handleGetCapabilities(peer: PeerState): Promise<void> {
+async function handleGetCapabilities(
+  peer: PeerState,
+  msg: MSGetCapabilities,
+): Promise<void> {
   // rtpCapabilities are identical for every router, so serve them from the
   // template router created at boot. This avoids allocating a per-room router
   // and prevents the room ceiling from being exhausted by capability queries.
+  const room = rooms.get(peer.roomCode);
+  // peer is already in its own room by the time this runs - frames on one
+  // connection are handled strictly in the order they arrived, and join()
+  // sends this right behind the join frame that put it there.
+  const roomPeerCount = room ? Math.max(0, room.size - 1) : 0;
   send(peer.ws, {
     type: "ms:capabilities",
+    requestId: msg.requestId,
     rtpCapabilities: templateRouter.rtpCapabilities,
+    roomPeerCount,
   } as MSCapabilities);
 }
 
@@ -585,6 +626,7 @@ async function handleCreateTransport(
 
   send(peer.ws, {
     type: "ms:transport-options",
+    requestId: msg.requestId,
     direction: msg.direction,
     options,
   } as MSTransportOptions);
@@ -701,7 +743,11 @@ async function handleProduce(peer: PeerState, msg: MSProduce): Promise<void> {
     consumers: new Set(),
   });
 
-  send(peer.ws, { type: "ms:produced", producerId: producer.id } as MSProduced);
+  send(peer.ws, {
+    type: "ms:produced",
+    requestId: msg.requestId,
+    producerId: producer.id,
+  } as MSProduced);
 
   // Notify every other peer in the room about the new producer
   const room = rooms.get(peer.roomCode);
@@ -718,7 +764,11 @@ async function handleProduce(peer: PeerState, msg: MSProduce): Promise<void> {
     }
   }
 
-  function notifyProducerClosed(producerId: string, source: "camera" | "screen") {
+  function notifyProducerClosed(
+    producerId: string,
+    source: "camera" | "screen",
+    kind: mediasoup.types.MediaKind,
+  ) {
     // Avoid duplicate notifications
     if (peer.notifiedClosedProducers.has(producerId)) {
       return;
@@ -735,13 +785,18 @@ async function handleProduce(peer: PeerState, msg: MSProduce): Promise<void> {
           peerId: peer.peerId,
           producerId,
           source,
+          kind,
         } as MSProducerClosed);
       }
     }
   }
 
   producer.on("transportclose", () => {
-    notifyProducerClosed(producer.id, producer.appData.source as "camera" | "screen");
+    notifyProducerClosed(
+      producer.id,
+      producer.appData.source as "camera" | "screen",
+      producer.kind,
+    );
   });
 
   console.log(
@@ -787,6 +842,7 @@ async function handleConsume(peer: PeerState, msg: MSConsume): Promise<void> {
       }
       send(peer.ws, {
         type: "ms:consumer-options",
+        requestId: msg.requestId,
         options,
         peerId: "", // Not needed for duplicate - client already has this
         source,
@@ -835,7 +891,14 @@ async function handleConsume(peer: PeerState, msg: MSConsume): Promise<void> {
     consumer = await peer.recvTransport.consume({
       producerId: msg.producerId,
       rtpCapabilities: msg.rtpCapabilities,
-      paused: false,
+      // Created paused (finding 3): the recv transport's DTLS handshake is
+      // not guaranteed to be done yet, and RTP forwarded before it completes
+      // is discarded - including the producer's next keyframe, which for a
+      // screen share on static content can be tens of seconds away. The
+      // client asks for ms:resume-consumer once its side of consume()
+      // resolves; mediasoup requests a fresh keyframe on resume, so the
+      // first frame the decoder ever sees is always an IDR.
+      paused: true,
     });
   } finally {
     peer.consumersInFlight--;
@@ -863,6 +926,10 @@ async function handleConsume(peer: PeerState, msg: MSConsume): Promise<void> {
       if (entry) {
         producerPeerId = pid;
         source = entry.source;
+        // The per-producer viewer set (finding 18) was written nowhere, so
+        // it never told the truth about who was watching; populate it here,
+        // at the one place a viewer is actually recorded.
+        entry.consumers.add(peer.peerId);
         break;
       }
     }
@@ -889,6 +956,7 @@ async function handleConsume(peer: PeerState, msg: MSConsume): Promise<void> {
 
   send(peer.ws, {
     type: "ms:consumer-options",
+    requestId: msg.requestId,
     options,
     peerId: producerPeerId,
     source,
@@ -908,6 +976,22 @@ async function handleConsume(peer: PeerState, msg: MSConsume): Promise<void> {
   );
 }
 
+function handleResumeConsumer(peer: PeerState, msg: MSResumeConsumer): void {
+  const consumerId = peer.consumersByProducerId.get(msg.producerId);
+  if (!consumerId) return;
+  const entry = peer.consumers.get(consumerId);
+  if (!entry) return;
+  // Idempotent: a retried ms:resume-consumer (or one that raced a producer
+  // close) resuming an already-resumed or already-closed consumer is a
+  // mediasoup no-op, not an error.
+  entry.consumer.resume().catch((err) => {
+    console.warn(
+      `[sfu] resume-consumer failed for peer ${peer.peerId}:`,
+      err,
+    );
+  });
+}
+
 function handleCloseConsumer(peer: PeerState, msg: MSCloseConsumer): void {
   // Look up the consumer by producerId using the index for O(1) lookup and cleanup
   const consumerId = peer.consumersByProducerId.get(msg.producerId);
@@ -922,18 +1006,24 @@ function handleCloseConsumer(peer: PeerState, msg: MSCloseConsumer): void {
     return;
   }
 
-  // Notify the producer owner that this peer stopped watching
+  // Notify the producer owner that this peer stopped watching. The room has
+  // at most one peer holding this producerId, so the loop always stops at
+  // it - previously the break sat inside the screen-only branch, so a
+  // CAMERA producer id (never "screen") scanned every remaining peer in the
+  // room for nothing.
   const room = rooms.get(peer.roomCode);
   if (room) {
     for (const [, p] of room) {
       const prodEntry = p.producers.get(msg.producerId);
-      if (prodEntry && prodEntry.source === "screen") {
-        prodEntry.consumers.delete(peer.peerId);
-        send(p.ws, {
-          type: "ms:producer-consumer-closed",
-          peerId: peer.peerId,
-          producerId: msg.producerId,
-        } as MSProducerConsumerClosed);
+      if (prodEntry) {
+        if (prodEntry.source === "screen") {
+          prodEntry.consumers.delete(peer.peerId);
+          send(p.ws, {
+            type: "ms:producer-consumer-closed",
+            peerId: peer.peerId,
+            producerId: msg.producerId,
+          } as MSProducerConsumerClosed);
+        }
         break;
       }
     }
@@ -948,6 +1038,7 @@ function handleCloseProducer(peer: PeerState, msg: MSCloseProducer): void {
   const entry = peer.producers.get(msg.producerId);
   if (entry) {
     const source = entry.source;
+    const kind = entry.producer.kind;
     entry.producer.close();
     peer.producers.delete(msg.producerId);
 
@@ -961,6 +1052,7 @@ function handleCloseProducer(peer: PeerState, msg: MSCloseProducer): void {
           peerId: peer.peerId,
           producerId: msg.producerId,
           source,
+          kind,
         } as MSProducerClosed);
       }
     }
@@ -1036,7 +1128,26 @@ const MAX_FRAME_BYTES = 256 * 1024;
 // TCP receive window, which is where backpressure belongs. Generous against
 // legitimate use: the largest honest burst is a peer joining a busy room and
 // consuming every existing producer at once, a few dozen frames of ~1 KB.
-const MAX_QUEUED_FRAME_BYTES = 4 * 1024 * 1024;
+const MAX_QUEUED_FRAME_BYTES = parseInt(
+  process.env.SFU_MAX_QUEUED_FRAME_BYTES ?? String(4 * 1024 * 1024),
+  10,
+);
+// How often the heartbeat sweeps every connection. Was 30s; halved so an
+// ordinary silent loss (no FIN - wifi to cellular, a killed tab) is reaped in
+// two ticks - 20s - instead of up to 60s, during which a fresh joiner was
+// still handed the dead peer's producers (finding 6).
+const HEARTBEAT_INTERVAL_MS = parseInt(
+  process.env.SFU_HEARTBEAT_INTERVAL_MS ?? "10000",
+  10,
+);
+// A socket flagged `backpressured` answers no ping and sends no close, so the
+// heartbeat used to skip it forever - correct for a peer that is merely slow,
+// wrong for one that is ALSO gone: nothing else in this file ever revisits a
+// backpressured socket, so it lived (and kept handing out its producers)
+// until the kernel eventually gave up on the TCP connection, sometimes
+// indefinitely. Two heartbeat intervals is generous headroom for a real burst
+// (joining a busy room) to drain before this treats the pause as terminal.
+const BACKPRESSURE_DEADLINE_MS = HEARTBEAT_INTERVAL_MS * 2;
 
 async function main(): Promise<void> {
   worker = await mediasoup.createWorker({
@@ -1086,23 +1197,15 @@ async function main(): Promise<void> {
 
   // Heartbeat to detect and terminate dead connections (silent disconnect, network handover, etc.)
   const heartbeatInterval = setInterval(() => {
+    const now = Date.now();
     wss.clients.forEach((ws: WebSocket) => {
-      // A connection paused for backpressure cannot answer: ws.pause() pauses
-      // the underlying socket, so PONGS AND THE CLOSE HANDSHAKE stop arriving
-      // along with the data frames. Treating that silence as death would have
-      // this heartbeat terminate a peer for the crime of sending too much -
-      // and it is the peers under real load that get paused. They are
-      // demonstrably alive; that is why they were paused.
-      if ((ws as unknown as { backpressured?: boolean }).backpressured) return;
-      const isAlive = (ws as any).isAlive;
-      if (isAlive === false) {
-        ws.terminate();
-      } else {
-        (ws as any).isAlive = false;
-        ws.ping();
-      }
+      sweepHeartbeatConnection(
+        ws as unknown as HeartbeatSocket,
+        now,
+        BACKPRESSURE_DEADLINE_MS,
+      );
     });
-  }, 30000); // 30 second interval
+  }, HEARTBEAT_INTERVAL_MS);
 
   wss.on("close", () => {
     clearInterval(heartbeatInterval);
@@ -1275,12 +1378,13 @@ async function main(): Promise<void> {
           // tiles for it sit frozen on its last frame.
           for (const [otherPeerId, otherPeer] of room) {
             if (otherPeerId === joinMsg.peerId) continue;
-            for (const [producerId, { source }] of oldPeer.producers) {
+            for (const [producerId, { source, producer }] of oldPeer.producers) {
               send(otherPeer.ws, {
                 type: "ms:producer-closed",
                 peerId: joinMsg.peerId,
                 producerId,
                 source,
+                kind: producer.kind,
               } as MSProducerClosed);
             }
           }
@@ -1319,7 +1423,7 @@ async function main(): Promise<void> {
       try {
         switch (msg.type) {
           case "ms:get-capabilities":
-            await handleGetCapabilities(peer);
+            await handleGetCapabilities(peer, msg as MSGetCapabilities);
             break;
           case "ms:create-transport":
             await handleCreateTransport(peer, msg as MSCreateTransport);
@@ -1332,6 +1436,9 @@ async function main(): Promise<void> {
             break;
           case "ms:consume":
             await handleConsume(peer, msg as MSConsume);
+            break;
+          case "ms:resume-consumer":
+            handleResumeConsumer(peer, msg as MSResumeConsumer);
             break;
           case "ms:close-consumer":
             handleCloseConsumer(peer, msg as MSCloseConsumer);
@@ -1368,7 +1475,12 @@ async function main(): Promise<void> {
       // until resume(), so the sender feels the stall through TCP instead of
       // this process growing on its behalf.
       if (queuedBytes >= MAX_QUEUED_FRAME_BYTES) {
-        (ws as unknown as { backpressured?: boolean }).backpressured = true;
+        const w = ws as unknown as {
+          backpressured?: boolean;
+          backpressuredSince?: number;
+        };
+        if (!w.backpressured) w.backpressuredSince = Date.now();
+        w.backpressured = true;
         ws.pause();
       }
       frameChain = frameChain
@@ -1381,7 +1493,12 @@ async function main(): Promise<void> {
           const wasOver = queuedBytes >= MAX_QUEUED_FRAME_BYTES;
           queuedBytes -= raw.length;
           if (wasOver && queuedBytes < MAX_QUEUED_FRAME_BYTES) {
-            (ws as unknown as { backpressured?: boolean }).backpressured = false;
+            const w = ws as unknown as {
+              backpressured?: boolean;
+              backpressuredSince?: number;
+            };
+            w.backpressured = false;
+            w.backpressuredSince = undefined;
             ws.resume();
           }
         });


### PR DESCRIPTION
## What this is

A full audit of the peer-connection status apparatus, and the repairs it
produced. Five read-only audits mapped four layers - the P2P voice path, the
libp2p connection lifecycle, the mediasoup SFU path, and the Go relay - and
found **58 defects**. This PR closes every P0 and every P1, plus the P2s whose
fix carried no behaviour risk.

Two reported symptoms drove the priority:

- **(a)** "I connect to some peer and it straight up doesn't work."
- **(b)** "I stop hearing from one peer" while everyone else stays fine.

## The one root cause behind both

Every repair path keyed on `RTCPeerConnection.connectionState` or on membership
of a set. **Nothing observed whether media or frames actually flowed.** Any
failure that left those signals healthy was therefore permanent until the user
left and rejoined.

The file already said so. `voice.ts` carried this comment before this PR:

> an ICE pair can die while both RTCPeerConnections still read connected, so
> both sides look fine while no audio crosses

The diagnosis was written down. The detector was never built.

## Detection, the missing half

| Layer | Detector | Repair path |
|---|---|---|
| Voice | `inbound-rtp bytesReceived` unmoved for 8 s while `connectionState === "connected"` | stops refreshing `okAt`, so the existing blip/wedge ladder owns it |
| SFU | same sweep over every consumer, 2 stalled samples | closes and re-consumes the producer, emits `trackStalled` |
| libp2p | `confirmedStreams` published as `streamProven` / `streamLost` | `transportState.provenPeers`; an unproven peer renders as connecting |
| Relay | rendezvous `PING` every 20 s, relay closes after 3 missed intervals | the returning peer re-registers |

No new timers. Each detector rides a tick that already existed, and each routes
into repair machinery that already existed.

A muted peer keeps sending RTP, so it does not trip the voice detector. Zero
growth is the trip condition, not slow growth, so DTX and comfort noise do not
either.

## Silent senders — the more likely cause of symptom (b)

- A **DTLN worklet that died after init** left the outbound track live, enabled
  and silent for the rest of the call. The sender saw nothing wrong: their own
  speaking ring kept animating, because it meters the raw mic and not the
  processed stream.
- A **mic or device switch** stopped the old track first, then awaited
  `replaceTrack` per peer with no guard. One rejection stranded every peer after
  it in Map order on a stopped track.
- **Deafen, leave, rejoin** seeded every peer's gain node at exactly 0 while the
  deafen icon read normal.
- The **join sequence** handed the voice layer an empty roster for the entire
  SFU join, so an offer arriving in that window was dropped silently and cost
  the dialer the full 30 s setup deadline.
- A **renegotiation offer in an unexpected signalling state** was dropped with a
  `console.warn` and no recovery on a live link — the late-mic-grant case.

## Relay ceilings that refused connections outright

- **`MaxCircuits`** was the one relay ceiling `relayResources()` forgot to lift,
  so the 17th relayed peer connection of any peer was refused at go-libp2p's
  default of 16.
- The **`PEERS` reply had no size bound** while the client fatally aborts its
  rendezvous stream past 16 KiB. A large room put every member into a permanent
  2 s reconnect loop. It chunks now.
- **TURN credentials** carried a 2 h TTL that nothing refreshed, so every
  `RTCPeerConnection` created after two hours got a 401 from coturn. `turn.go`
  already claimed the client refreshed; now it does, at half the TTL.

## The status surface could not express a per-peer failure

- `iceConnectedPeers` was filled with full peer ids and pruned with
  `slice(-8)` ids, so the set only ever grew and a torn-down peer rendered as a
  healthy participant forever.
- `voice-peer-left` had three consumers and no emitter.
- `voice.ts` emitted statuses that never reached the app: nothing wired its
  `status` event into the transport's stream, so several fixes here would have
  been no-ops without that one line.
- The call badge derived a single global quality value, so one peer's
  `voice-degraded` painted the whole call and any other peer's `trackAdded`
  erased it.

## Verification

| Suite | Result |
|---|---|
| `frontend` `pnpm test` | 869 passed, 73 files |
| `frontend` `pnpm check` | 5038 files, 0 errors, 0 warnings |
| `frontend` `pnpm build` | passes |
| `relay` `go test -race -count=1 ./...` | ok |
| `relay` `go vet` + `gofmt -l` | clean |
| `sfu` `npm test` | 5/5 |
| `sfu` `npx tsc --noEmit` | clean |

Every P0 fix carries a regression test that was checked to fail against the
pre-fix code.

## Not in this PR

- **SFU pool placement at runtime** (SFU audit finding 13). Build-time
  `VITE_SFU_URLS` plus a cached PWA bundle can still put two participants on
  different SFU nodes. The interim guard ships here: `ms:capabilities` now
  carries `roomPeerCount` so a client can tell it is alone in a room that should
  not be empty. The real fix is a new relay endpoint that serves the pool, and
  it is its own change.
- **P2 hygiene items** that needed more than a one-liner are listed in each
  audit report rather than silently dropped.
