### PR TITLE
share: send a window's own audio, and never send audio that echoes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ group video.
   suppression (DTLN) and per-peer volume.
 - **Camera and screen share** at 30 fps through a self-hosted SFU: sharing is
   opt-in to watch, the sharer sees who is watching, and a streamers-only
-  view hides everyone without video.
+  view hides everyone without video. Screen-share audio is scoped to the
+  shared window where the OS/browser allow it (Windows 11 / macOS 14.2+ on
+  a recent Chrome); everywhere else - including Linux and Firefox - audio
+  is only sent once the browser confirms it will not echo, and is withheld
+  by default otherwise (opt-in in Settings > Audio).
 - **Files and media**: WebTorrent transfers with no public trackers, inline
   images, video, audio and GIFs, a GIF picker with saved favorites, and
   small files delivered inside the message itself so they load instantly.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -640,6 +640,37 @@ Video:
   - unexpected WS drop mid-call → client emits error + one full automatic
     rejoin (device + transports + republish of live local tracks)
 
+Screen share audio (share-audio.ts):
+  - problem: whole-system audio re-captures awful.chat's own playback of
+    every remote participant, so everyone hears themselves echoed back
+  - buildShareOptions() requests windowAudio:"window" + restrictOwnAudio
+    (inside the audio constraint, never at the top level) plus the
+    Chromium picker-shaping options (systemAudio, selfBrowserSurface,
+    surfaceSwitching, monitorTypeSurfaces, audioSelection). One options
+    object, no user-agent sniffing - unsupported members are silently
+    ignored per the WebIDL dictionary spec
+  - classifyShareAudio() checks what was ACTUALLY captured
+    (videoTrack.getSettings().displaySurface,
+    audioTrack.getSettings().restrictOwnAudio) rather than trusting the
+    request: windowAudio degrades to system audio silently, and
+    getSupportedConstraints().restrictOwnAudio reports "supported" even on
+    platforms (Linux) that can never honour it
+  - verdict kinds: "application-scoped" (tab audio, or a window share with
+    own-audio removal confirmed), "system-audio-own-audio-stripped" (whole
+    screen, own-audio removal confirmed), "echo-risk" (own-audio removal
+    NOT confirmed on a non-tab surface), "no-audio" (no audio track at all)
+  - default is fail-closed: an "echo-risk" audio track is stopped and
+    removed before it reaches the SFU, and the sharer is told why in one
+    sentence. Settings > Audio has a device-local, room-invisible opt-in
+    ("send audio despite echo risk") to publish it anyway
+  - real per-application audio (not just own-audio filtering) exists only
+    on Windows 11 with Chrome 146+ and macOS 14.2+ with Chrome 150+; it
+    never exists on Linux, ChromeOS, Firefox, or Safari - those either get
+    a fail-closed silent share or the sharer's explicit opt-in
+  - audioTrack.onmute/onunmute are wired so a share whose audio goes silent
+    mid-call (own-audio suppression leaving nothing to send, or an
+    output-device change) is reported instead of silently dead
+
 Screen share transmissions:
   - remote screen producers emit transmissionAvailable(peerId, producerId)
   - UI shows pending "Click to watch" tile (not auto-consumed)

--- a/frontend/src/lib/components/InstallPrompt.svelte
+++ b/frontend/src/lib/components/InstallPrompt.svelte
@@ -13,7 +13,7 @@
     // Check if already installed
     isStandalone =
       window.matchMedia("(display-mode: standalone)").matches ||
-      (window.navigator as any).standalone === true;
+      window.navigator.standalone === true;
 
     if (isStandalone) return;
 
@@ -32,10 +32,10 @@
       }, 3000); // Show 3 seconds after load
     };
 
-    window.addEventListener("beforeinstallprompt", handler as any);
+    window.addEventListener("beforeinstallprompt", handler);
 
     return () => {
-      window.removeEventListener("beforeinstallprompt", handler as any);
+      window.removeEventListener("beforeinstallprompt", handler);
     };
   });
 

--- a/frontend/src/lib/components/settings/AudioSettings.svelte
+++ b/frontend/src/lib/components/settings/AudioSettings.svelte
@@ -27,7 +27,12 @@
     setVoiceDtlnNoiseGate,
     getVoiceDtlnNoiseGate,
   } from "$lib/transport/voice.svelte";
-  import { setDeafened, toggleMute } from "$lib/transport/call.svelte";
+  import {
+    setDeafened,
+    toggleMute,
+    getShareAudioDespiteEchoRisk,
+    setShareAudioDespiteEchoRisk,
+  } from "$lib/transport/call.svelte";
   import {
     formatGain,
     gainToSlider,
@@ -62,6 +67,9 @@
   // Restored from the last session, not a fresh default.
   let noiseGateThreshold = $state(getVoiceDtlnNoiseGate());
   let noiseGateSlider = $state<number[]>([getVoiceDtlnNoiseGate() * 10000]);
+  // Off by default: screen-share audio that could not be confirmed
+  // echo-free is withheld unless the sharer opts in here (share-audio.ts).
+  let shareAudioDespiteEchoRisk = $state(getShareAudioDespiteEchoRisk());
 
   let isMicTesting = $state(false);
   // Distinct from isMicTesting: set only during async startup so a second
@@ -505,5 +513,32 @@
         class="w-full"
       />
     </div>
+  </div>
+
+  <!-- Screen Share Audio Section -->
+  <div
+    class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+  >
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <div class="w-1 h-4 bg-purple-500 rounded-full"></div>
+        <Label
+          class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+          >Screen Share Audio</Label
+        >
+      </div>
+      <Switch
+        bind:checked={shareAudioDespiteEchoRisk}
+        onCheckedChange={(checked) => setShareAudioDespiteEchoRisk(checked)}
+      />
+    </div>
+    <p class="text-[10px] text-muted-foreground font-mono">
+      A screen share's audio is only sent when awful.chat can confirm it
+      will not echo everyone's own voice back to them (a per-window share
+      on Windows 11 / macOS 14.2+, or any share with the browser's
+      own-audio filter confirmed on). When it can't confirm that, audio is
+      dropped by default. Turn this on to send it anyway - people may hear
+      themselves with a delay.
+    </p>
   </div>
 </div>

--- a/frontend/src/lib/transport/audio-prefs.ts
+++ b/frontend/src/lib/transport/audio-prefs.ts
@@ -14,6 +14,13 @@ export interface AudioPrefs {
   dtlnEnabled: boolean;
   noiseGate: number;
   /**
+   * Screen-share audio that could not be confirmed echo-free (see
+   * share-audio.ts) is withheld by default - the sharer must opt in here
+   * to send it anyway. Device-local and never sent to the room: it is a
+   * choice about what THIS device publishes, not room state.
+   */
+  shareAudioDespiteEchoRisk: boolean;
+  /**
    * How loud each person is for us, keyed by their did:key - the durable
    * identity, so the setting survives them reinstalling or changing devices,
    * where a peerId would not.
@@ -28,6 +35,7 @@ export const AUDIO_PREF_DEFAULTS: AudioPrefs = {
   outputVolume: 1.0,
   dtlnEnabled: true,
   noiseGate: 0.002,
+  shareAudioDespiteEchoRisk: false,
   peerVolumes: {},
 };
 
@@ -70,6 +78,10 @@ export function loadAudioPrefs(): AudioPrefs {
           ? p.dtlnEnabled
           : AUDIO_PREF_DEFAULTS.dtlnEnabled,
       noiseGate: num(p.noiseGate, AUDIO_PREF_DEFAULTS.noiseGate, 0, 0.01),
+      shareAudioDespiteEchoRisk:
+        typeof p.shareAudioDespiteEchoRisk === "boolean"
+          ? p.shareAudioDespiteEchoRisk
+          : AUDIO_PREF_DEFAULTS.shareAudioDespiteEchoRisk,
       peerVolumes: sanitizePeerVolumes(p.peerVolumes),
     };
   } catch {

--- a/frontend/src/lib/transport/call.svelte.ts
+++ b/frontend/src/lib/transport/call.svelte.ts
@@ -511,13 +511,6 @@ export function setShareAudioDespiteEchoRisk(enabled: boolean): void {
   saveAudioPrefs({ shareAudioDespiteEchoRisk: enabled });
 }
 
-export function pauseVideo(source: VideoSource): void {
-  _video.pauseVideo(source);
-}
-export function resumeVideo(source: VideoSource): void {
-  _video.resumeVideo(source);
-}
-
 export function setDeafened(deafened: boolean): void {
   if (deafened) {
     // Save current states before deafening

--- a/frontend/src/lib/transport/call.svelte.ts
+++ b/frontend/src/lib/transport/call.svelte.ts
@@ -22,6 +22,8 @@ import {
 } from "./transport.svelte";
 import type { VideoSource } from "./types";
 import { setTransmissionOutputVolume } from "./transmission.svelte";
+import { buildShareOptions, classifyShareAudio } from "./share-audio";
+import { loadAudioPrefs, saveAudioPrefs } from "./audio-prefs";
 import {
   cancelErrorClear,
   describeMediaError,
@@ -378,62 +380,100 @@ export function toggleScreenShare(): Promise<void> {
   return _screenPromise;
 }
 
-export async function startScreenShare(): Promise<void> {
+/**
+ * Starts (or accepts a pre-captured) screen share, then decides whether its
+ * audio track is safe to send.
+ *
+ * `stream` lets a caller that already ran getDisplayMedia hand the result
+ * straight in - the VideoTransport interface has always supported this (see
+ * types.ts) to avoid a second capture prompt. Either way the resulting
+ * track's REAL settings get classified: what we asked for and what the
+ * platform actually did can differ, and only the actual settings say
+ * whether the echo is really gone.
+ */
+export async function startScreenShare(stream?: MediaStream): Promise<void> {
   // Clear any pending error timeout and reset the error state. Attempting
   // the operation again makes any stale error irrelevant.
   cancelErrorClear();
   transportState.error = null;
-  if (!navigator.mediaDevices.getDisplayMedia) {
+  if (!stream && !navigator.mediaDevices.getDisplayMedia) {
     throw new Error("Screen sharing is not supported on this device");
   }
   try {
-    // Game and media audio verbatim: mic-style processing (AEC, noise
-    // suppression, AGC) mangles music and adds nothing to a loopback
-    // capture. The extra hints are Chromium-only and ignored elsewhere:
-    // they surface the audio checkbox for screens, hide our own tab from
-    // the picker, and let the sharer switch surfaces mid-share.
-    const options = {
-      video: { frameRate: { ideal: 30 } },
-      audio: {
-        echoCancellation: false,
-        noiseSuppression: false,
-        autoGainControl: false,
-        // Stereo at full rate: without asking, Chromium hands over mono.
-        channelCount: 2,
-        sampleRate: 48000,
-      },
-      systemAudio: "include",
-      selfBrowserSurface: "exclude",
-      surfaceSwitching: "include",
-    } as MediaStreamConstraints;
-    const stream = await navigator.mediaDevices.getDisplayMedia(options);
-    // Whole-screen audio loops the call itself back into the stream, so
-    // everyone hears their own voice with a delay. Window audio (Chrome or
-    // Edge on Windows) carries only that app's sound - tell the sharer.
-    const surface = stream
-      .getVideoTracks()[0]
-      ?.getSettings?.().displaySurface;
-    if (surface === "monitor" && stream.getAudioTracks().length > 0) {
-      _transport.announce({
-        type: "app-warning",
-        message:
-          "Sharing the whole screen sends ALL system audio - people will hear themselves. Share the game window instead (with 'Also share audio') to send only its sound.",
-      });
-    }
+    const captured =
+      stream ??
+      (await navigator.mediaDevices.getDisplayMedia(
+        buildShareOptions(navigator.mediaDevices.getSupportedConstraints())
+      ));
+
     // "music" keeps the browser's encoder from treating loopback audio as
     // speech. Video hint stays unset: "motion" would smooth games but smear
     // shared text, and we cannot know which this share is.
-    for (const track of stream.getAudioTracks()) track.contentHint = "music";
-    transportState.localScreenStream = stream;
+    for (const track of captured.getAudioTracks())
+      track.contentHint = "music";
+
+    // windowAudio degrades to system audio SILENTLY, and
+    // getSupportedConstraints().restrictOwnAudio lies on platforms (Linux)
+    // that can never honour it - so classify what the live tracks actually
+    // report, never what was requested.
+    const videoTrack = captured.getVideoTracks()[0];
+    let audioTrack: MediaStreamTrack | null =
+      captured.getAudioTracks()[0] ?? null;
+    const verdict = classifyShareAudio(
+      videoTrack?.getSettings() ?? {},
+      audioTrack?.getSettings() ?? null
+    );
+
+    if (verdict.kind === "echo-risk" && audioTrack) {
+      if (loadAudioPrefs().shareAudioDespiteEchoRisk) {
+        _transport.announce({
+          type: "app-warning",
+          message: `${verdict.message} Sending it anyway - "Send screen-share audio despite echo risk" is on in Settings > Audio.`,
+        });
+      } else {
+        // Default to safety: withhold the track so nobody hears themselves.
+        // Stop it too, or the OS-level capture session for audio nobody
+        // gets stays alive for the rest of the share.
+        audioTrack.stop();
+        captured.removeTrack(audioTrack);
+        audioTrack = null;
+        _transport.announce({
+          type: "app-warning",
+          message: verdict.message,
+        });
+      }
+    }
+
+    if (audioTrack) {
+      // The spec mandates a muted track when own-audio suppression leaves
+      // nothing to send, and a default-output-device change mid-share is a
+      // known real cause (crbug 1432877) - either way, tell the sharer
+      // rather than let the share go silently dead.
+      audioTrack.onmute = () => {
+        _transport.announce({
+          type: "app-warning",
+          message:
+            "This share's audio went silent - often caused by switching audio output devices mid-share.",
+        });
+      };
+      audioTrack.onunmute = () => {
+        _transport.announce({
+          type: "app-warning",
+          message: "This share's audio is back.",
+        });
+      };
+    }
+
+    transportState.localScreenStream = captured;
     transportState.screenSharing = true;
     playScreenShareStartSound();
-    stream.getVideoTracks()[0].onended = () => stopScreenShare();
+    videoTrack.onended = () => stopScreenShare();
     try {
-      await _video.startScreenShare(stream);
+      await _video.startScreenShare(captured);
     } catch (err) {
       // As with the camera: otherwise we advertise a transmission that does
       // not exist and the browser keeps the capture indicator up.
-      stream.getTracks().forEach((t) => t.stop());
+      captured.getTracks().forEach((t) => t.stop());
       transportState.localScreenStream = null;
       transportState.screenSharing = false;
       throw err;
@@ -454,6 +494,20 @@ export function stopScreenShare(): void {
   transportState.screenSharing = false;
   playScreenShareStopSound();
   _video.stopScreenShare();
+}
+
+/**
+ * The sharer's device-local choice to send screen-share audio even when it
+ * could not be confirmed echo-free. Off by default (see startScreenShare) -
+ * this never travels to the room, it only decides what THIS device
+ * publishes on its next share.
+ */
+export function getShareAudioDespiteEchoRisk(): boolean {
+  return loadAudioPrefs().shareAudioDespiteEchoRisk;
+}
+
+export function setShareAudioDespiteEchoRisk(enabled: boolean): void {
+  saveAudioPrefs({ shareAudioDespiteEchoRisk: enabled });
 }
 
 export function pauseVideo(source: VideoSource): void {

--- a/frontend/src/lib/transport/share-audio.test.ts
+++ b/frontend/src/lib/transport/share-audio.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { buildShareOptions, classifyShareAudio } from "./share-audio";
+
+/**
+ * Minimal MediaTrackSettings builders. Only the fields classifyShareAudio
+ * reads are meaningful; everything else on the real interface is optional.
+ */
+function video(displaySurface?: string): MediaTrackSettings {
+  return { displaySurface };
+}
+function audio(restrictOwnAudio?: boolean): MediaTrackSettings {
+  return { restrictOwnAudio };
+}
+
+describe("buildShareOptions", () => {
+  // Every member the research's recommended object requires, regardless of
+  // which audio branch fires. A silently-dropped member is exactly the kind
+  // of regression this test exists to catch.
+  const REQUIRED_KEYS = [
+    "video",
+    "audio",
+    "windowAudio",
+    "systemAudio",
+    "monitorTypeSurfaces",
+    "selfBrowserSurface",
+    "surfaceSwitching",
+    "audioSelection",
+  ] as const;
+
+  it("never omits a member the research requires, with restrictOwnAudio supported", () => {
+    const options = buildShareOptions({ restrictOwnAudio: true });
+    for (const key of REQUIRED_KEYS) {
+      expect(options).toHaveProperty(key);
+    }
+    expect(options.windowAudio).toBe("window");
+    expect(options.systemAudio).toBe("include");
+    expect(options.monitorTypeSurfaces).toBe("include");
+    expect(options.selfBrowserSurface).toBe("exclude");
+    expect(options.surfaceSwitching).toBe("include");
+    expect(options.audioSelection).toBe("preferred");
+    expect(options.video).toEqual({
+      displaySurface: "window",
+      frameRate: { ideal: 30 },
+    });
+  });
+
+  it("never omits a member the research requires, without restrictOwnAudio support", () => {
+    const options = buildShareOptions({ restrictOwnAudio: false });
+    for (const key of REQUIRED_KEYS) {
+      expect(options).toHaveProperty(key);
+    }
+    // The picker-shaping members do not depend on restrictOwnAudio support.
+    expect(options.windowAudio).toBe("window");
+    expect(options.systemAudio).toBe("include");
+    expect(options.monitorTypeSurfaces).toBe("include");
+    expect(options.selfBrowserSurface).toBe("exclude");
+    expect(options.surfaceSwitching).toBe("include");
+    expect(options.audioSelection).toBe("preferred");
+  });
+
+  it("requests verbatim stereo audio plus restrictOwnAudio when the platform reports support", () => {
+    const options = buildShareOptions({ restrictOwnAudio: true });
+    expect(options.audio).toEqual({
+      restrictOwnAudio: true,
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+      channelCount: 2,
+      sampleRate: 48000,
+    });
+  });
+
+  it("falls back to echo-cancelled mono when restrictOwnAudio is unsupported (Chrome 137-141 style)", () => {
+    const options = buildShareOptions({ restrictOwnAudio: false });
+    expect(options.audio).toEqual({
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+      channelCount: 1,
+    });
+  });
+
+  it("still requests restrictOwnAudio on Linux, which reports support it can never honour", () => {
+    // getSupportedConstraints().restrictOwnAudio is hardcoded true in the
+    // IDL on every engine that recognises the name, including Linux. There
+    // is no pre-picker way to tell the lie apart from the truth, so
+    // buildShareOptions trusts it - and classifyShareAudio catches the lie
+    // afterwards (see the Linux case below).
+    const options = buildShareOptions({ restrictOwnAudio: true });
+    expect(options.audio).toMatchObject({ restrictOwnAudio: true });
+  });
+});
+
+describe("classifyShareAudio", () => {
+  it("Windows 11 + Chrome 146+: window share with genuine per-application audio", () => {
+    const verdict = classifyShareAudio(video("window"), audio(true));
+    expect(verdict.kind).toBe("application-scoped");
+  });
+
+  it("Windows 10: window share degrades to system audio, restrictOwnAudio strips the echo", () => {
+    // Chromium reports identical settings for this case and the Windows 11
+    // case above - there is no JS-visible signal that distinguishes genuine
+    // per-app loopback from a system-audio fallback that got filtered
+    // clean. Both are echo-free, so both get the same, correct verdict.
+    const verdict = classifyShareAudio(video("window"), audio(true));
+    expect(verdict.kind).toBe("application-scoped");
+    expect(verdict.reason).toContain("indistinguishable");
+  });
+
+  it("macOS 14.2+ + Chrome 150+: window share with genuine per-application audio", () => {
+    const verdict = classifyShareAudio(video("window"), audio(true));
+    expect(verdict.kind).toBe("application-scoped");
+  });
+
+  it("Linux: getSupportedConstraints() claims restrictOwnAudio, but the live track never confirms it", () => {
+    // audio(undefined) models getSettings().restrictOwnAudio coming back
+    // absent - the platform cannot honour the constraint, so it never
+    // reports the setting, no matter what getSupportedConstraints() said
+    // before the picker opened.
+    const verdict = classifyShareAudio(video("window"), audio(undefined));
+    expect(verdict.kind).toBe("echo-risk");
+  });
+
+  it("monitor share with own audio not stripped: echo risk", () => {
+    const verdict = classifyShareAudio(video("monitor"), audio(false));
+    expect(verdict.kind).toBe("echo-risk");
+    expect(verdict.message).toMatch(/not sent/);
+  });
+
+  it("monitor share with own audio confirmed stripped: system audio, safe", () => {
+    const verdict = classifyShareAudio(video("monitor"), audio(true));
+    expect(verdict.kind).toBe("system-audio-own-audio-stripped");
+  });
+
+  it("no audio track at all", () => {
+    const verdict = classifyShareAudio(video("monitor"), null);
+    expect(verdict.kind).toBe("no-audio");
+  });
+
+  it("tab surface is always safe, even without restrictOwnAudio: our own tab is excluded from the picker", () => {
+    const verdict = classifyShareAudio(video("browser"), audio(false));
+    expect(verdict.kind).toBe("application-scoped");
+  });
+
+  it("fails closed on an unrecognised surface even when restriction is confirmed", () => {
+    const verdict = classifyShareAudio(video(undefined), audio(true));
+    expect(verdict.kind).toBe("echo-risk");
+  });
+});

--- a/frontend/src/lib/transport/share-audio.ts
+++ b/frontend/src/lib/transport/share-audio.ts
@@ -1,0 +1,208 @@
+/**
+ * Scoped screen-share audio: the getDisplayMedia() request to send, and the
+ * decision about whether the audio track that comes back is safe to publish.
+ *
+ * The problem this fixes: a screen share that captures whole-system audio
+ * also captures awful.chat's own playback of every remote participant. The
+ * SFU forwards that back out, so everyone hears themselves a moment later.
+ *
+ * The fix has two halves, kept apart on purpose:
+ *   - buildShareOptions() asks the platform to avoid the echo up front
+ *     (windowAudio: "window", restrictOwnAudio).
+ *   - classifyShareAudio() checks whether it actually worked, because both
+ *     of those options can degrade or fail SILENTLY. Chromium falls back
+ *     from per-application audio to whole-system audio without telling the
+ *     page (Chromium CL 7487294, "gDM: Fallback to system audio when
+ *     window audio is unsupported"), and getSupportedConstraints() reports
+ *     restrictOwnAudio as usable on platforms, like Linux, that can never
+ *     honour it. The only trustworthy signal is what the browser reports
+ *     back on the live tracks after capture has already started.
+ *
+ * This module has no DOM side effects and touches no transport state, so it
+ * is unit-testable against the W3C Screen Capture spec's platform matrix
+ * (Windows 11, Windows 10, macOS 14.2+, Linux) without a browser - see
+ * share-audio.test.ts.
+ */
+
+/**
+ * The outcome of checking a captured screen-share audio track against the
+ * settings the browser actually gave us.
+ *
+ * "application-scoped" and "system-audio-own-audio-stripped" are both SAFE
+ * to publish - neither can contain this call's own voice. They are named
+ * separately because they mean different things to a sharer even though
+ * awful.chat cannot always tell them apart from JavaScript (see the
+ * "window surface" branch in classifyShareAudio below): the browser gives
+ * no signal that distinguishes "genuinely captured only that application"
+ * from "captured the whole system, then filtered our own output back out".
+ */
+export type ShareAudioVerdictKind =
+  | "application-scoped"
+  | "system-audio-own-audio-stripped"
+  | "echo-risk"
+  | "no-audio";
+
+export interface ShareAudioVerdict {
+  kind: ShareAudioVerdictKind;
+  /** Machine-readable explanation, for logs and tests - not shown to the user. */
+  reason: string;
+  /** One sentence for the sharer, matching this verdict. */
+  message: string;
+}
+
+/**
+ * The single getDisplayMedia() options object for a screen share.
+ *
+ * Ship ONE object; never branch on the browser's user agent. Every member
+ * here is a WebIDL dictionary member - an engine that does not recognise
+ * one silently drops it (W3C Screen Capture spec is explicit: unknown
+ * members are ignored, not rejected). Firefox and Safari know none of the
+ * audio-scoping vocabulary below and fall back to whatever they already do;
+ * this function does not need to know that.
+ *
+ * The one real conditional is restrictOwnAudio. Its presence in
+ * `supported` only proves the ENGINE recognises the name (the spec
+ * hardcodes it to `true` in the IDL, even on platforms - Linux - that can
+ * never honour it) but it is still the only pre-picker signal available,
+ * and it changes which audio-processing settings are correct: real own-
+ * audio restriction beats browser echo-cancellation, so ask for verbatim
+ * stereo when restriction might apply, and fall back to lossy mono AEC
+ * (Chrome's own workaround before restrictOwnAudio existed) when it can't.
+ */
+export function buildShareOptions(
+  supported: MediaTrackSupportedConstraints
+): DisplayMediaStreamOptions {
+  const audio: MediaTrackConstraints = supported.restrictOwnAudio
+    ? {
+        // Removes this document's own output from whatever got captured.
+        // Chrome 141+, Windows and macOS only - but harmless to request
+        // everywhere else, since an engine that does not honour it just
+        // ignores it.
+        restrictOwnAudio: true,
+        // Verbatim capture: no mic-style processing on game/media audio.
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        channelCount: 2,
+        sampleRate: 48000,
+      }
+    : {
+        // restrictOwnAudio cannot help here. Chrome turned echoCancellation
+        // OFF by default for getDisplayMedia audio in M137 (crbug
+        // 422611724), so without restriction to lean on, ask for it
+        // explicitly - exactly what Jitsi does for the same platforms.
+        // Mono because AEC processing already costs fidelity; asking for
+        // stereo on top of it buys nothing.
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+      };
+
+  return {
+    video: {
+      // A picker-ordering HINT only - the spec guarantees displaySurface
+      // can never cause OverconstrainedError - so this can only nudge the
+      // user toward a window, never break the capture.
+      displaySurface: "window",
+      frameRate: { ideal: 30 },
+    },
+    audio,
+    // Ask for real per-application audio where the platform can give it
+    // (Windows 11 + Chrome 146+, macOS 14.2+ + Chrome 150+). Falls back to
+    // system audio, then to nothing, everywhere else - restrictOwnAudio
+    // above, and classifyShareAudio after capture, are what keep that safe.
+    windowAudio: "window",
+    // Still let a whole-screen share carry audio; restrictOwnAudio is what
+    // keeps that echo-free, not this.
+    systemAudio: "include",
+    monitorTypeSurfaces: "include",
+    // Never offer awful.chat's own window/tab in the picker - there is
+    // nothing useful to share from inside the call, and Chromium refuses
+    // application-audio capture of its own windows anyway.
+    selfBrowserSurface: "exclude",
+    surfaceSwitching: "include",
+    // Chrome 152+: nudges the picker's audio checkbox on by default.
+    audioSelection: "preferred",
+  };
+}
+
+/**
+ * Decide whether a captured screen-share audio track is safe to publish.
+ *
+ * Echo risk exists only for a non-tab surface whose own audio was not
+ * confirmed stripped: a tab capture cannot contain awful.chat's own voice
+ * (selfBrowserSurface excludes our own tab from the picker), so it is safe
+ * by construction regardless of restrictOwnAudio. Everything else needs
+ * restrictOwnAudio to have actually applied - not merely been requested.
+ *
+ * Fails closed: any surface value this function does not recognise is
+ * treated as risky, never as safe by default.
+ */
+export function classifyShareAudio(
+  videoSettings: MediaTrackSettings,
+  audioSettings: MediaTrackSettings | null
+): ShareAudioVerdict {
+  if (!audioSettings) {
+    return {
+      kind: "no-audio",
+      reason: "getDisplayMedia returned a stream with no audio track",
+      message:
+        "This share has no audio - the browser can return video only even when audio was requested. Re-share and check the audio box in the picker if you want sound.",
+    };
+  }
+
+  const surface = videoSettings.displaySurface;
+  // getSettings().restrictOwnAudio is the ONLY reliable proof that own-audio
+  // suppression actually ran. getSupportedConstraints() cannot be trusted
+  // for this (it lies on Linux), and the request can silently degrade
+  // without telling the page. Trust only the live track's own settings.
+  const restricted = audioSettings.restrictOwnAudio === true;
+
+  if (surface === "browser") {
+    // A captured tab is, by construction, some OTHER page's audio - our own
+    // tab is excluded from the picker, so there is no echo path here.
+    return {
+      kind: "application-scoped",
+      reason: "tab surface audio is scoped to that tab, not the whole system",
+      message: "Sharing this tab's audio only.",
+    };
+  }
+
+  if (restricted && surface === "window") {
+    // Cannot tell, from JavaScript, whether this is genuine per-application
+    // loopback (Windows 11 Chrome 146+, macOS 14.2+ Chrome 150+) or a
+    // system-audio fallback that restrictOwnAudio filtered clean - Chromium
+    // exposes no signal that distinguishes them. Both are echo-free, so a
+    // window pick gets the benefit of the doubt.
+    return {
+      kind: "application-scoped",
+      reason:
+        "window surface with confirmed own-audio removal (genuine per-app loopback, or a system-audio fallback filtered clean - indistinguishable from here)",
+      message: "Sharing this window's audio.",
+    };
+  }
+
+  if (restricted && surface === "monitor") {
+    // A monitor pick is definitely whole-system audio, even though it is
+    // safe: restrictOwnAudio strips our own output from it either way.
+    return {
+      kind: "system-audio-own-audio-stripped",
+      reason:
+        "monitor surface with confirmed own-audio removal: whole-system audio, minus this call's own output",
+      message: "Sharing your whole screen's audio (this call's own sound is removed).",
+    };
+  }
+
+  // Either restriction was requested but never confirmed, or the surface is
+  // something this function does not recognise. Either way, do not assume
+  // safety we cannot prove.
+  return {
+    kind: "echo-risk",
+    reason: restricted
+      ? `own-audio removal confirmed but surface "${String(surface)}" is not a recognised safe surface`
+      : "non-tab surface with unconfirmed own-audio suppression: the captured audio can contain this call's own voice played back to everyone",
+    message:
+      "This share's audio was not confirmed echo-safe, so it was not sent - everyone would otherwise hear themselves a moment later. Share a single window with its audio box checked, or turn on \"Send audio despite echo risk\" in Settings > Audio to send it anyway.",
+  };
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -79,12 +79,53 @@ interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
 }
 
-// Extend WindowEventMap to include beforeinstallprompt
-declare global {
-  interface WindowEventMap {
-    beforeinstallprompt: BeforeInstallPromptEvent;
-  }
-  interface Navigator {
-    standalone?: boolean;
-  }
+// Screen Capture spec members TypeScript's DOM lib does not know yet
+// (checked against lib.dom.d.ts shipped with TypeScript 5.9): windowAudio,
+// restrictOwnAudio, and the picker-shaping options around them. Chromium
+// ships all of these in stable; see frontend/src/lib/transport/share-audio.ts
+// for why awful.chat depends on them to avoid a screen-share echo.
+interface DisplayMediaStreamOptions {
+  /** Audio scoping for a WINDOW surface. "window" asks for audio from
+   * only the selected window; Chromium silently falls back to "system"
+   * on platforms that cannot honour it (never observable from options
+   * alone - see classifyShareAudio). */
+  windowAudio?: "system" | "window" | "exclude";
+  /** Whether system (whole-machine) audio is offered for MONITOR
+   * surfaces. Does not apply to window or tab surfaces. */
+  systemAudio?: "include" | "exclude";
+  /** Whether the capturer's own tab/window may be offered in the picker. */
+  selfBrowserSurface?: "include" | "exclude";
+  /** Whether the browser offers a live surface-switch control mid-share. */
+  surfaceSwitching?: "include" | "exclude";
+  /** Whether whole-monitor surfaces appear in the picker at all. */
+  monitorTypeSurfaces?: "include" | "exclude";
+  /** Nudges the picker's audio checkbox on by default (Chrome 152+). */
+  audioSelection?: "preferred";
+}
+interface MediaTrackConstraintSet {
+  /** Strips the audio produced by the tab that called getDisplayMedia
+   * out of whatever it captured. The fix for screen-share echo. */
+  restrictOwnAudio?: ConstrainBoolean;
+}
+interface MediaTrackSupportedConstraints {
+  /** Hardcoded `true` by the spec on every engine that knows the name -
+   * including platforms, like Linux, that can never honour it. Proves
+   * the name is recognised, never that it works. */
+  restrictOwnAudio?: boolean;
+}
+interface MediaTrackSettings {
+  /** The only reliable, post-capture proof that own-audio suppression
+   * actually ran. */
+  restrictOwnAudio?: boolean;
+}
+
+// Extend WindowEventMap to include beforeinstallprompt.
+// This file is a global script, so an interface here is already global; a
+// "declare global" wrapper silently does nothing and left InstallPrompt
+// casting to any.
+interface WindowEventMap {
+  beforeinstallprompt: BeforeInstallPromptEvent;
+}
+interface Navigator {
+  standalone?: boolean;
 }


### PR DESCRIPTION
## The problem

Sharing a screen attached **whole-system audio**, which contains every remote
participant's voice. They heard themselves back with a delay. This is worst
exactly where screen share matters most — sharing a game.

The old code knew: it warned the sharer when `displaySurface === "monitor"` and
an audio track existed. A warning does not stop an echo.

## The fix

Two Chromium features solve this properly, and both are now requested:

- **`windowAudio: "window"`** — audio scoped to the shared window. Windows 11
  from Chrome 146, macOS 14.2+ from Chrome 150.
- **`restrictOwnAudio: true`** — strips this document's own output out of
  whatever was captured. Chrome 141+, Windows and macOS.

Requesting them is not enough. `windowAudio: "window"` **degrades silently to
system audio**, and the page cannot see the degradation from the options it
sent. So the decision is made from what the live tracks report —
`getSettings().displaySurface` and `getSettings().restrictOwnAudio` — and it
**fails closed**: on an echo-risk verdict the audio track is stopped and removed
before it reaches the SFU, and the sharer is told why and how to get audio
through.

A sharer who wants it anyway turns on **Send audio despite echo risk** in
Settings > Audio. That is a device-local preference which never goes to the
room, and it switches to the degraded mono AEC mode that is correct when
`restrictOwnAudio` is unavailable.

`share-audio.ts` holds both decisions as pure functions:

```ts
buildShareOptions(supported: MediaTrackSupportedConstraints): DisplayMediaStreamOptions
classifyShareAudio(videoSettings, audioSettings): ShareAudioVerdict
```

Four verdicts: `application-scoped`, `system-audio-own-audio-stripped`,
`echo-risk`, `no-audio`. Only the first two are published.

## Honest per-platform outcome

| OS | Window audio | Screen audio | Own-audio suppression | Result |
|---|---|---|---|---|
| Windows 11 | yes, app-scoped (Chrome 146+) | yes | yes (141+) | audio sent |
| Windows 10 | system audio only | yes | yes (141+) | audio sent, own output filtered |
| macOS 14.2+ | yes, app-scoped (Chrome 150+) | yes (141+) | yes (141+) | audio sent |
| macOS < 14.2 | no | no | n/a | no audio |
| Linux | **no** | **no** | **no** — `getSupportedConstraints()` reports it and it never works | withheld, sharer told |
| Firefox | no | no | no | typically video only |
| Safari | no | no | no | no audio track at all |

Linux, Firefox and Safari users now get told they have no share audio instead of
silently echoing the call back into it. The opt-in still exists for anyone who
accepts the echo.

## Also handled

`audioTrack.onmute` / `onunmute`. The spec mandates a muted track when own-audio
suppression leaves nothing to send, and a default-output-device change mid-share
does the same. A share whose audio dies now says so rather than going quietly
dead.

## Drive-by fix found while adding the types

`vite-env.d.ts`'s two `declare global` blocks did nothing: a global script's
interfaces are already global, so the wrapper was inert. That is why
`InstallPrompt.svelte` had to cast to `any` for `beforeinstallprompt` and
`navigator.standalone`. Both casts are gone and the augmentations now apply.

## Verification

| Suite | Result |
|---|---|
| `pnpm test` | 828 passed, 67 files |
| `pnpm check` | 5030 files, 0 errors, 0 warnings |
| `pnpm build` | passes |

`share-audio.test.ts` covers one case per row of the table above, including the
Linux case where `getSupportedConstraints()` claims `restrictOwnAudio` on a
platform that can never honour it.

## Sources

Every capability claim above is version-pinned against the W3C Screen Capture
Working Draft (2026-08-27) and Chromium source at tag 152.0.7977.65 —
`media/base/media_switches.cc` (`IsApplicationLoopbackCaptureSupported`,
`kApplicationAudioCaptureWin`, `kApplicationAudioCaptureMac`,
`kPulseaudioLoopbackForScreenShare`) and
`chrome/browser/ui/views/desktop_capture/desktop_media_picker_views.cc`
(`GetWindowCaptureAudioType`). MDN's compat data still claims Chrome rejects the
`"window"` value; that note describes Chrome 141 and is stale.
