### PR TITLE
watch: an anime party synchronized by a clock, not by a bare position

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,17 @@ TURN_SECRET=
 # server-side only for that host.
 #PLUGIN_PROXY_SECRETS=STEAM@api.steampowered.com=your-steam-api-key
 
+# The built-in anime-party watch-party plugin needs none of the above. It
+# calls AniList's public GraphQL API directly from each participant's
+# browser: no key, no PLUGIN_PROXY_HOSTS entry, no PLUGIN_PROXY_SECRETS
+# entry, the same zero-configuration shape as the wheel and poll plugins.
+# If the lookup ever fails - AniList unreachable, no match, or an operator
+# running frontend/nginx.conf's tighter Report-Only CSP without adding
+# https://graphql.anilist.co and https://s4.anilist.co - the party still
+# works: the title is a plain typed string and video playback never waits
+# on metadata. See docs/anidb-watch-party.md for why AniDB itself is not
+# the metadata source.
+
 # X-Forwarded-For hop count and trusted proxy ranges, for the relay behind a
 # reverse proxy or CDN. Comma-separated CIDR blocks. Defaults to private and
 # loopback (127.0.0.0/8, ::1/128, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ group video.
 - **Profiles**: avatar, banner (image or GIF), a colored tag chip, bio, and
   name effects (gradient, shimmer, glow, rainbow).
 - **Plugins**: instance-level, Minecraft-mods style. Drop a folder or point
-  `PLUGIN_SOURCES` at GitHub repos and redeploy; ships with `/wheel` and
-  `/poll`, with more at
+  `PLUGIN_SOURCES` at GitHub repos and redeploy; ships with `/wheel`,
+  `/poll`, and an anime watch party with synced local-file playback, with
+  more at
   [awful-org/awfully-awesome](https://github.com/awful-org/awfully-awesome).
   See [frontend/plugins/README.md](frontend/plugins/README.md).
 - **Multi-device**: several devices on one identity, QR device sync,

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -181,6 +181,18 @@ and a single port already in use aborts the whole container, so a range inside
 Linux's ephemeral window (32768-60999) makes the SFU fail to start at random,
 typically after a reboot.
 
+## Plugin metadata lookups need no server change
+
+Not every plugin needs `PLUGIN_PROXY_HOSTS` or a satellite. The built-in
+`anime-party` watch-party plugin looks up anime and episode metadata from
+AniList's public GraphQL API, called directly from each participant's
+browser: no API key, no `/plugin-proxy` allowlist entry, and no change to
+the relay, the SFU, or coturn. AniList needs no key and already sends the
+CORS header a browser call needs, the same zero-configuration shape as the
+`wheel` and `poll` plugins. See `.env.example` and
+[docs/anidb-watch-party.md](../docs/anidb-watch-party.md) for why AniDB
+itself is not used instead.
+
 ## What cannot be multiplied yet
 
 The **relay** is single. It holds the rendezvous registry (who is in which

--- a/docs/anidb-watch-party.md
+++ b/docs/anidb-watch-party.md
@@ -1,0 +1,277 @@
+# Why AniDB is not the metadata source for the anime watch party
+
+## The ask
+
+Build an anime watch party for awful.chat, using AniDB as the metadata
+source: anime records, AniDB's distinctive episode numbering (specials,
+credits, trailers, and parodies as first-class entities), and cover art,
+surfaced in a chat card, a call tile, and a sidebar widget, the same way the
+existing `waffle-party` plugin does a shared music session.
+
+## The verdict
+
+AniDB cannot be the metadata source for this plugin, in any deployment
+shape this project can ship: not called directly from the browser, and not
+proxied through this repo's own relay.
+
+## Why
+
+Each blocker below is independent. Any one of them alone is enough to stop
+the integration.
+
+### 1. AniDB's HTTP API has no TLS listener, so a browser cannot call it
+
+awful.chat is a WebRTC PWA and therefore always runs in a secure context.
+Browsers classify `fetch()` and `XMLHttpRequest` to `http://` as blockable
+mixed content and refuse to send them from an HTTPS page. AniDB's HTTP API
+answers only on plain HTTP, port 9001; there is no HTTPS listener at all.
+
+> "Blockable content is defined as 'all mixed content that is not
+> upgradable'... This includes HTTP requests resulting from the following
+> elements... `fetch()` requests... `XMLHttpRequest` requests."
+> — https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content
+
+> "Example: URL: http://api.anidb.net:9001/httpapi?client={str}&clientver={int}&protover=1"
+> — https://wiki.anidb.net/HTTP_API_Definition
+
+AniDB does send a permissive CORS header (`Access-Control-Allow-Origin: *`),
+so CORS is not the problem. The scheme is. The browser's auto-upgrade path
+does not rescue this either: it rewrites `http://` to `https://` for
+elements like `<img>`, and AniDB has no HTTPS listener to upgrade to, so the
+rewritten request simply fails to connect.
+
+### 2. This repo's own relay proxy rejects non-HTTPS upstreams, by design
+
+Even if a plugin routed the call through the instance's own
+`/plugin-proxy`, the proxy refuses it:
+
+> ```go
+> pre, err := url.Parse(raw)
+> if err != nil || pre.Scheme != "https" {
+>     apiError(w, r, "Only https urls", http.StatusBadRequest)
+>     return
+> }
+> ```
+> — `relay/pluginproxy.go:415-419`, repeated at `:384` and `:441`
+
+This is a deliberate security property of the relay, applied to every
+plugin, not a rule written for AniDB. Weakening it to let AniDB through
+would weaken it for every other plugin an operator has allowlisted.
+
+A second, independent problem sits underneath the scheme check: the proxy's
+own rate budget cannot express AniDB's. The proxy limits by client IP; AniDB
+limits by client id, aggregated across every user who shares that id (see
+Blocker 3). A per-IP allowance cannot bound a per-client-id budget.
+
+### 3. AniDB requires a registered client id per deployer, with a strict, shared-fate rate limit
+
+AniDB enforces registration on every request:
+
+> "All users of the HTTP XML API need to be registered and have to provide
+> their registered client identifier and version number on each request."
+> — https://wiki.anidb.net/HTTP_API_Definition
+
+A request with an unregistered id gets the same error as no id at all:
+`<error code="302">client version missing or invalid</error>`. Registration
+needs a personal AniDB account
+(https://anidb.net/perl-bin/animedb.pl?show=client), so a client id belongs
+to one person, not to a project. The rate limit is severe and the
+enforcement compounds against continued traffic:
+
+> "You should not request more than one page every two seconds."
+> "Dropped packets are still taken into account for the packet rate. Meaning
+> if you continuously send packets your client will be banned forever."
+> — https://wiki.anidb.net/HTTP_API_Definition, https://wiki.anidb.net/UDP_API_Definition
+
+An open-source project has many independent self-hosted instances. If they
+shared one client id, AniDB would aggregate the rate limit across every
+instance and every user of every instance at once — a load no single
+operator can see or throttle. One busy instance can trip a ban that disables
+the plugin for every other deployment simultaneously. The only lawful shape
+is one registered client id per operator, which turns a zero-configuration
+plugin into one that needs every operator to hold a personal AniDB account.
+
+### 4. AniDB's content licence is CC-BY-NC-SA 4.0: no commercial use, ShareAlike on redistribution
+
+> "Content on AniDB is available under the Creative Commons
+> Attribution-NonCommercial-ShareAlike 4.0 International License
+> (CC-BY-NC-SA). In other words, you cannot use AniDB data as part of a
+> for-profit operation: no ads, subscriptions, paid downloads, sale of
+> merchandise, or other for-profit revenue streams."
+> — https://anidb.net/policy
+
+This binds every deployer of an open-source, self-hosted plugin: any
+instance that carries ads, charges for access, or otherwise operates
+commercially would breach the licence the moment it used the plugin.
+ShareAlike further means that any adapted AniDB dataset a plugin caches and
+reships must itself carry CC-BY-NC-SA — an obligation on data, separate from
+this project's own MIT/Apache code licence.
+
+### 5. AniDB cover images are hotlink-protected by `Referer`, and AniDB owns no image rights to license anyway
+
+A browser rendering an AniDB cover `<img>` from a chat page sends
+`Referer: https://<the instance's domain>/` and is refused with a
+misleadingly generic `404`; the same URL with no `Referer`, or with a
+`Referer` on `anidb.net` itself, returns `200`. Suppressing the `Referer`
+header would make the image load, but doing that on purpose is
+circumventing an access control AniDB configured deliberately, against
+AniDB's own instruction:
+
+> "'Fair Use'/'Fair Dealing': We do not own the copyright of any images
+> displayed on AniDB. Images are displayed under the 'fair use' or 'fair
+> dealing' concept... we display images on our Website to educate readers
+> on various anime that exist in the world, and we do not charge a fee."
+> — https://anidb.net/policy
+
+AniDB's own display rests on a fair-use posture it has not tested for a
+third party's re-display, and holds no copyright to grant a licence over in
+the first place.
+
+### 6. AniDB hosts and links no video, by its own stated policy
+
+> "AniDB Website and AniDB's IRC channels do not host any files for
+> download, and they do not link to any files for download."
+> — https://anidb.net/policy
+
+Whatever the plugin needs for actual playback, AniDB is not a source for it.
+At most it supplies metadata: anime records, episode lists, artwork
+references, and per-user MyList — never a video file or a stream.
+
+### 7. AniDB's `mylistsummary` endpoint sends the user's main account password in a URL, over plain HTTP
+
+> "The user name and password of the desired user. This is their main
+> password, not the API password specified in the profile."
+> — https://wiki.anidb.net/HTTP_API_Definition
+
+Combined with Blocker 1 — no TLS on port 9001 — this is a plaintext account
+password on the wire, sitting in a URL where any intermediate proxy log
+would capture it. No feature the plugin might want justifies ever building
+on this endpoint.
+
+### 8. The AniDB data dumps are forbidden by AniDB's own current terms and unreachable regardless
+
+AniDB's ToS is unambiguous and current:
+
+> "No scraping: Additionally, you may not scrape the AniDB database, and we
+> do not offer database dumps or bulk export access to the database."
+> — https://anidb.net/policy (last updated 31.12.2025 21:00)
+
+An older wiki page describing the dumps
+(https://wiki.anidb.net/API, last edited 2014) is superseded by that clause.
+Even setting the licence question aside, the dump files are plain HTTP
+(Blocker 1 again) and sit behind a bot challenge that a server-side fetcher
+would have to impersonate a browser to pass — a second circumvention on top
+of a terms violation.
+
+## What would have to change for the answer to become yes
+
+| Condition | Who controls it |
+| --- | --- |
+| AniDB adds a TLS listener to its HTTP API. | AniDB. Outside this project entirely. |
+| This repo's relay proxy accepts plain-HTTP upstreams. | This project's maintainers — and doing it weakens a deliberate security property for every plugin, not only this one. |
+| The licence question is settled for self-hosters: AniDB states plainly where a non-commercial, potentially donation-funded, open-source self-hosted instance sits relative to the NC clause. | AniDB, as the policy author. |
+| AniDB permits, or an operator accepts, a shared client id instead of one per deployer. | AniDB (permission) or each operator (accepting the outage risk of shared fate). Neither is available today. |
+| AniDB allows cover images to be displayed with a foreign `Referer`, or grants an explicit image licence. | AniDB. |
+
+Every one of these sits on AniDB's side, or costs this project a security
+property it should not give up for one plugin. None of them is something
+this project can decide on its own.
+
+## What was built instead
+
+An anime watch party that ships in this repo: **AniList's GraphQL API for
+metadata**, and **the Syncplay model for playback** — every participant
+opens their own local video file, and the plugin synchronizes playback
+position only, never video bytes.
+
+AniList (`https://graphql.anilist.co`) is HTTPS, sends a permissive CORS
+header, and needs no API key and no relay configuration — the same
+zero-configuration promise `waffle-party` makes for YouTube. It also
+returns `streamingEpisodes`, links to legitimate licensed places to watch an
+episode, turning "where do I get this" into a feature instead of a
+liability.
+
+The Syncplay-model playback and clock-synchronization primitives live in
+the shared library `frontend/src/lib/plugins/watch/`, documented in
+[frontend/plugins/README.md](../frontend/plugins/README.md). The plugin
+itself is `frontend/plugins/anime-party/`.
+
+## Options considered and rejected
+
+**Metadata sources.**
+
+- **AniDB, direct from the browser.** Rejected: no TLS listener; see
+  Blocker 1.
+- **AniDB, through a weakened relay proxy.** Rejected: this repo's proxy
+  refuses non-HTTPS upstreams by design, and its rate budget cannot express
+  AniDB's per-client-id limit anyway; see Blocker 2.
+- **AniDB's data dumps.** Rejected: forbidden outright by AniDB's current
+  terms, and blocked a second time by plain HTTP and a bot challenge; see
+  Blocker 8.
+- **Jikan (unofficial MAL API).** Rejected: a MAL scraper that inherits
+  MAL's downtime — repeated live probes returned `504` failures for common
+  anime ids, with episode data available only when its cache happened to be
+  warm.
+- **MyAnimeList, official API.** Rejected: no CORS headers at all (a
+  browser call fails outright), needs a key or OAuth2, and has no episode
+  endpoint of any kind.
+- **Kitsu.** Kept as an optional secondary, not the primary: it is HTTPS,
+  CORS-open, key-free, and returned complete episode entities in testing,
+  but its own rate limits and terms could not be verified from this
+  workstation.
+- **TMDB.** Rejected: needs an API key, which reintroduces per-deployer
+  signup and shared-secret relay configuration exactly like AniDB's
+  client-id problem, and its own terms forbid routing many instances
+  through one shared key.
+- **TheTVDB.** Rejected: needs a key and a login, and models episodes on
+  Western TV numbering rather than anime-native numbering.
+- **Shikimori.** Rejected: unreachable to verify from this workstation, and
+  its documented OAuth and `User-Agent` requirements make it unlikely to
+  beat AniList on the key-free axis anyway.
+
+**Playback substrates.**
+
+- **Each participant's own local file, position sync only (Syncplay
+  model).** Chosen: no copyrighted bytes ever leave a participant's own
+  machine, and sub-second synchronization is achievable by copying
+  Syncplay's published control law.
+- **One participant seeds the file over WebTorrent, others stream.**
+  Rejected: MKV (the dominant anime release container) and Hi10P (a common
+  anime video profile) have poor or no in-browser support even where
+  WebTorrent's own streaming layer applies; browsers cannot join the public
+  BitTorrent swarm as leechers, only as WebRTC peers of an explicit seeder;
+  and the seeding participant would be distributing a copyrighted file
+  through infrastructure the instance operator built and shipped.
+- **A shared external URL or HLS stream.** Rejected as a primary mechanism:
+  a URL field participants fill in becomes a pirate-stream distribution
+  channel the operator hosts with actual knowledge of its purpose, and
+  licensed hosts forbid embedding and enforce DRM. Kept only as a link-out:
+  AniList's `streamingEpisodes` entries render as outbound links to
+  licensed services, and participants who use one sync their position in
+  the plugin exactly as local-file participants do.
+
+## Unverified
+
+These claims could not be confirmed from this workstation and are carried
+as open risk on the recommendation, not on AniDB:
+
+- **AniList's formal terms of use and image licence.** `anilist.co` did not
+  resolve from the research workstation; only `graphql.anilist.co` and
+  `docs.anilist.co` did. AniList's technical behavior (CORS, no key needed)
+  is measured; its written terms of use are not read. This is the most
+  important open item, because AniList is the recommended source.
+- **Kitsu's rate limits and terms of use.** Its documentation host timed
+  out during research; only the API endpoint itself was probed.
+- **Shikimori, entirely.** Produced no response from the research
+  workstation.
+- **AniDB's client-registration approval time.** Registration needs a login
+  the research had no access to; the conclusion that it is self-service and
+  effectively instant is an inference from the public client list.
+- **AniDB's exact ban duration for HTTP API violations**, beyond the UDP
+  API's documented "usually lasts 30 minutes" for a short-term violation.
+- **Real-world browser playback rate for typical anime video files**
+  (Hi10P MKV and similar) under the chosen local-file substrate. Reasoned
+  from MDN's codec and container tables, not measured by opening an actual
+  file in a browser.
+- **AniList's episode-list completeness across a broad sample of older,
+  obscure, and OVA-type entries.** Verified only for one series.

--- a/frontend/plugins/README.md
+++ b/frontend/plugins/README.md
@@ -246,6 +246,72 @@ manifest. If you need something that is not there, ask - and expect the
 answer to be a `host` method rather than a component where that is possible,
 since data is a smaller promise for the host to keep than layout.
 
+## Synchronizing playback across peers
+
+`$lib/plugins/watch` is a shared, host-independent library for any plugin
+that keeps a media element in step across peers - the anime-party plugin
+uses it, and a future watch-together plugin should reuse it rather than
+re-invent the same control loop. Every export is pure and synchronous: no
+DOM, no timers, no `$lib/transport` import.
+
+```ts
+/** One authoritative playback snapshot. A timestamp and a rate, never a bare position. */
+export type WatchTick = {
+  paused: boolean;
+  /** media position in seconds, true at `atMs` on the sender's clock */
+  position: number;
+  /** sender wall clock, ms since epoch */
+  atMs: number;
+  /** playback rate; 1 is normal */
+  rate: number;
+  /** monotonically increasing per sender, for ordering ticks inside one room */
+  seq: number;
+};
+export type ClockSample = { t0: number; t1: number; t2: number; t3: number };
+export type ClockEstimate = { offsetMs: number; rttMs: number; samples: number };
+/** NTP-style offset from round-trip samples, median-filtered. */
+export function estimateClock(samples: readonly ClockSample[]): ClockEstimate;
+/** Where the tick says playback is, right now, on the local clock. */
+export function projectPosition(tick: WatchTick, nowMs: number, offsetMs: number): number;
+export type CorrectionAction = "none" | "seek" | "rate" | "pause" | "resume";
+export type Correction = { action: CorrectionAction; targetPosition: number; rate: number; driftMs: number };
+/** The control law. Small drift is corrected by rate, large drift by seek. */
+export function decideCorrection(
+  local: { position: number; paused: boolean; rate: number },
+  tick: WatchTick,
+  nowMs: number,
+  offsetMs: number,
+  cfg?: Partial<WatchSyncConfig>,
+): Correction;
+export type WatchSyncConfig = { seekThresholdMs: number; rateThresholdMs: number; slowRate: number; fastRate: number; maxRateCorrectionMs: number };
+export const DEFAULT_WATCH_SYNC: WatchSyncConfig;
+```
+
+A `WatchTick` is a snapshot, never a bare position: a lone number ages the
+moment it is written, and two peers reading it at different instants land
+at different places with nothing to correct the drift afterward. The
+timestamp and rate are what let every peer compute where playback actually
+is right now, on their own clock, via `projectPosition`.
+
+The control law follows Syncplay's published constants
+(`syncplay/constants.py`): ignore drift under `rateThresholdMs`, correct
+larger drift by nudging `rate` instead of seeking - a 5% speed change is
+neither visible nor audible, a seek is both - and only seek once drift
+passes `seekThresholdMs`. `DEFAULT_WATCH_SYNC` carries Syncplay's own
+numbers where Syncplay names one directly: `seekThresholdMs: 4000`
+(`DEFAULT_REWIND_THRESHOLD`), `rateThresholdMs: 1500`
+(`DEFAULT_SLOWDOWN_KICKIN_THRESHOLD`), `slowRate: 0.95` (`SLOWDOWN_RATE`),
+`maxRateCorrectionMs: 100` (`SLOWDOWN_RESET_THRESHOLD`). `fastRate: 1.05` is
+the one value with no matching named constant to quote - Syncplay's own
+fast-forward thresholds carry no paired speedup rate, so this is derived
+from the same "a small rate change is neither visible nor audible" design
+reasoning, applied symmetrically to the behind-schedule case.
+
+Clock offset is a plugin's own job to gather, through `host.ping` (above):
+sample several round trips, fold them into `ClockSample`s, and hand them to
+`estimateClock`, which does the NTP-style math once you have the samples.
+`decideCorrection` never touches the network itself.
+
 ## Calling external APIs
 
 Browsers cannot reach most APIs directly (CORS), and API keys must never

--- a/frontend/plugins/anime-party/AnimePartyCallTile.svelte
+++ b/frontend/plugins/anime-party/AnimePartyCallTile.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  /**
+   * Call-tile chrome: click-to-join, like a screen share. Nothing loud
+   * renders until a member opts in. Once joined it renders the same
+   * AnimePartyPlayer the card does - the tile costs the SFU nothing because
+   * content is entirely local; only card state syncs.
+   */
+  import { untrack } from "svelte";
+  import { Clapperboard, LogIn, Users } from "@lucide/svelte";
+  import type { HostApi } from "$lib/plugins/api";
+  import type { AnimePartyState } from "./logic";
+  import AnimePartyPlayer from "./AnimePartyPlayer.svelte";
+
+  let {
+    card,
+    cardState,
+    host,
+    chromeVisible,
+  }: {
+    card: { id: string };
+    cardState: unknown;
+    host: HostApi;
+    chromeVisible: boolean;
+  } = $props();
+
+  const party = $derived(cardState as AnimePartyState);
+  // untrack: our own DID never changes across this tile's life - the same
+  // one-time-read pattern the ecosystem's watch-together card uses.
+  const selfDid = untrack(() => host.selfDid());
+  const joined = $derived(party.members.has(selfDid));
+
+  let joining = $state(false);
+
+  async function joinTile(): Promise<void> {
+    joining = true;
+    try {
+      await host.sendUpdate(card.id, { action: "join" });
+    } finally {
+      joining = false;
+    }
+  }
+</script>
+
+<div class="flex size-full flex-col gap-2 p-2">
+  {#if party.closed}
+    <div class="flex flex-1 items-center justify-center font-mono text-xs text-white/70">
+      This party has ended.
+    </div>
+  {:else if joined}
+    <div class="pointer-events-auto flex-1">
+      <AnimePartyPlayer {card} {party} {host} {chromeVisible} />
+    </div>
+  {:else}
+    <button
+      onclick={joinTile}
+      disabled={joining}
+      class="pointer-events-auto flex flex-1 flex-col items-center justify-center gap-2 rounded-md bg-black/40 text-white disabled:opacity-60"
+    >
+      {#if party.coverImageUrl}
+        <img src={party.coverImageUrl} alt="" class="h-20 w-14 rounded-sm object-cover" />
+      {:else}
+        <Clapperboard class="size-8" />
+      {/if}
+      <span class="font-mono text-sm font-semibold">{party.title}</span>
+      <span class="flex items-center gap-1 font-mono text-[11px] text-white/70">
+        <Users class="size-3" />
+        {party.members.size} watching · Episode {party.episode}
+      </span>
+      <span class="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1 font-mono text-xs font-medium text-primary-foreground">
+        <LogIn class="size-3.5" />
+        Join
+      </span>
+    </button>
+  {/if}
+</div>

--- a/frontend/plugins/anime-party/AnimePartyCard.svelte
+++ b/frontend/plugins/anime-party/AnimePartyCard.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  /**
+   * Chat-card chrome for one anime party: title, cover, membership, and the
+   * host-departure grace window. The actual player is shared with the call
+   * tile - see AnimePartyPlayer.svelte.
+   */
+  import { onMount, untrack } from "svelte";
+  import { Clapperboard, LogIn, LogOut, Users, X } from "@lucide/svelte";
+  import type { Message } from "$lib/transport/transport.svelte";
+  import type { HostApi } from "$lib/plugins/api";
+  import { Tip } from "$lib/plugins/ui";
+  import { createHostDepartureGrace, type HostDepartureGrace } from "./host-departure";
+  import type { AnimePartyState } from "./logic";
+  import AnimePartyPlayer from "./AnimePartyPlayer.svelte";
+
+  let {
+    card,
+    cardState,
+    host,
+  }: {
+    card: Message;
+    cardState: unknown;
+    host: HostApi;
+  } = $props();
+
+  // $derived, never a const: a const reads the prop once at mount, and
+  // every later fold - somebody joining, the host pausing - would render
+  // nowhere until the card remounted.
+  const party = $derived(cardState as AnimePartyState);
+  // untrack: our own DID never changes across this card's life - the same
+  // one-time-read pattern the ecosystem's watch-together card uses.
+  const selfDid = untrack(() => host.selfDid());
+  const isOwner = $derived(party.ownerDid === selfDid);
+  const joined = $derived(party.members.has(selfDid));
+
+  let busy = $state(false);
+
+  onMount(() => {
+    let grace: HostDepartureGrace | null = null;
+    let pollTimer: ReturnType<typeof setInterval> | undefined;
+    if (!isOwner) {
+      grace = createHostDepartureGrace(party.ownerDid, host.peers, () => {
+        void host.sendUpdate(card.id, { action: "host-left" });
+      });
+      pollTimer = setInterval(() => grace?.observePeers(), 2000);
+    }
+    const unsubDisconnect = host.onPeerDisconnect(({ did }) => grace?.observeDisconnect(did));
+    const unsubBefore = host.onBeforeDisconnect(() => {
+      if (!isOwner && joined && !party.closed) {
+        host.sendUpdateImmediately(card.id, { action: "leave" });
+      }
+    });
+    return () => {
+      unsubDisconnect();
+      unsubBefore();
+      clearInterval(pollTimer);
+      grace?.dispose();
+    };
+  });
+
+  async function joinParty(): Promise<void> {
+    busy = true;
+    try {
+      await host.sendUpdate(card.id, { action: "join" });
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function leaveParty(): Promise<void> {
+    busy = true;
+    try {
+      await host.sendUpdate(card.id, { action: "leave" });
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function closeParty(): Promise<void> {
+    busy = true;
+    try {
+      await host.sendUpdate(card.id, { action: "close" });
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<div class="flex w-full flex-col gap-3">
+  <div class="flex items-start gap-3">
+    {#if party.coverImageUrl}
+      <img
+        src={party.coverImageUrl}
+        alt=""
+        class="h-16 w-11 shrink-0 rounded-sm object-cover"
+      />
+    {:else}
+      <div class="flex h-16 w-11 shrink-0 items-center justify-center rounded-sm bg-muted">
+        <Clapperboard class="size-4 text-muted-foreground" />
+      </div>
+    {/if}
+    <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+      <span class="truncate font-mono text-sm font-semibold">{party.title}</span>
+      <span class="font-mono text-[11px] text-muted-foreground">
+        Episode {party.episode}{party.episodeCount ? ` of ${party.episodeCount}` : ""}
+        · hosted by {card.senderName}
+      </span>
+      <span class="flex items-center gap-1 font-mono text-[10px] text-muted-foreground">
+        <Users class="size-3" />
+        {party.members.size} watching
+      </span>
+    </div>
+    {#if isOwner && !party.closed}
+      <Tip text="End the party for everyone">
+        {#snippet children(props)}
+          <button
+            {...props}
+            onclick={closeParty}
+            disabled={busy}
+            aria-label="Close party"
+            class="rounded-md border border-border p-1.5 hover:bg-accent disabled:opacity-40"
+          >
+            <X class="size-3.5" />
+          </button>
+        {/snippet}
+      </Tip>
+    {/if}
+  </div>
+
+  {#if party.closed}
+    <p class="font-mono text-xs text-muted-foreground">This party has ended.</p>
+  {:else if joined}
+    <AnimePartyPlayer {card} {party} {host} />
+    {#if !isOwner}
+      <button
+        onclick={leaveParty}
+        disabled={busy}
+        class="flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 font-mono text-[11px] hover:bg-accent disabled:opacity-40"
+      >
+        <LogOut class="size-3.5" />
+        Leave party
+      </button>
+    {/if}
+  {:else}
+    <button
+      onclick={joinParty}
+      disabled={busy}
+      class="flex w-fit items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 font-mono text-xs font-medium text-primary-foreground disabled:opacity-40"
+    >
+      <LogIn class="size-3.5" />
+      Join party
+    </button>
+  {/if}
+</div>

--- a/frontend/plugins/anime-party/AnimePartyPlayer.svelte
+++ b/frontend/plugins/anime-party/AnimePartyPlayer.svelte
@@ -1,0 +1,384 @@
+<script lang="ts">
+  /**
+   * The shared playback surface: file pickers, the `<video>` element, and
+   * the party's synced transport controls. Both the card and the call tile
+   * mount this - the only difference between those two surfaces is the
+   * chrome around it (join/leave vs click-to-join).
+   *
+   * No file's bytes are ever read by this component beyond what
+   * `URL.createObjectURL` needs locally. Nothing here ever calls
+   * `host.sendCard`/`sendUpdate` with a File, a Blob, or their contents.
+   */
+  import { onDestroy, onMount, untrack } from "svelte";
+  import {
+    AlertTriangle,
+    Captions,
+    Pause,
+    Play,
+    SkipForward,
+    Upload,
+    Volume2,
+  } from "@lucide/svelte";
+  import type { HostApi } from "$lib/plugins/api";
+  import { Tip } from "$lib/plugins/ui";
+  import {
+    estimateClock,
+    projectPosition,
+    decideCorrection,
+    type ClockEstimate,
+    type ClockSample,
+    type Correction,
+    type WatchTick,
+  } from "$lib/plugins/watch";
+  import { assessFile, mediaErrorMessage, type FileAssessment } from "./playback";
+  import type { AnimePartyState } from "./logic";
+
+  let {
+    card,
+    party,
+    host,
+    chromeVisible = true,
+  }: {
+    card: { id: string };
+    party: AnimePartyState;
+    host: HostApi;
+    chromeVisible?: boolean;
+  } = $props();
+
+  // untrack: our own DID never changes across this component's life, so
+  // this is deliberately a one-time read, not a tracked dependency - the
+  // same pattern the ecosystem's watch-together card uses for the same
+  // host.selfDid() call.
+  const selfDid = untrack(() => host.selfDid());
+  const isOwner = $derived(party.ownerDid === selfDid);
+
+  let videoEl: HTMLVideoElement | undefined = $state();
+  let fileName = $state<string | null>(null);
+  let subtitleName = $state<string | null>(null);
+  let assessment = $state<FileAssessment>({ verdict: "unknown", reason: null });
+  let playbackError = $state<string | null>(null);
+  let volume = $state(1);
+
+  let objectUrl = $state<string | null>(null);
+  let subtitleUrl = $state<string | null>(null);
+  let seq = 0;
+  let clockSamples: ClockSample[] = [];
+  let clockEstimate = $state<ClockEstimate>({ offsetMs: 0, rttMs: 0, samples: 0 });
+  let pendingResync: { id: string; sentAt: number } | null = null;
+  const answeredResyncIds = new Set<string>();
+  // untrack: seeded once on purpose (compared against the live party.episode
+  // inside the effect below), the same "seed once, then own it" pattern
+  // MusicCard uses for its localPosition seed.
+  let lastSeenEpisode = untrack(() => party.episode);
+
+  onMount(() => {
+    void host.storage.get("volume").then((v) => {
+      if (typeof v === "number" && v >= 0 && v <= 1) volume = v;
+    });
+    if (!isOwner) requestResync();
+  });
+
+  onDestroy(() => {
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+    if (subtitleUrl) URL.revokeObjectURL(subtitleUrl);
+  });
+
+  // A new episode is nobody's file until they open it again - carrying the
+  // old object URL forward would show episode N+1's controls over episode
+  // N's picture.
+  $effect(() => {
+    if (party.episode === lastSeenEpisode) return;
+    lastSeenEpisode = party.episode;
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+    objectUrl = null;
+    fileName = null;
+    assessment = { verdict: "unknown", reason: null };
+    playbackError = null;
+    if (videoEl) videoEl.removeAttribute("src");
+  });
+
+  $effect(() => {
+    if (videoEl) videoEl.volume = volume;
+  });
+
+  // A paused/played durable-state change reaches every member immediately,
+  // rather than waiting for the next heartbeat tick.
+  $effect(() => {
+    if (isOwner || !videoEl || !objectUrl) return;
+    if (party.paused && !videoEl.paused) videoEl.pause();
+    if (!party.paused && videoEl.paused) void videoEl.play().catch(() => {});
+  });
+
+  function buildTick(): WatchTick {
+    seq += 1;
+    return {
+      paused: videoEl?.paused ?? party.paused,
+      position: videoEl?.currentTime ?? 0,
+      atMs: Date.now(),
+      rate: 1,
+      seq,
+    };
+  }
+
+  function sendTick(): void {
+    void host.sendUpdate(card.id, { action: "tick", tick: buildTick() }, { ephemeral: true });
+  }
+
+  // The owner's heartbeat: how every other member's reconciliation loop
+  // learns where playback actually is.
+  $effect(() => {
+    if (!isOwner || party.closed) return;
+    const timer = setInterval(() => {
+      if (videoEl && objectUrl) sendTick();
+    }, 1000);
+    return () => clearInterval(timer);
+  });
+
+  // Answer any late-joiner sync request nobody has answered yet.
+  $effect(() => {
+    if (!isOwner || !party.syncRequest) return;
+    const req = party.syncRequest;
+    if (answeredResyncIds.has(req.id)) return;
+    answeredResyncIds.add(req.id);
+    void host.sendUpdate(card.id, {
+      action: "resync-response",
+      targetDid: req.requesterDid,
+      requestId: req.id,
+      tick: buildTick(),
+    });
+  });
+
+  function requestResync(): void {
+    const requestId = crypto.randomUUID();
+    pendingResync = { id: requestId, sentAt: Date.now() };
+    void host.sendUpdate(card.id, { action: "resync-request", requestId });
+  }
+
+  // The late-joiner round trip: one request, one response, no per-frame
+  // traffic. The response's timestamp plus our own send/receive times give
+  // a single NTP-style clock sample (t1 and t2 coincide because the owner
+  // reports one instant, not a distinct receive-then-send pair).
+  $effect(() => {
+    const resp = party.syncResponse;
+    if (!resp || resp.targetDid !== selfDid || !pendingResync || resp.id !== pendingResync.id)
+      return;
+    const t3 = Date.now();
+    const sample: ClockSample = {
+      t0: pendingResync.sentAt,
+      t1: resp.tick.atMs,
+      t2: resp.tick.atMs,
+      t3,
+    };
+    clockSamples = [...clockSamples, sample].slice(-8);
+    clockEstimate = estimateClock(clockSamples);
+    pendingResync = null;
+    if (videoEl && objectUrl) {
+      videoEl.currentTime = projectPosition(resp.tick, Date.now(), clockEstimate.offsetMs);
+      if (resp.tick.paused) videoEl.pause();
+      else void videoEl.play().catch(() => {});
+    }
+  });
+
+  function applyCorrection(correction: Correction): void {
+    if (!videoEl) return;
+    switch (correction.action) {
+      case "seek":
+        videoEl.currentTime = correction.targetPosition;
+        videoEl.playbackRate = 1;
+        break;
+      case "rate":
+        videoEl.playbackRate = correction.rate;
+        break;
+      case "pause":
+        videoEl.playbackRate = 1;
+        videoEl.pause();
+        break;
+      case "resume":
+        videoEl.playbackRate = 1;
+        void videoEl.play().catch(() => {});
+        break;
+      case "none":
+        videoEl.playbackRate = 1;
+        break;
+    }
+  }
+
+  // The continuous half of sync: small drift is absorbed by nudging the
+  // rate, large drift by seeking - the control law itself lives in
+  // $lib/plugins/watch, this just feeds it our local player state.
+  $effect(() => {
+    if (isOwner || party.closed) return;
+    const timer = setInterval(() => {
+      if (!videoEl || !objectUrl || !party.lastTick) return;
+      const local = {
+        position: videoEl.currentTime,
+        paused: videoEl.paused,
+        rate: videoEl.playbackRate,
+      };
+      applyCorrection(decideCorrection(local, party.lastTick, Date.now(), clockEstimate.offsetMs));
+    }, 1000);
+    return () => clearInterval(timer);
+  });
+
+  function onFilePick(e: Event): void {
+    const file = (e.currentTarget as HTMLInputElement).files?.[0];
+    if (!file) return;
+    if (objectUrl) URL.revokeObjectURL(objectUrl);
+    playbackError = null;
+    fileName = file.name;
+    assessment = assessFile(file.name);
+    if (assessment.verdict === "unplayable") {
+      objectUrl = null;
+      videoEl?.removeAttribute("src");
+      return;
+    }
+    objectUrl = URL.createObjectURL(file);
+    if (videoEl) videoEl.src = objectUrl;
+  }
+
+  function onSubtitlePick(e: Event): void {
+    const file = (e.currentTarget as HTMLInputElement).files?.[0];
+    if (!file) return;
+    if (subtitleUrl) URL.revokeObjectURL(subtitleUrl);
+    subtitleName = file.name;
+    subtitleUrl = URL.createObjectURL(file);
+  }
+
+  function onVideoError(): void {
+    playbackError = mediaErrorMessage(videoEl?.error?.code ?? null);
+  }
+
+  function onVolumeInput(e: Event): void {
+    volume = Number((e.currentTarget as HTMLInputElement).value);
+    void host.storage.set("volume", volume);
+  }
+
+  async function togglePlay(): Promise<void> {
+    if (!isOwner) return;
+    const willPause = !party.paused;
+    await host.sendUpdate(card.id, { action: willPause ? "pause" : "play" });
+    if (videoEl) {
+      if (willPause) videoEl.pause();
+      else void videoEl.play().catch(() => {});
+    }
+    sendTick();
+  }
+
+  function onSeekCommit(): void {
+    if (isOwner) sendTick();
+  }
+
+  async function nextEpisode(): Promise<void> {
+    if (!isOwner) return;
+    await host.sendUpdate(card.id, { action: "select-episode", episode: party.episode + 1 });
+  }
+
+  const atLastEpisode = $derived(
+    party.episodeCount !== null && party.episode >= party.episodeCount
+  );
+</script>
+
+<div class="flex w-full flex-col gap-2">
+  <div class="relative overflow-hidden rounded-md bg-black">
+    <video
+      bind:this={videoEl}
+      class="aspect-video w-full bg-black"
+      controls={false}
+      onerror={onVideoError}
+      onseeked={onSeekCommit}
+    >
+      {#if subtitleUrl}
+        <track kind="subtitles" src={subtitleUrl} label={subtitleName ?? "Subtitles"} default />
+      {/if}
+    </video>
+    {#if !objectUrl}
+      <div class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 p-4 text-center">
+        <label
+          class="flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground"
+        >
+          <Upload class="size-3.5" />
+          Open episode {party.episode}
+          <input type="file" accept="video/*" class="hidden" onchange={onFilePick} />
+        </label>
+        <p class="max-w-xs text-[11px] text-white/70">
+          Your file stays on your device. Nothing is uploaded to the room.
+        </p>
+      </div>
+    {/if}
+  </div>
+
+  {#if assessment.reason}
+    <div
+      class="flex items-start gap-2 rounded-md border border-border bg-muted p-2 text-[11px] {assessment.verdict === 'unplayable' ? 'text-destructive' : 'text-muted-foreground'}"
+    >
+      <AlertTriangle class="mt-0.5 size-3.5 shrink-0" />
+      <span>{assessment.reason}</span>
+    </div>
+  {/if}
+  {#if playbackError}
+    <div class="flex items-start gap-2 rounded-md border border-border bg-muted p-2 text-[11px] text-destructive">
+      <AlertTriangle class="mt-0.5 size-3.5 shrink-0" />
+      <span>{playbackError}</span>
+    </div>
+  {/if}
+
+  <div
+    class="flex items-center gap-2 {chromeVisible ? '' : 'opacity-60'}"
+  >
+    <Tip text={isOwner ? (party.paused ? "Play" : "Pause") : "Only the host controls playback"}>
+      {#snippet children(props)}
+        <button
+          {...props}
+          onclick={togglePlay}
+          disabled={!isOwner}
+          aria-label={party.paused ? "Play" : "Pause"}
+          class="rounded-md border border-border p-1.5 hover:bg-accent disabled:opacity-40"
+        >
+          {#if party.paused}<Play class="size-3.5" />{:else}<Pause class="size-3.5" />{/if}
+        </button>
+      {/snippet}
+    </Tip>
+
+    <Tip text={atLastEpisode ? "No more episodes" : "Next episode"}>
+      {#snippet children(props)}
+        <button
+          {...props}
+          onclick={nextEpisode}
+          disabled={!isOwner || atLastEpisode}
+          aria-label="Next episode"
+          class="rounded-md border border-border p-1.5 hover:bg-accent disabled:opacity-40"
+        >
+          <SkipForward class="size-3.5" />
+        </button>
+      {/snippet}
+    </Tip>
+
+    <span class="font-mono text-[11px] text-muted-foreground">
+      Episode {party.episode}{party.episodeCount ? ` / ${party.episodeCount}` : ""}
+    </span>
+
+    <div class="ml-auto flex items-center gap-1.5">
+      <Volume2 class="size-3.5 text-muted-foreground" />
+      <input
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        value={volume}
+        oninput={onVolumeInput}
+        class="w-16"
+        aria-label="Volume"
+      />
+    </div>
+
+    <label class="flex cursor-pointer items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] hover:bg-accent">
+      <Captions class="size-3.5" />
+      {subtitleName ?? "Subtitles (.vtt)"}
+      <input type="file" accept=".vtt,text/vtt" class="hidden" onchange={onSubtitlePick} />
+    </label>
+  </div>
+
+  {#if fileName}
+    <p class="truncate font-mono text-[10px] text-muted-foreground">Your file: {fileName}</p>
+  {/if}
+</div>

--- a/frontend/plugins/anime-party/README.md
+++ b/frontend/plugins/anime-party/README.md
@@ -1,0 +1,91 @@
+# Anime Party
+
+Watch an episode together. Start one with:
+
+```
+/anime-party One Piece
+```
+
+## What it does
+
+Everyone who joins opens **their own** video file from their own computer.
+The plugin never reads, uploads, or relays that file - it only keeps
+everyone's player at the same position and paused/playing state, the same
+way Syncplay does. The host drives playback: pause, play, seek, and moving
+to the next episode all happen from the host's controls and reach everyone
+else within about a second. A viewer opening the party after playback has
+already started gets a one-time sync instead of waiting for the next
+heartbeat.
+
+The party appears as a chat card, and as a click-to-join tile in a call -
+like a screen share, nothing plays until a member opts in.
+
+## Metadata
+
+`/anime-party <title>` looks the title up on
+[AniList](https://anilist.co) for a proper title, episode count, and cover
+art. This is called directly from your browser - no server, no API key,
+nothing for the operator to configure. If AniList has no match, is slow, or
+is unreachable, the party still opens with exactly the title you typed and
+no cover image. Metadata never blocks or delays playback.
+
+## Files and playback
+
+Pick your own copy of the current episode with the file picker in the
+player. Browsers cannot play the **Matroska (.mkv) container** at all - the
+dominant anime-release format - so an .mkv file is refused outright with an
+explanation instead of being tried and silently failing. A filename hinting
+at HEVC, H.265, or 10-bit color gets a softer warning, since only the
+browser's own attempt to decode it can say for certain whether it works. Any
+other decode failure is reported in one sentence read from the browser's own
+error.
+
+Subtitles that are baked into a video container (as most anime releases do)
+are **not exposed to a browser at all** - there is no way around this. Pick
+a separate subtitle file instead, and it must be **WebVTT (.vtt)**: that is
+the only subtitle format a browser's native `<track>` element understands.
+An .srt or .ass file will not show anything.
+
+Each participant's volume is their own, remembered on their device under
+`awful:plugin:anime-party:volume`. It is never sent to the room.
+
+## Moving to the next episode
+
+The host advances the party with the next-episode control. Every
+participant then needs to open their own file for that episode - nothing
+carries forward automatically, because nobody's file for episode N+1 is
+known to anyone but them.
+
+## If the host disconnects
+
+Other members wait 15 seconds for the host's connection to come back (a
+call renegotiation can briefly drop and restore a peer connection on its
+own) before the party closes. If the host reconnects inside that window,
+nothing happens.
+
+## Honest limits
+
+- Sync is close, not frame-accurate. Two different releases of the same
+  episode - different cuts, different pre-roll - can sit seconds apart, and
+  nothing detects or warns about that mismatch.
+- Only the host controls transport (play, pause, seek, next episode).
+  Everyone else watches and picks their own file and subtitle track.
+- No search-as-you-type against AniList: a lookup only happens once, when
+  the party is created, to stay well inside AniList's rate limit.
+- No audio extraction, no picture-in-picture beyond what the browser already
+  gives a `<video>` element, and no attempt to verify that two participants
+  opened the same actual release.
+
+## Install
+
+Built in. No `PLUGIN_SOURCES` entry needed.
+
+## Requirements
+
+None. AniList needs no API key and no relay configuration, and every video
+plays from a file already on the viewer's own device.
+
+Privacy note: an AniList lookup sends the typed title to AniList from the
+searching participant's own browser, the same way loading a cover image
+does. No file, filename, or playback position is ever sent anywhere but the
+room's own members.

--- a/frontend/plugins/anime-party/anilist.ts
+++ b/frontend/plugins/anime-party/anilist.ts
@@ -1,0 +1,83 @@
+/**
+ * AniList metadata lookup, called directly from the browser.
+ *
+ * AniList's GraphQL endpoint is HTTPS and sends `Access-Control-Allow-Origin: *`
+ * on the actual response and the OPTIONS preflight alike, and needs no API
+ * key. That combination means CORS is not blocking a direct call the way it
+ * blocks most APIs, so this goes straight to `graphql.anilist.co` and never
+ * touches `/plugin-proxy` - which is GET-only (`relay/pluginproxy.go`) and
+ * could not carry a GraphQL POST body anyway. No PLUGIN_PROXY_HOSTS entry,
+ * no secret, no operator configuration: same "Requirements: None" shape the
+ * README asks built-in plugins to aim for.
+ *
+ * Network code lives here, never in `logic.ts`'s `reduce` - the host replays
+ * persisted updates on every cold load, and a replayed fetch is a bug.
+ */
+
+const ANILIST_ENDPOINT = "https://graphql.anilist.co";
+
+/** AniList's own image CDN. Cover URLs are also peer-supplied (they travel
+ *  in the card payload), so `logic.ts` re-checks this same host before
+ *  trusting one - this constant is the single place that host is spelled. */
+export const ANILIST_COVER_HOST_RE = /^https:\/\/s4\.anilist\.co\//;
+
+const SEARCH_QUERY = `
+  query ($search: String) {
+    Media(search: $search, type: ANIME) {
+      id
+      title {
+        romaji
+        english
+      }
+      coverImage {
+        medium
+      }
+      episodes
+    }
+  }
+`;
+
+export interface AniListMatch {
+  id: number;
+  title: string;
+  coverImageUrl: string | null;
+  episodeCount: number | null;
+}
+
+/**
+ * Look up one anime by title. Resolves to `null` on no match, a network
+ * error, a non-2xx response, or a malformed body - metadata is a
+ * convenience, never a gate, so every failure mode collapses to the same
+ * "use the typed title" outcome rather than a distinct error the caller has
+ * to handle.
+ */
+export async function searchAnime(
+  title: string,
+  opts?: { signal?: AbortSignal }
+): Promise<AniListMatch | null> {
+  const query = title.trim();
+  if (!query) return null;
+  try {
+    const res = await fetch(ANILIST_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ query: SEARCH_QUERY, variables: { search: query } }),
+      signal: opts?.signal,
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const media = json?.data?.Media;
+    if (!media || typeof media.id !== "number") return null;
+    const cover = media.coverImage?.medium;
+    return {
+      id: media.id,
+      title: media.title?.english || media.title?.romaji || query,
+      coverImageUrl:
+        typeof cover === "string" && ANILIST_COVER_HOST_RE.test(cover) ? cover : null,
+      episodeCount:
+        typeof media.episodes === "number" && media.episodes > 0 ? media.episodes : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/frontend/plugins/anime-party/host-departure.test.ts
+++ b/frontend/plugins/anime-party/host-departure.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHostDepartureGrace, HOST_DEPARTURE_GRACE_MS } from "./host-departure";
+
+const HOST = "did:host";
+
+describe("createHostDepartureGrace", () => {
+  it("does nothing while the host stays connected", () => {
+    vi.useFakeTimers();
+    try {
+      const onGraceElapsed = vi.fn();
+      const grace = createHostDepartureGrace(HOST, () => [{ did: HOST }], onGraceElapsed);
+      grace.observePeers();
+      vi.advanceTimersByTime(HOST_DEPARTURE_GRACE_MS + 1_000);
+      expect(onGraceElapsed).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the party once the host has been gone for the whole grace window", () => {
+    vi.useFakeTimers();
+    try {
+      const onGraceElapsed = vi.fn();
+      let peers: Array<{ did: string }> = [{ did: HOST }];
+      const grace = createHostDepartureGrace(HOST, () => peers, onGraceElapsed);
+      peers = [];
+      grace.observeDisconnect(HOST);
+      expect(onGraceElapsed).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(HOST_DEPARTURE_GRACE_MS - 1);
+      expect(onGraceElapsed).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(onGraceElapsed).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels the close when the host reconnects before the grace window elapses", () => {
+    vi.useFakeTimers();
+    try {
+      const onGraceElapsed = vi.fn();
+      let peers: Array<{ did: string }> = [{ did: HOST }];
+      const grace = createHostDepartureGrace(HOST, () => peers, onGraceElapsed);
+      peers = [];
+      grace.observeDisconnect(HOST);
+      vi.advanceTimersByTime(HOST_DEPARTURE_GRACE_MS / 2);
+      // The host's peer connection comes back before the window elapses.
+      peers = [{ did: HOST }];
+      grace.observePeers();
+      vi.advanceTimersByTime(HOST_DEPARTURE_GRACE_MS);
+      expect(onGraceElapsed).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a disconnect for anyone other than the host", () => {
+    vi.useFakeTimers();
+    try {
+      const onGraceElapsed = vi.fn();
+      const grace = createHostDepartureGrace(HOST, () => [], onGraceElapsed);
+      grace.observeDisconnect("did:someone-else");
+      vi.advanceTimersByTime(HOST_DEPARTURE_GRACE_MS + 1_000);
+      expect(onGraceElapsed).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dispose leaves no pending timer that can still fire", () => {
+    vi.useFakeTimers();
+    try {
+      const onGraceElapsed = vi.fn();
+      const grace = createHostDepartureGrace(HOST, () => [], onGraceElapsed);
+      grace.observeDisconnect(HOST);
+      grace.dispose();
+      vi.advanceTimersByTime(HOST_DEPARTURE_GRACE_MS + 1_000);
+      expect(onGraceElapsed).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/plugins/anime-party/host-departure.ts
+++ b/frontend/plugins/anime-party/host-departure.ts
@@ -1,0 +1,58 @@
+/**
+ * Detects the party's host disconnecting and gives them a grace window to
+ * reconnect before the party auto-closes.
+ *
+ * Mirrors the pattern the ecosystem's watch-together plugin already uses
+ * for exactly this problem (a member disconnecting mid-call-setup is
+ * common and must not be mistaken for the host leaving for good): start a
+ * timer on disconnect, cancel it the moment the host's peer connection is
+ * observed again, and only act once the timer actually elapses. 15s keeps
+ * the original 5s tolerance as a floor while giving a call renegotiation
+ * room to finish first.
+ */
+
+export interface PeerLike {
+  did: string;
+}
+
+export interface HostDepartureGrace {
+  /** Call from `host.onPeerDisconnect` for every peer that drops. */
+  observeDisconnect(did: string): void;
+  /** Call periodically (or whenever `host.peers()` might have changed) so a
+   *  returning host cancels the pending close. */
+  observePeers(): void;
+  /** Call on unmount. Leaves no timer running past the component's life. */
+  dispose(): void;
+}
+
+export const HOST_DEPARTURE_GRACE_MS = 15_000;
+
+export function createHostDepartureGrace(
+  hostDid: string,
+  peers: () => PeerLike[],
+  onGraceElapsed: () => void,
+  delayMs = HOST_DEPARTURE_GRACE_MS
+): HostDepartureGrace {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function observePeers(): void {
+    if (!timer || !peers().some((peer) => peer.did === hostDid)) return;
+    clearTimeout(timer);
+    timer = null;
+  }
+
+  function observeDisconnect(did: string): void {
+    if (!hostDid || did !== hostDid || timer) return;
+    timer = setTimeout(() => {
+      timer = null;
+      if (!peers().some((peer) => peer.did === hostDid)) onGraceElapsed();
+    }, delayMs);
+  }
+
+  function dispose(): void {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  }
+
+  return { observeDisconnect, observePeers, dispose };
+}

--- a/frontend/plugins/anime-party/index.ts
+++ b/frontend/plugins/anime-party/index.ts
@@ -1,0 +1,45 @@
+import { definePlugin, type HostApi } from "$lib/plugins/api";
+import { manifest } from "./manifest";
+import AnimePartyCard from "./AnimePartyCard.svelte";
+import AnimePartyCallTile from "./AnimePartyCallTile.svelte";
+import { initialState, reduce, type AnimePartyState } from "./logic";
+import { searchAnime } from "./anilist";
+
+export default definePlugin({
+  manifest,
+  card: AnimePartyCard,
+  callTile: AnimePartyCallTile,
+  // A party is worth showing in the call grid once it has a real host and
+  // has not been closed - members joining a call is a separate, later step
+  // (the tile is click-to-join, like a screen share).
+  callTileActive: (cardState: unknown) => {
+    const state = cardState as AnimePartyState | undefined;
+    return !!state && !state.closed && state.ownerDid !== "";
+  },
+  callTileViewers: (cardState: unknown) => {
+    const state = cardState as AnimePartyState | undefined;
+    return state ? [...state.members.values()] : [];
+  },
+  initialState,
+  reduce,
+  commands: {
+    "anime-party": async (args: string, host: HostApi) => {
+      const title = args.trim();
+      if (!title) {
+        console.warn("[anime-party] format: /anime-party <anime title>");
+        return;
+      }
+      // A best-effort lookup, never a gate: AniList timing out, having no
+      // match, or erroring all collapse to the same outcome as never
+      // asking - a card with the typed title and no metadata.
+      const match = await searchAnime(title).catch(() => null);
+      await host.sendCard({
+        ownerDid: host.selfDid(),
+        title: match?.title ?? title,
+        anilistId: match?.id ?? null,
+        coverImageUrl: match?.coverImageUrl ?? null,
+        episodeCount: match?.episodeCount ?? null,
+      });
+    },
+  },
+});

--- a/frontend/plugins/anime-party/logic.test.ts
+++ b/frontend/plugins/anime-party/logic.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it } from "vitest";
+import { initialState, reduce, type AnimePartyState } from "./logic";
+
+const HOST = "did:host";
+const HOST_NAME = "Host";
+const ALICE = "did:alice";
+const BOB = "did:bob";
+
+function newParty(): AnimePartyState {
+  return initialState({ ownerDid: HOST, title: "Cowboy Bebop", episodeCount: 26 });
+}
+
+function ctx(senderDid: string, senderName: string, opts?: { ephemeral?: boolean }) {
+  return {
+    senderDid,
+    senderName,
+    updateId: `${senderDid}-${Math.random()}`,
+    lamport: 1,
+    ephemeral: opts?.ephemeral ?? false,
+  };
+}
+
+function tick(overrides: Partial<Record<string, unknown>> = {}) {
+  return { paused: false, position: 10, atMs: 1_000, rate: 1, seq: 1, ...overrides };
+}
+
+describe("initialState", () => {
+  it("seeds the owner as the sole member and starts paused, open, at episode 1", () => {
+    const party = newParty();
+    expect(party.ownerDid).toBe(HOST);
+    expect(party.episode).toBe(1);
+    expect(party.paused).toBe(true);
+    expect(party.closed).toBe(false);
+    expect([...party.members.entries()]).toEqual([[HOST, "Host"]]);
+  });
+
+  it("is born closed when the card carries no owner - a forged card, not a hostless party", () => {
+    const party = initialState({ title: "no owner" });
+    expect(party.closed).toBe(true);
+    expect(party.members.size).toBe(0);
+  });
+
+  it("falls back to a plain title and drops a cover image off the AniList host", () => {
+    const party = initialState({
+      title: 123,
+      coverImageUrl: "https://evil.example/cover.jpg",
+    });
+    expect(party.title).toBe("Untitled anime");
+    expect(party.coverImageUrl).toBeNull();
+  });
+
+  it("accepts a cover image from AniList's own CDN", () => {
+    const party = initialState({
+      ownerDid: HOST,
+      coverImageUrl: "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/1.jpg",
+    });
+    expect(party.coverImageUrl).toBe(
+      "https://s4.anilist.co/file/anilistcdn/media/anime/cover/medium/1.jpg"
+    );
+  });
+});
+
+describe("join / leave", () => {
+  it("adds a new member under their sender name", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    expect([...next.members.keys()]).toEqual([HOST, ALICE]);
+  });
+
+  it("is a no-op for someone already a member", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    const again = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    expect(again).toBe(party);
+  });
+
+  it("removes a member who leaves", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    const next = reduce(party, { data: { action: "leave" } }, ctx(ALICE, "Alice"));
+    expect(next.members.has(ALICE)).toBe(false);
+  });
+
+  it("refuses to let the owner leave through the leave action", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "leave" } }, ctx(HOST, HOST_NAME));
+    expect(next).toBe(party);
+    expect(next.members.has(HOST)).toBe(true);
+  });
+
+  it("is a no-op for someone who was never a member", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "leave" } }, ctx(ALICE, "Alice"));
+    expect(next).toBe(party);
+  });
+});
+
+describe("select-episode", () => {
+  it("lets the owner jump to an episode within the known count, resetting playback", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "select-episode", episode: 5 } }, ctx(HOST, HOST_NAME));
+    expect(next.episode).toBe(5);
+    expect(next.paused).toBe(true);
+    expect(next.lastTick).toBeNull();
+  });
+
+  it("refuses a non-owner's episode selection", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "select-episode", episode: 5 } }, ctx(ALICE, "Alice"));
+    expect(next).toBe(party);
+  });
+
+  it("refuses an episode past the known episode count", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "select-episode", episode: 27 } }, ctx(HOST, HOST_NAME));
+    expect(next).toBe(party);
+  });
+
+  it("refuses a non-integer or non-positive episode", () => {
+    const party = newParty();
+    expect(reduce(party, { data: { action: "select-episode", episode: 0 } }, ctx(HOST, HOST_NAME))).toBe(party);
+    expect(reduce(party, { data: { action: "select-episode", episode: 1.5 } }, ctx(HOST, HOST_NAME))).toBe(party);
+  });
+
+  it("clears a stale heartbeat so followers do not see the old episode's position", () => {
+    let party = newParty();
+    party = reduce(
+      party,
+      { data: { action: "tick", tick: tick() } },
+      ctx(HOST, HOST_NAME, { ephemeral: true })
+    );
+    expect(party.lastTick).not.toBeNull();
+    const next = reduce(party, { data: { action: "select-episode", episode: 2 } }, ctx(HOST, HOST_NAME));
+    expect(next.lastTick).toBeNull();
+  });
+});
+
+describe("pause / resume", () => {
+  it("the owner pauses a playing party", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "play" } }, ctx(HOST, HOST_NAME));
+    expect(party.paused).toBe(false);
+    const next = reduce(party, { data: { action: "pause" } }, ctx(HOST, HOST_NAME));
+    expect(next.paused).toBe(true);
+  });
+
+  it("resume is a no-op when already playing, and vice versa", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "play" } }, ctx(HOST, HOST_NAME));
+    const again = reduce(party, { data: { action: "play" } }, ctx(HOST, HOST_NAME));
+    expect(again).toBe(party);
+    const paused = reduce(party, { data: { action: "pause" } }, ctx(HOST, HOST_NAME));
+    const againPaused = reduce(paused, { data: { action: "pause" } }, ctx(HOST, HOST_NAME));
+    expect(againPaused).toBe(paused);
+  });
+
+  it("refuses play/pause from anyone but the owner", () => {
+    const party = newParty();
+    expect(reduce(party, { data: { action: "play" } }, ctx(ALICE, "Alice"))).toBe(party);
+    expect(reduce(party, { data: { action: "pause" } }, ctx(ALICE, "Alice"))).toBe(party);
+  });
+});
+
+describe("close and host departure", () => {
+  it("only the owner can close the party", () => {
+    const party = newParty();
+    expect(reduce(party, { data: { action: "close" } }, ctx(ALICE, "Alice"))).toBe(party);
+    const next = reduce(party, { data: { action: "close" } }, ctx(HOST, HOST_NAME));
+    expect(next.closed).toBe(true);
+    expect(next.paused).toBe(true);
+  });
+
+  it("every action is a no-op once closed, including join", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "close" } }, ctx(HOST, HOST_NAME));
+    const next = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    expect(next).toBe(party);
+  });
+
+  it("closes on host-left, but only from the longest-standing non-owner member", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    party = reduce(party, { data: { action: "join" } }, ctx(BOB, "Bob"));
+    // Bob is not the designated observer (Alice joined first) - his attempt
+    // must be rejected even though he is a real member.
+    const rejected = reduce(party, { data: { action: "host-left" } }, ctx(BOB, "Bob"));
+    expect(rejected).toBe(party);
+    const accepted = reduce(party, { data: { action: "host-left" } }, ctx(ALICE, "Alice"));
+    expect(accepted.closed).toBe(true);
+    expect(accepted.paused).toBe(true);
+  });
+
+  it("refuses host-left from a non-member", () => {
+    const party = newParty();
+    const next = reduce(party, { data: { action: "host-left" } }, ctx(ALICE, "Alice"));
+    expect(next).toBe(party);
+  });
+});
+
+describe("late-joiner sync round trip", () => {
+  it("records a member's resync request", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    const next = reduce(
+      party,
+      { data: { action: "resync-request", requestId: "request-alice-1" } },
+      ctx(ALICE, "Alice")
+    );
+    expect(next.syncRequest).toEqual({ id: "request-alice-1", requesterDid: ALICE });
+  });
+
+  it("refuses a resync request from a non-member, and a malformed request id", () => {
+    const party = newParty();
+    expect(
+      reduce(party, { data: { action: "resync-request", requestId: "request-alice-1" } }, ctx(ALICE, "Alice"))
+    ).toBe(party);
+    const joined = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    expect(
+      reduce(joined, { data: { action: "resync-request", requestId: "short" } }, ctx(ALICE, "Alice"))
+    ).toBe(joined);
+  });
+
+  it("the owner's response targets the requester and seeds lastTick, without a round trip per frame", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    party = reduce(
+      party,
+      { data: { action: "resync-request", requestId: "request-alice-1" } },
+      ctx(ALICE, "Alice")
+    );
+    const responseTick = tick({ position: 42, atMs: 5_000 });
+    const next = reduce(
+      party,
+      {
+        data: {
+          action: "resync-response",
+          targetDid: ALICE,
+          requestId: "request-alice-1",
+          tick: responseTick,
+        },
+      },
+      ctx(HOST, HOST_NAME)
+    );
+    expect(next.syncResponse).toEqual({
+      id: "request-alice-1",
+      targetDid: ALICE,
+      tick: responseTick,
+    });
+    // The request is cleared once answered - nothing keeps re-triggering it.
+    expect(next.syncRequest).toBeUndefined();
+    expect(next.lastTick).toEqual(responseTick);
+  });
+
+  it("refuses a resync response from anyone but the owner", () => {
+    let party = newParty();
+    party = reduce(party, { data: { action: "join" } }, ctx(ALICE, "Alice"));
+    const next = reduce(
+      party,
+      {
+        data: {
+          action: "resync-response",
+          targetDid: ALICE,
+          requestId: "x",
+          tick: tick(),
+        },
+      },
+      ctx(BOB, "Bob")
+    );
+    expect(next).toBe(party);
+  });
+});
+
+describe("ephemeral tick", () => {
+  it("folds a valid tick from the owner into lastTick without touching persisted fields", () => {
+    const party = newParty();
+    const next = reduce(
+      party,
+      { data: { action: "tick", tick: tick({ position: 12.5, seq: 1 }) } },
+      ctx(HOST, HOST_NAME, { ephemeral: true })
+    );
+    expect(next.lastTick).toEqual(tick({ position: 12.5, seq: 1 }));
+    expect(next.paused).toBe(party.paused);
+  });
+
+  it("refuses a tick from anyone but the owner", () => {
+    const party = newParty();
+    const next = reduce(
+      party,
+      { data: { action: "tick", tick: tick() } },
+      ctx(ALICE, "Alice", { ephemeral: true })
+    );
+    expect(next).toBe(party);
+  });
+
+  it("refuses a malformed tick", () => {
+    const party = newParty();
+    const malformed = [
+      { ...tick(), position: -1 },
+      { ...tick(), rate: 0 },
+      { ...tick(), rate: 5 },
+      { ...tick(), seq: 1.5 },
+      { ...tick(), paused: "no" },
+      null,
+      "not an object",
+    ];
+    for (const bad of malformed) {
+      const next = reduce(
+        party,
+        { data: { action: "tick", tick: bad } },
+        ctx(HOST, HOST_NAME, { ephemeral: true })
+      );
+      expect(next).toBe(party);
+    }
+  });
+
+  it("drops a reordered (stale) tick so the shown position never rolls backwards", () => {
+    let party = newParty();
+    party = reduce(
+      party,
+      { data: { action: "tick", tick: tick({ seq: 5, position: 50 }) } },
+      ctx(HOST, HOST_NAME, { ephemeral: true })
+    );
+    const stale = reduce(
+      party,
+      { data: { action: "tick", tick: tick({ seq: 3, position: 10 }) } },
+      ctx(HOST, HOST_NAME, { ephemeral: true })
+    );
+    expect(stale).toBe(party);
+    expect(stale.lastTick?.position).toBe(50);
+  });
+
+  it("stays well under the 4 KB ephemeral cap even packed alongside a cardId and pluginId", () => {
+    const envelope = {
+      pluginId: "anime-party",
+      cardId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+      data: { action: "tick", tick: tick({ position: 12345.678, seq: 999_999 }) },
+    };
+    expect(JSON.stringify(envelope).length).toBeLessThan(4096);
+  });
+});

--- a/frontend/plugins/anime-party/logic.ts
+++ b/frontend/plugins/anime-party/logic.ts
@@ -1,0 +1,190 @@
+/**
+ * Pure state and reducer for one anime watch party, separated from Svelte
+ * so tests exercise the real fold.
+ *
+ * Durable card state carries what the party's history needs to survive a
+ * reload: who owns it, what is selected, whether it is paused, who is in
+ * it. It deliberately does NOT carry a live position - a bare position
+ * ages the instant it is written (see the ecosystem's own watch-together
+ * plugin, whose flat `position: number` cannot stay correct). Position
+ * only ever travels as a `WatchTick` - a timestamp and a rate, never a
+ * bare number - either folded live as an EPHEMERAL update (the routine
+ * heartbeat) or carried once inside a `resync-response` (the late-joiner
+ * round trip). `$lib/plugins/watch` owns what a client DOES with a tick;
+ * this module only validates the shape peers put on the wire.
+ */
+import type { UpdateCtx } from "$lib/plugins/api";
+import type { WatchTick } from "$lib/plugins/watch";
+import { ANILIST_COVER_HOST_RE } from "./anilist";
+
+export interface AnimePartyState {
+  ownerDid: string;
+  title: string;
+  anilistId: number | null;
+  coverImageUrl: string | null;
+  episode: number;
+  episodeCount: number | null;
+  paused: boolean;
+  closed: boolean;
+  /** did -> display name. Insertion order is fold order, so every client
+   *  agrees on who the longest-standing non-owner member is (the one
+   *  allowed to declare the host gone - see `reduce`'s "host-left"). */
+  members: Map<string, string>;
+  syncRequest?: { id: string; requesterDid: string };
+  syncResponse?: { id: string; targetDid: string; tick: WatchTick };
+  /** The owner's most recent tick. EPHEMERAL-folded only: never persisted,
+   *  never replayed, so a cold load starts with this null until the owner
+   *  sends the next heartbeat - exactly like a viewer who was never sent
+   *  one of ping's samples. */
+  lastTick: WatchTick | null;
+}
+
+const MAX_TITLE_LEN = 200;
+
+function clampTitle(value: unknown): string {
+  if (typeof value !== "string") return "Untitled anime";
+  const trimmed = value.trim().slice(0, MAX_TITLE_LEN);
+  return trimmed || "Untitled anime";
+}
+
+function validCoverUrl(value: unknown): string | null {
+  return typeof value === "string" && ANILIST_COVER_HOST_RE.test(value) ? value : null;
+}
+
+function validEpisodeCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function validAnilistId(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+/** Structural check on a peer-supplied tick. `rate` is capped at 4x: the
+ *  control law only ever asks for a small catch-up nudge, so anything past
+ *  that is a forged or nonsensical value, not a real playback rate. */
+function validTick(value: unknown): WatchTick | null {
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.paused !== "boolean") return null;
+  if (typeof v.position !== "number" || !Number.isFinite(v.position) || v.position < 0)
+    return null;
+  if (typeof v.atMs !== "number" || !Number.isFinite(v.atMs) || v.atMs <= 0) return null;
+  if (typeof v.rate !== "number" || !Number.isFinite(v.rate) || v.rate <= 0 || v.rate > 4)
+    return null;
+  if (typeof v.seq !== "number" || !Number.isInteger(v.seq) || v.seq < 0) return null;
+  return { paused: v.paused, position: v.position, atMs: v.atMs, rate: v.rate, seq: v.seq };
+}
+
+export function initialState(cardData: unknown): AnimePartyState {
+  const data = cardData as Record<string, unknown> | null | undefined;
+  // Peer-supplied and possibly forged (any room member can call
+  // host.sendCard): an absent or empty ownerDid is not a party with no
+  // host, it is a party nobody can be shown to own, so it is born closed -
+  // the reducer's first line then turns every action into a no-op rather
+  // than every case having to remember to check.
+  const ownerDid =
+    typeof data?.ownerDid === "string" && data.ownerDid !== "" ? data.ownerDid : "";
+  return {
+    ownerDid,
+    title: clampTitle(data?.title),
+    anilistId: validAnilistId(data?.anilistId),
+    coverImageUrl: validCoverUrl(data?.coverImageUrl),
+    episode: 1,
+    episodeCount: validEpisodeCount(data?.episodeCount),
+    paused: true,
+    closed: ownerDid === "",
+    members: new Map(ownerDid ? [[ownerDid, "Host"]] : []),
+    lastTick: null,
+  };
+}
+
+export function reduce(
+  state: unknown,
+  update: { data: unknown },
+  ctx: UpdateCtx
+): AnimePartyState {
+  const party = state as AnimePartyState;
+  const data = update.data as Record<string, unknown>;
+  if (typeof data !== "object" || data === null) return party;
+  if (party.closed) return party;
+
+  if (ctx.ephemeral) {
+    if (data.action !== "tick" || ctx.senderDid !== party.ownerDid) return party;
+    const tick = validTick(data.tick);
+    // seq guards against network reordering: ephemeral updates are live-only
+    // and unordered by design, so without this an out-of-order heartbeat
+    // could roll the shown position backwards.
+    if (!tick || (party.lastTick && tick.seq <= party.lastTick.seq)) return party;
+    return { ...party, lastTick: tick };
+  }
+
+  switch (data.action) {
+    case "join": {
+      if (party.members.has(ctx.senderDid)) return party;
+      const members = new Map(party.members);
+      members.set(ctx.senderDid, ctx.senderName);
+      return { ...party, members };
+    }
+    case "leave": {
+      if (!party.members.has(ctx.senderDid) || ctx.senderDid === party.ownerDid) return party;
+      const members = new Map(party.members);
+      members.delete(ctx.senderDid);
+      return { ...party, members };
+    }
+    case "close":
+      return ctx.senderDid !== party.ownerDid ? party : { ...party, closed: true, paused: true };
+    // Fired by whichever non-owner member observed the host's grace window
+    // elapse (see host-departure.ts). Every member may attempt it; only the
+    // longest-standing non-owner member's attempt is honoured, so the
+    // outcome is the same on every client regardless of who is still
+    // running a timer for it.
+    case "host-left": {
+      const observers = [...party.members.keys()].filter((did) => did !== party.ownerDid);
+      return observers[0] !== ctx.senderDid
+        ? party
+        : { ...party, closed: true, paused: true };
+    }
+    case "select-episode": {
+      if (ctx.senderDid !== party.ownerDid) return party;
+      const episode = data.episode;
+      if (typeof episode !== "number" || !Number.isInteger(episode) || episode < 1)
+        return party;
+      if (party.episodeCount !== null && episode > party.episodeCount) return party;
+      if (episode === party.episode) return party;
+      // A new episode is a new file for every participant: nothing carries
+      // forward from the last one's playback.
+      return { ...party, episode, paused: true, lastTick: null };
+    }
+    case "play":
+      return ctx.senderDid !== party.ownerDid || !party.paused
+        ? party
+        : { ...party, paused: false };
+    case "pause":
+      return ctx.senderDid !== party.ownerDid || party.paused
+        ? party
+        : { ...party, paused: true };
+    case "resync-request": {
+      if (!party.members.has(ctx.senderDid)) return party;
+      const requestId = data.requestId;
+      if (typeof requestId !== "string" || requestId.length < 8 || requestId.length > 128)
+        return party;
+      return { ...party, syncRequest: { id: requestId, requesterDid: ctx.senderDid } };
+    }
+    case "resync-response": {
+      if (ctx.senderDid !== party.ownerDid) return party;
+      const targetDid = data.targetDid;
+      const requestId = data.requestId;
+      const tick = validTick(data.tick);
+      if (typeof targetDid !== "string" || typeof requestId !== "string" || !tick)
+        return party;
+      return {
+        ...party,
+        syncRequest: party.syncRequest?.id === requestId ? undefined : party.syncRequest,
+        syncResponse: { targetDid, id: requestId, tick },
+        lastTick: tick,
+      };
+    }
+    default:
+      return party;
+  }
+}

--- a/frontend/plugins/anime-party/manifest.ts
+++ b/frontend/plugins/anime-party/manifest.ts
@@ -1,0 +1,15 @@
+import type { PluginManifest } from "$lib/plugins/api";
+
+export const manifest: PluginManifest = {
+  id: "anime-party",
+  name: "Anime Party",
+  description:
+    "Watch an episode together. Everyone opens their own file; the party keeps every player in step.",
+  icon: "lucide:clapperboard",
+  author: "awful.chat",
+  license: "Apache-2.0",
+  version: "1.0.0",
+  repository: "https://github.com/awful-org/awful.chat/tree/main/frontend/plugins/anime-party",
+  apiVersion: 1,
+  commands: [{ name: "anime-party", usage: "/anime-party One Piece" }],
+};

--- a/frontend/plugins/anime-party/playback.test.ts
+++ b/frontend/plugins/anime-party/playback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { assessFile, extensionOf, mediaErrorMessage } from "./playback";
+
+describe("extensionOf", () => {
+  it("lowercases and strips the leading dot", () => {
+    expect(extensionOf("Episode.01.MKV")).toBe("mkv");
+  });
+
+  it("returns empty for a filename with no extension", () => {
+    expect(extensionOf("episode01")).toBe("");
+  });
+});
+
+describe("assessFile", () => {
+  it("verdicts Matroska containers as unplayable, by name", () => {
+    for (const name of ["episode.mkv", "EPISODE.MKV", "ep01.mka", "ep01.mks"]) {
+      const result = assessFile(name);
+      expect(result.verdict).toBe("unplayable");
+      expect(result.reason).toMatch(/matroska/i);
+    }
+  });
+
+  it("flags an HEVC/10-bit-named file as risky, not unplayable - the browser gets the final say", () => {
+    for (const name of ["episode.hevc.mp4", "episode.h265.mp4", "episode.10bit.mp4", "episode.Hi10P.mkv"]) {
+      const result = assessFile(name);
+      expect(result.verdict === "unplayable" || result.verdict === "risky").toBe(true);
+    }
+    // A risky hint on a container that would actually load:
+    const risky = assessFile("episode.hevc.mp4");
+    expect(risky.verdict).toBe("risky");
+    expect(risky.reason).toMatch(/hevc|10-bit/i);
+  });
+
+  it("gives an unremarkable mp4 no verdict at all - let the browser try", () => {
+    const result = assessFile("episode01.mp4");
+    expect(result.verdict).toBe("unknown");
+    expect(result.reason).toBeNull();
+  });
+});
+
+describe("mediaErrorMessage", () => {
+  it("maps every MediaError code to one plain sentence", () => {
+    expect(mediaErrorMessage(1)).toMatch(/aborted/i);
+    expect(mediaErrorMessage(2)).toMatch(/network|file-access/i);
+    expect(mediaErrorMessage(3)).toMatch(/decoding failed/i);
+    expect(mediaErrorMessage(4)).toMatch(/does not support/i);
+  });
+
+  it("falls back to a plain sentence for an unknown or missing code", () => {
+    expect(mediaErrorMessage(99)).toMatch(/unknown reason/i);
+    expect(mediaErrorMessage(null)).toMatch(/unknown reason/i);
+    expect(mediaErrorMessage(undefined)).toMatch(/unknown reason/i);
+  });
+});

--- a/frontend/plugins/anime-party/playback.ts
+++ b/frontend/plugins/anime-party/playback.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure, DOM-free rules for whether a local file is likely to play, and for
+ * turning a native `<video>` decode failure into one honest sentence.
+ *
+ * Deliberately NOT a `canPlayType`/`MediaCapabilities` probe: this module
+ * is imported by `reduce`-adjacent tests that run under vitest's `node`
+ * environment (no DOM, see `frontend/vitest.config.ts`), and a codec's real
+ * fate is only known once the browser actually tries to decode the file
+ * anyway. What is knowable ahead of time, filename alone, is the one
+ * failure that is not a maybe: Chromium and most browsers never play
+ * Matroska at all, container or codec aside.
+ */
+
+export type PlaybackVerdict = "unplayable" | "risky" | "unknown";
+
+export interface FileAssessment {
+  verdict: PlaybackVerdict;
+  /** One plain sentence, or null when there is nothing to warn about yet. */
+  reason: string | null;
+}
+
+/** Matroska family. The dominant anime-release container, and the one
+ *  browsers never play regardless of the codec inside it. */
+const UNPLAYABLE_EXTENSIONS = new Set(["mkv", "mka", "mks"]);
+
+/** Filename hints for encodes that decode unreliably even in a playable
+ *  container (MP4/WebM). A hint, not a verdict - the browser's own attempt
+ *  is the only real answer, so this only ever softens to "risky", never
+ *  blocks a file the way the container check does. */
+const RISKY_NAME_HINTS: RegExp[] = [
+  /\bhevc\b/i,
+  /\bh\.?265\b/i,
+  /\b10.?bit\b/i,
+  /\bhi10p\b/i,
+];
+
+export function extensionOf(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  return dot === -1 ? "" : filename.slice(dot + 1).toLowerCase();
+}
+
+export function assessFile(filename: string): FileAssessment {
+  const ext = extensionOf(filename);
+  if (UNPLAYABLE_EXTENSIONS.has(ext)) {
+    return {
+      verdict: "unplayable",
+      reason: `Browsers cannot play the Matroska (.${ext}) container. Convert this file to .mp4 or .webm, or watch it in a desktop player instead.`,
+    };
+  }
+  if (RISKY_NAME_HINTS.some((re) => re.test(filename))) {
+    return {
+      verdict: "risky",
+      reason:
+        "This file's name suggests HEVC or 10-bit color, which many browsers decode unreliably. It may stutter, show no picture, or fail outright.",
+    };
+  }
+  return { verdict: "unknown", reason: null };
+}
+
+/**
+ * `HTMLMediaElement.error.code` to one plain sentence. Codes are the
+ * standard `MediaError` constants (`MEDIA_ERR_ABORTED` = 1, ... `_SRC_NOT_SUPPORTED` = 4).
+ */
+const MEDIA_ERROR_MESSAGES: Record<number, string> = {
+  1: "Loading this file was aborted.",
+  2: "The file could not be loaded, which usually means a network or file-access problem, not the format.",
+  3: "The file started playing but decoding failed partway through - often an unsupported codec profile inside an otherwise playable container.",
+  4: "This browser does not support this file's format at all.",
+};
+
+export function mediaErrorMessage(code: number | null | undefined): string {
+  if (code == null) return "This file could not be played, for an unknown reason.";
+  return MEDIA_ERROR_MESSAGES[code] ?? "This file could not be played, for an unknown reason.";
+}

--- a/frontend/src/lib/plugins/watch/README.md
+++ b/frontend/src/lib/plugins/watch/README.md
@@ -1,0 +1,111 @@
+# watch: shared sync library for video watch-party plugins
+
+## What this is for
+
+A watch-party plugin does not send video. Every participant opens their
+own local file. This library answers the one hard problem that design
+creates: given a snapshot of where the other person's player is, how do
+you keep your own player in step with theirs, over a network with
+variable delay, without the correction itself being visible or audible.
+
+This module is pure and synchronous. No DOM element, no `setTimeout`, no
+network call lives here. It reads a `WatchTick` and clock samples and
+returns numbers and an action name. The caller — the plugin — owns the
+`<video>` element, the round-trip ping, and the timer loop that calls
+this library on an interval.
+
+## Why a bare `{playing, position}` snapshot cannot hold video in sync
+
+The comparable plugin already in this repo, `waffle-party`, models its
+shared state as `MusicState { playing: boolean; position: number }` — an
+absolute position with no timestamp and no rate. That is fine for a music
+plugin where being a couple of seconds off just means one person's chorus
+lands a beat late. It fails for video.
+
+The reason is that a bare position number starts going stale the instant
+it is written. Every reader applies it at a different wall-clock moment,
+so two clients that receive the exact same update land at two different
+positions, and nothing in the shape ever corrects the gap afterward.
+waffle-party is honest about this in its own README: it does not "promise
+frame-accurate synchronization." For video, a gap of even one or two
+seconds means one participant sees a reaction shot, a joke, or a spoiler
+before the other has seen the frame that causes it.
+
+The fix is to never send a bare position. Send an anchor: a position, the
+sender's wall-clock time when that position was true, and the rate
+playback was running at. A reader with an anchor and its own estimate of
+clock offset can compute "where should playback be right now" at any
+later instant, not just at the instant the update was sent. That anchor
+is `WatchTick`, and computing "where should it be now" from it is
+`projectPosition`.
+
+## The clock problem
+
+`WatchTick.atMs` is a timestamp on the sender's clock, not the reader's.
+Two computers rarely agree on wall-clock time to better than a few
+hundred milliseconds, and skew drifts over a session. Before a
+`WatchTick` is useful, the reader needs an estimate of the offset between
+the two clocks.
+
+`estimateClock` takes NTP-style round-trip samples (`t0` you send, `t1`
+they receive, `t2` they reply, `t3` you receive the reply) and returns
+the classic NTP offset and round-trip-time estimate. It takes the
+**median** across samples, not the mean, because one slow, reordered, or
+NAT-mangled packet skews a mean but cannot move a median as long as it
+stays a minority of the batch. `samples` in the result is the count of
+samples that went in, so a caller can decide not to act on an estimate
+built from only one or two of them.
+
+## The control law
+
+This is Syncplay's three-band controller, copied because it is a decade
+of production tuning against exactly this problem, not because the exact
+numbers are sacred. Source: `syncplay/constants.py`, quoted verbatim in
+the anime feasibility research (finding 10). Every constant below is that
+source, or is derived from a line of that source's own prose — the
+comments in `sync.ts` say which for each one.
+
+| band | Syncplay source | this module |
+| --- | --- | --- |
+| dead band: drift is small, do nothing | `SEEK_THRESHOLD = 1`, kick-in `DEFAULT_SLOWDOWN_KICKIN_THRESHOLD = 1.5` | `rateThresholdMs = 1500` |
+| rate band: drift is medium, nudge the rate | `SLOWDOWN_RATE = 0.95` ahead; 5% change described as inaudible either direction | `slowRate = 0.95`, `fastRate = 1.05` |
+| rate band exit: keep correcting until drift is almost gone | `SLOWDOWN_RESET_THRESHOLD = 0.1` | `maxRateCorrectionMs = 100` |
+| seek band: drift is large, jump | `DEFAULT_REWIND_THRESHOLD = 4` | `seekThresholdMs = 4000` |
+
+Syncplay splits "ahead of the group" and "behind the group" into
+slightly different thresholds (1.5 s vs 1.75 s to start a rate
+correction, 4 s vs 5 s to seek). This module uses one number per band,
+the stricter (smaller) of Syncplay's two, so a correction in either
+direction never waits longer than Syncplay's own most aggressive case.
+
+`fastRate = 1.05` is the one number here that is not a literal Syncplay
+constant name. Syncplay names no symmetric speed-up rate for the behind
+case; its own text describes the general mechanism as "a 5% rate change
+is neither [visible nor audible]." `1.05` mirrors `SLOWDOWN_RATE = 0.95`
+under that same description.
+
+Why rate correction at all, instead of just seeking every time drift is
+non-zero: a seek is a visible jump and an audible pop. A 5% rate change
+is neither. Small, steady drift gets absorbed quietly; only drift too
+large to close quietly gets a seek.
+
+`decideCorrection` also handles the case a pure position controller
+cannot: `local.paused !== tick.paused`. If the two disagree on whether
+playback is running at all, that is corrected first, alone, with
+`"pause"` or `"resume"` — there is no point computing a rate correction
+for a player that is about to stop or start.
+
+## Honest limits
+
+- This is close sync, not frame-accurate sync. The seek band alone is 4
+  seconds wide; two players can legitimately differ by up to that much
+  before either corrects.
+- Every participant needs their own copy of the same release of the same
+  episode. Different cuts, different framerates, or different pre-roll
+  put positions offset by seconds that this library reads as ordinary
+  drift and cannot tell apart from network skew.
+- Clock offset estimation needs several round-trip samples to be
+  trustworthy. `estimateClock` reports `samples` back for exactly this
+  reason: check it before trusting a one-sample estimate.
+- Nothing here checks that two files actually contain the same video.
+  That check, if a plugin wants one, belongs in the plugin, not here.

--- a/frontend/src/lib/plugins/watch/index.ts
+++ b/frontend/src/lib/plugins/watch/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Public entry point for the watch-party sync library. Plugin authors
+ * import from here, never from `./sync` directly.
+ */
+export {
+  estimateClock,
+  projectPosition,
+  decideCorrection,
+  DEFAULT_WATCH_SYNC,
+} from "./sync";
+export type {
+  WatchTick,
+  ClockSample,
+  ClockEstimate,
+  CorrectionAction,
+  Correction,
+  WatchSyncConfig,
+} from "./sync";

--- a/frontend/src/lib/plugins/watch/sync.test.ts
+++ b/frontend/src/lib/plugins/watch/sync.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateClock,
+  projectPosition,
+  decideCorrection,
+  DEFAULT_WATCH_SYNC,
+  type WatchTick,
+  type ClockSample,
+} from "./sync";
+
+describe("estimateClock", () => {
+  it("gives a clean offset and rtt for consistent samples", () => {
+    // Remote clock is exactly 500 ms ahead of local. Every sample has a
+    // 100 ms round trip split evenly: 50 ms out, 50 ms back.
+    const samples: ClockSample[] = [
+      { t0: 1000, t1: 1550, t2: 1560, t3: 1110 },
+      { t0: 2000, t1: 2550, t2: 2560, t3: 2110 },
+      { t0: 3000, t1: 3550, t2: 3560, t3: 3110 },
+    ];
+    const estimate = estimateClock(samples);
+    expect(estimate.offsetMs).toBeCloseTo(500, 5);
+    expect(estimate.rttMs).toBeCloseTo(100, 5);
+    expect(estimate.samples).toBe(3);
+  });
+
+  it("is robust to one outlier sample via the median", () => {
+    const clean: ClockSample[] = [
+      { t0: 1000, t1: 1550, t2: 1560, t3: 1110 },
+      { t0: 2000, t1: 2550, t2: 2560, t3: 2110 },
+      { t0: 3000, t1: 3550, t2: 3560, t3: 3110 },
+      { t0: 4000, t1: 4550, t2: 4560, t3: 4110 },
+    ];
+    // A wildly delayed reply: huge apparent rtt and offset, one bad sample
+    // among five.
+    const outlier: ClockSample = { t0: 5000, t1: 20_000, t2: 20_010, t3: 5110 };
+    const estimate = estimateClock([...clean, outlier]);
+    expect(estimate.offsetMs).toBeCloseTo(500, 5);
+    expect(estimate.rttMs).toBeCloseTo(100, 5);
+    expect(estimate.samples).toBe(5);
+  });
+
+  it("reports zero samples for an empty batch", () => {
+    expect(estimateClock([])).toEqual({ offsetMs: 0, rttMs: 0, samples: 0 });
+  });
+});
+
+describe("projectPosition", () => {
+  it("advances position while playing at normal rate", () => {
+    const tick: WatchTick = { paused: false, position: 10, atMs: 1000, rate: 1, seq: 1 };
+    // 3 seconds later on the remote clock, no offset.
+    expect(projectPosition(tick, 4000, 0)).toBeCloseTo(13, 5);
+  });
+
+  it("does not advance a paused tick regardless of elapsed time", () => {
+    const tick: WatchTick = { paused: true, position: 42, atMs: 1000, rate: 1, seq: 1 };
+    expect(projectPosition(tick, 999_000, 0)).toBe(42);
+  });
+
+  it("advances faster than wall-clock time at a rate above 1", () => {
+    const tick: WatchTick = { paused: false, position: 0, atMs: 0, rate: 2, seq: 1 };
+    // 5 seconds of remote wall-clock time at 2x rate is 10 seconds of media.
+    expect(projectPosition(tick, 5000, 0)).toBeCloseTo(10, 5);
+  });
+
+  it("advances slower than wall-clock time at a rate below 1", () => {
+    const tick: WatchTick = { paused: false, position: 0, atMs: 0, rate: 0.5, seq: 1 };
+    expect(projectPosition(tick, 4000, 0)).toBeCloseTo(2, 5);
+  });
+
+  it("applies clock offset before computing elapsed time", () => {
+    const tick: WatchTick = { paused: false, position: 10, atMs: 1000, rate: 1, seq: 1 };
+    // Local clock reads 2000, but the remote clock is 2000 ms ahead, so the
+    // remote-clock instant is 4000: 3 seconds past atMs.
+    expect(projectPosition(tick, 2000, 2000)).toBeCloseTo(13, 5);
+  });
+});
+
+describe("decideCorrection", () => {
+  const baseTick: WatchTick = { paused: false, position: 100, atMs: 0, rate: 1, seq: 1 };
+
+  it("does nothing when drift is inside the dead band", () => {
+    // Tick projects to 100 at now=0/offset=0. Local is 0.5 s ahead, well
+    // under the 1500 ms rate threshold.
+    const local = { position: 100.5, paused: false, rate: 1 };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("none");
+    expect(result.rate).toBe(1);
+    expect(result.driftMs).toBeCloseTo(500, 5);
+  });
+
+  it("slows down when local is ahead by a rate-band amount", () => {
+    // 2 s ahead: past the 1500 ms rate threshold, under the 4000 ms seek
+    // threshold.
+    const local = { position: 102, paused: false, rate: 1 };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("rate");
+    expect(result.rate).toBe(DEFAULT_WATCH_SYNC.slowRate);
+    expect(result.driftMs).toBeCloseTo(2000, 5);
+  });
+
+  it("speeds up when local is behind by a rate-band amount", () => {
+    const local = { position: 98, paused: false, rate: 1 };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("rate");
+    expect(result.rate).toBe(DEFAULT_WATCH_SYNC.fastRate);
+    expect(result.driftMs).toBeCloseTo(-2000, 5);
+  });
+
+  it("seeks when drift is past the seek band", () => {
+    // 6 s ahead: past the 4000 ms seek threshold.
+    const local = { position: 106, paused: false, rate: 1 };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("seek");
+    expect(result.targetPosition).toBeCloseTo(100, 5);
+    expect(result.rate).toBe(1);
+  });
+
+  it("keeps correcting via rate below the entry threshold once already correcting", () => {
+    // 0.3 s ahead: under the 1500 ms entry threshold, but the player is
+    // already mid-correction (rate !== 1) and drift is still above the
+    // 100 ms exit threshold, so correction continues instead of resetting.
+    const local = { position: 100.3, paused: false, rate: DEFAULT_WATCH_SYNC.slowRate };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("rate");
+    expect(result.rate).toBe(DEFAULT_WATCH_SYNC.slowRate);
+  });
+
+  it("resets to normal rate once a correction closes the drift", () => {
+    // 0.05 s ahead: under the 100 ms exit threshold, even mid-correction.
+    const local = { position: 100.05, paused: false, rate: DEFAULT_WATCH_SYNC.slowRate };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("none");
+    expect(result.rate).toBe(1);
+  });
+
+  it("emits pause when local is playing but the tick is paused", () => {
+    const pausedTick: WatchTick = { paused: true, position: 50, atMs: 0, rate: 1, seq: 2 };
+    const local = { position: 50, paused: false, rate: 1 };
+    const result = decideCorrection(local, pausedTick, 0, 0);
+    expect(result.action).toBe("pause");
+    expect(result.targetPosition).toBe(50);
+  });
+
+  it("emits resume when local is paused but the tick is playing", () => {
+    const local = { position: 100, paused: true, rate: 1 };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("resume");
+  });
+
+  it("prioritizes pause/resume over position drift", () => {
+    // Large positional drift AND a paused disagreement: pause/resume wins,
+    // no seek.
+    const pausedTick: WatchTick = { paused: true, position: 50, atMs: 0, rate: 1, seq: 2 };
+    const local = { position: 200, paused: false, rate: 1 };
+    const result = decideCorrection(local, pausedTick, 0, 0);
+    expect(result.action).toBe("pause");
+  });
+
+  it("handles a tick from the future without a sign error", () => {
+    // The tick's projected position (100) is ahead of local (90): local is
+    // behind by 10 s, well past the seek threshold, and the seek must go
+    // forward to 100, not backward.
+    const local = { position: 90, paused: false, rate: 1 };
+    const result = decideCorrection(local, baseTick, 0, 0);
+    expect(result.action).toBe("seek");
+    expect(result.driftMs).toBeCloseTo(-10_000, 5);
+    expect(result.targetPosition).toBeCloseTo(100, 5);
+  });
+
+  it("respects a custom config override", () => {
+    const local = { position: 101, paused: false, rate: 1 };
+    const strict = decideCorrection(local, baseTick, 0, 0, { rateThresholdMs: 500 });
+    expect(strict.action).toBe("rate");
+    const lenient = decideCorrection(local, baseTick, 0, 0, { rateThresholdMs: 5000 });
+    expect(lenient.action).toBe("none");
+  });
+});

--- a/frontend/src/lib/plugins/watch/sync.ts
+++ b/frontend/src/lib/plugins/watch/sync.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared watch-party clock sync and playback correction logic.
+ *
+ * Every participant plays their own local video file. This module never
+ * touches the file. It only answers two questions, both pure and
+ * synchronous: what time is it on the other person's clock, and given
+ * where they say playback is, how far off is my player and what should
+ * I do about it.
+ *
+ * The control law is Syncplay's three-band controller (small drift: do
+ * nothing; medium drift: nudge the rate; large drift: seek), and the clock
+ * model is NTP-style round-trip offset estimation, the same shape Jellyfin
+ * uses in its TimeSyncController. See README.md for the full explanation
+ * and the exact source lines each constant below comes from.
+ *
+ * No DOM, no timers, no network. The caller owns all of that.
+ */
+
+/** One authoritative playback snapshot. A timestamp and a rate, never a bare position. */
+export type WatchTick = {
+  paused: boolean;
+  /** media position in seconds, true at `atMs` on the sender's clock */
+  position: number;
+  /** sender wall clock, ms since epoch */
+  atMs: number;
+  /** playback rate; 1 is normal */
+  rate: number;
+  /** monotonically increasing per sender, for ordering ticks inside one room */
+  seq: number;
+};
+
+/** One NTP-style round-trip sample: t0 local send, t1 remote receive, t2 remote send, t3 local receive. */
+export type ClockSample = { t0: number; t1: number; t2: number; t3: number };
+
+export type ClockEstimate = { offsetMs: number; rttMs: number; samples: number };
+
+/**
+ * NTP-style offset from round-trip samples, median-filtered.
+ *
+ * `offsetMs` is defined so that `remoteClockMs = localClockMs + offsetMs`:
+ * add it to a local timestamp to get the equivalent point on the remote
+ * clock. Each sample gives an independent offset and round-trip-time
+ * estimate; the median of each is reported rather than the mean, because
+ * one slow or reordered packet skews a mean but cannot move a median as
+ * long as it stays a minority of the batch. `samples` is the number of
+ * samples given, so a caller can refuse to act on an estimate built from
+ * too few of them.
+ */
+export function estimateClock(samples: readonly ClockSample[]): ClockEstimate {
+  if (samples.length === 0) {
+    return { offsetMs: 0, rttMs: 0, samples: 0 };
+  }
+  const offsets: number[] = [];
+  const rtts: number[] = [];
+  for (const s of samples) {
+    offsets.push((s.t1 - s.t0 + (s.t2 - s.t3)) / 2);
+    rtts.push(s.t3 - s.t0 - (s.t2 - s.t1));
+  }
+  return {
+    offsetMs: median(offsets),
+    rttMs: median(rtts),
+    samples: samples.length,
+  };
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Where the tick says playback is, right now, on the local clock.
+ *
+ * A paused tick does not advance: `position` is returned unchanged
+ * regardless of how much time has passed. A playing tick advances by
+ * elapsed sender-clock time times `rate`. `nowMs` is the caller's local
+ * clock; `offsetMs` (from `estimateClock`) converts it to the sender's
+ * clock before computing elapsed time.
+ */
+export function projectPosition(tick: WatchTick, nowMs: number, offsetMs: number): number {
+  if (tick.paused) {
+    return tick.position;
+  }
+  const remoteNowMs = nowMs + offsetMs;
+  const elapsedSeconds = (remoteNowMs - tick.atMs) / 1000;
+  return tick.position + elapsedSeconds * tick.rate;
+}
+
+export type CorrectionAction = "none" | "seek" | "rate" | "pause" | "resume";
+
+export type Correction = {
+  action: CorrectionAction;
+  targetPosition: number;
+  rate: number;
+  driftMs: number;
+};
+
+export type WatchSyncConfig = {
+  seekThresholdMs: number;
+  rateThresholdMs: number;
+  slowRate: number;
+  fastRate: number;
+  maxRateCorrectionMs: number;
+};
+
+/**
+ * Defaults are Syncplay's own control-law constants (`syncplay/constants.py`,
+ * quoted in the research doc, finding 10), applied symmetrically. Syncplay
+ * splits "ahead" and "behind" into slightly different thresholds; this
+ * module uses one number per band, taking the stricter (smaller) of
+ * Syncplay's two bounds so a correction never waits longer than Syncplay's
+ * own most aggressive case in either direction.
+ */
+export const DEFAULT_WATCH_SYNC: WatchSyncConfig = {
+  // DEFAULT_REWIND_THRESHOLD = 4 ("behind by >4 s: seek forward"). Syncplay's
+  // ahead-side bound is DEFAULT_FASTFORWARD_THRESHOLD = 5; 4 s is the
+  // stricter of the two, so it is used for both directions here.
+  seekThresholdMs: 4000,
+  // DEFAULT_SLOWDOWN_KICKIN_THRESHOLD = 1.5 ("beyond 1.5 s ahead, reduce
+  // rate"). Syncplay's behind-side bound is FASTFORWARD_BEHIND_THRESHOLD =
+  // 1.75; 1.5 s is the stricter of the two, so it is used for both
+  // directions here.
+  rateThresholdMs: 1500,
+  // SLOWDOWN_RATE = 0.95 ("ahead: play at 0.95x"). Applied when the local
+  // player is ahead of the tick and needs to slow down to let it catch up.
+  slowRate: 0.95,
+  // Syncplay names no symmetric speed-up rate; its own text describes the
+  // mechanism generally as "a 5% rate change is neither [visible nor
+  // audible]" (finding 10). 1.05 is that same 5% change mirrored for the
+  // behind case, not a separately quoted Syncplay constant.
+  fastRate: 1.05,
+  // SLOWDOWN_RESET_THRESHOLD = 0.1 ("resume 1.0x within 100 ms"). Once a
+  // rate correction is in effect, it holds until drift falls under this
+  // much tighter bound, rather than the wider entry threshold, so playback
+  // does not chatter between "none" and "rate" right at the edge.
+  maxRateCorrectionMs: 100,
+};
+
+/**
+ * The control law. Small drift is corrected by rate, large drift by seek.
+ *
+ * `local.position`/`local.paused` are the caller's own player state, in
+ * the same seconds unit as `WatchTick.position`. `local.rate` is the
+ * rate the player is currently applying; passing back whatever rate a
+ * previous `Correction` set (or 1, if none was ever applied) gives the
+ * hysteresis Syncplay relies on: a correction that has already kicked in
+ * keeps running until drift falls under `maxRateCorrectionMs`, not merely
+ * back under `rateThresholdMs`, so playback does not oscillate at the
+ * boundary.
+ *
+ * `driftMs` is `local.position - projectedPosition`, in milliseconds:
+ * positive means the local player is ahead of the tick, negative means it
+ * is behind. It is always reported, even for `"none"`, `"pause"`, and
+ * `"resume"`, so a caller can log or graph it.
+ *
+ * A paused/playing disagreement between `local.paused` and `tick.paused`
+ * is corrected first and alone, with `"pause"` or `"resume"`, before any
+ * position math: there is no point rate-correcting a player that is about
+ * to be paused or resumed anyway.
+ */
+export function decideCorrection(
+  local: { position: number; paused: boolean; rate: number },
+  tick: WatchTick,
+  nowMs: number,
+  offsetMs: number,
+  cfg: Partial<WatchSyncConfig> = {},
+): Correction {
+  const config: WatchSyncConfig = { ...DEFAULT_WATCH_SYNC, ...cfg };
+  const targetPosition = projectPosition(tick, nowMs, offsetMs);
+  const driftMs = (local.position - targetPosition) * 1000;
+
+  if (local.paused !== tick.paused) {
+    return {
+      action: tick.paused ? "pause" : "resume",
+      targetPosition,
+      rate: 1,
+      driftMs,
+    };
+  }
+
+  const absDriftMs = Math.abs(driftMs);
+
+  if (absDriftMs > config.seekThresholdMs) {
+    return { action: "seek", targetPosition, rate: 1, driftMs };
+  }
+
+  const wasCorrecting = local.rate !== 1;
+  const rateExitThresholdMs = wasCorrecting ? config.maxRateCorrectionMs : config.rateThresholdMs;
+
+  if (absDriftMs > rateExitThresholdMs) {
+    const rate = driftMs > 0 ? config.slowRate : config.fastRate;
+    return { action: "rate", targetPosition, rate, driftMs };
+  }
+
+  return { action: "none", targetPosition, rate: 1, driftMs };
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -41,6 +41,8 @@
     "plugins/poll/**/*.ts",
     "plugins/poll/**/*.svelte",
     "plugins/wheel/**/*.ts",
-    "plugins/wheel/**/*.svelte"
+    "plugins/wheel/**/*.svelte",
+    "plugins/anime-party/**/*.ts",
+    "plugins/anime-party/**/*.svelte"
   ]
 }


### PR DESCRIPTION
## AniDB is dropped, and here is exactly why

`docs/anidb-watch-party.md` is the full record, every blocker with a
primary-source quote and a URL. The short version — five independent blockers,
any one of which is fatal:

1. **No TLS.** `api.anidb.net:9001` answers only over plain HTTP. There is no
   HTTPS listener on 9001 and none on 443. A secure-context PWA cannot
   `fetch()` it: MDN classifies `fetch` as *blockable* mixed content. The irony
   is that AniDB does send `Access-Control-Allow-Origin: *` — CORS was never the
   obstacle, the scheme is.
2. **This repo's proxy refuses it, before AniDB's terms even come up.**
   `relay/pluginproxy.go` validates `pre.Scheme != "https"` and rejects. Routing
   AniDB through it means an operator weakening a deliberate security property
   of the relay for every allowlisted host, not just this one.
3. **A shared client id cannot ship in open source.** Registration is mandatory
   and enforced — an unregistered `client` returns `<error code="302">`. The
   limit is one request per two seconds *per client id*, with permanent bans for
   sustained overrun. A single id shared across every self-hoster is a
   guaranteed ban. Each deployer would have to register their own.
4. **CC-BY-NC-SA 4.0.** No commercial use ever, ShareAlike on redistribution,
   no bulk export, and cover images are `Referer`-hotlink-protected.
5. **No video.** AniDB hosts none and links none, by its own written policy.
   So even a working integration supplies metadata only.

`mylistsummary` is worth naming separately: it transmits the user's **main
AniDB website password in a query string over unencrypted HTTP**. Nothing should
be built on it.

## What ships instead

The user asked for integrated anime watch parties. That is still delivered, on
foundations that are lawful and that actually work in a browser:

- **AniList GraphQL** for metadata — HTTPS, permissive CORS, no API key, real
  anime episode data. Called directly from the participant's browser, the same
  shape as the reference listen-party plugin's use of YouTube oEmbed, so an
  operator configures nothing. A failed lookup falls back to a typed-in title
  and **playback never waits on metadata**.
- **The Syncplay model** for playback — every participant opens their own local
  file and only the position travels. No copyrighted bytes cross the room, which
  is what makes this safe for a self-hoster.

## The shared library, and why it is not a copy of waffle-party

`$lib/plugins/watch` is the reusable piece the request asked about. It
deliberately does not follow the reference plugin, whose `MusicState` is
`{playing, position}` — a snapshot with **no timestamp and no rate**. A receiver
cannot tell how old that is, which is why that plugin's own README declines to
promise frame-accurate sync. For audio nobody notices. For video everybody does.

```ts
type WatchTick = { paused, position, atMs, rate, seq };

estimateClock(samples): ClockEstimate        // NTP-style offset, median-filtered
projectPosition(tick, nowMs, offsetMs)       // where playback should be NOW
decideCorrection(local, tick, ...): Correction
```

`decideCorrection` is Syncplay's two-band control law:

| Drift | Action | Source |
|---|---|---|
| under 1.5 s | none | `DEFAULT_SLOWDOWN_KICKIN_THRESHOLD` |
| 1.5 s to 4 s | nudge rate to 0.95 or 1.05 | `SLOWDOWN_RATE = 0.95` |
| over 4 s | seek | `DEFAULT_REWIND_THRESHOLD = 4` |
| under 100 ms while correcting | back to 1.0 | `SLOWDOWN_RESET_THRESHOLD = 0.1` |

A 5% rate change is inaudible and invisible; a seek is jarring, so its band is
deliberately wide. Every constant names the Syncplay source it came from, and
`fastRate: 1.05` says plainly that Syncplay names no symmetric constant and that
the value is derived.

## Wire budget

| Channel | Payload | Size |
|---|---|---|
| card (16 KB cap) | host, title, AniList id, cover, episode count | under 200 B |
| update (4 KB cap) | join, leave, close, host-left, select-episode, play, pause, resync | a few hundred B |
| ephemeral (4 KB cap) | one `WatchTick`, ~1/s | well under cap, asserted in a test |

A late joiner gets the current position from one `resync-request` /
`resync-response` round trip, then rides the tick. Position updates are
ephemeral, so a room's history does not fill with them.

## What a user will actually hit

- **Everyone needs their own copy of the same release.** A different cut or
  framerate produces an offset the library cannot distinguish from clock drift.
- **Chromium cannot play MKV**, and HEVC and 10-bit are unreliable. The plugin
  detects an unplayable file and says why in one sentence.
- **Subtitles inside a container are not exposed** to the browser. An external
  subtitle file works through `<track>`.
- **Sync is close, not frame-accurate.** The seek band alone is 4 s wide.
- Browser autoplay policy can still require one Play press.

## Verification

| Suite | Result |
|---|---|
| `pnpm test` | 875 passed, 70 files (42 new) |
| `pnpm check` | 5043 files, 0 errors, 0 warnings |
| `pnpm build` | passes |

Committed with `--no-verify`, which is what `.githooks/pre-commit` documents for
adding a new built-in plugin.

## Operator note

Nothing to configure. No `PLUGIN_PROXY_HOSTS`, no key, no relay change. If an
operator tightens the Report-Only CSP into the enforced one, it needs
`connect-src https://graphql.anilist.co` and `img-src https://s4.anilist.co`;
both are documented in `.env.example` and `deploy/README.md`.
