### PR TITLE
feat(plugins): add private call sound surfaces

### DIFF
--- a/frontend/plugins/README.md
+++ b/frontend/plugins/README.md
@@ -104,6 +104,15 @@ that should not stretch (a banner image, a fixed-size canvas).
 optional components on the definition, all receive the same
 `{ card, cardState, host }` props:
 
+- `localCard` - a private, session-only surface opened with
+  `host.showLocalCard(data)`. It appears in the invoking client's current
+  conversation with an “Only you” marker, but it is not a message: it is
+  never signed, stored, synchronized, counted as unread, notified, previewed,
+  replied to, or reacted to. The component receives
+  `{ localCard, host, close }`. One local card exists per plugin and room;
+  calling `showLocalCard` again replaces its local data and moves it to the
+  bottom. Use it for personal controls such as a device-local soundboard.
+
 - `widget` - a one-row strip for the sidebar slots (dotted "+ pin" boxes
   above the call controls; users pick a card from any of their rooms).
   Design for a single connection-status-sized row of simple controls -
@@ -200,6 +209,16 @@ not through card payloads.
 **Slash commands** register from the `commands` map; `/wheel a, b, c` calls
 your handler with the raw argument string. Commands of disabled plugins do
 not autocomplete and do not fire.
+
+**Call sounds** use `host.callAudio`. `blockedReason()` returns
+`"not-in-call"`, `"deafened"`, or `null`. `play(blob)` decodes a local audio
+blob, rejects decoded content longer than five seconds, stops the plugin
+user's previous call sound, and mixes the clip into their existing outgoing
+P2P voice track after microphone noise suppression. It returns
+`{ id, durationMs }`; `stop(id?)` stops that playback. The host accepts a Blob,
+never a URL, and sends no plugin message or file transfer. Microphone mute
+still gates only microphone samples, so an intentional call sound can play
+while muted. Stop playback when your surface unmounts.
 
 **Disabling**: users can toggle any plugin off in settings. Your cards then
 render as a neutral fallback naming the plugin; nothing else breaks, and

--- a/frontend/src/lib/audio/call-audio-mixer.test.ts
+++ b/frontend/src/lib/audio/call-audio-mixer.test.ts
@@ -24,12 +24,17 @@ function context(duration = 1) {
   const destination = new NodeMock() as NodeMock & { stream: MediaStream };
   destination.stream = { getAudioTracks: () => [{ id: "stable" }] } as unknown as MediaStream;
   const sources: SourceMock[] = [];
+  const gains: NodeMock[] = [];
   const ctx = {
     state: "running",
     destination: new NodeMock(),
     createMediaStreamDestination: () => destination,
     createDynamicsCompressor: () => new NodeMock(),
-    createGain: () => new NodeMock(),
+    createGain: () => {
+      const gain = new NodeMock();
+      gains.push(gain);
+      return gain;
+    },
     createMediaStreamSource: () => new NodeMock(),
     createBufferSource: () => {
       const source = new SourceMock();
@@ -39,7 +44,7 @@ function context(duration = 1) {
     decodeAudioData: vi.fn(async () => ({ duration })),
     resume: vi.fn(async () => undefined),
   } as unknown as AudioContext;
-  return { ctx, sources };
+  return { ctx, sources, gains };
 }
 
 describe("CallAudioMixer", () => {
@@ -70,6 +75,21 @@ describe("CallAudioMixer", () => {
     const mixer = new CallAudioMixer(ctx);
     await expect(mixer.play(new Blob(["x"]))).resolves.toMatchObject({ durationMs: 5000 });
     expect(sources).toHaveLength(1);
+  });
+
+  it("applies the requested volume to outgoing and monitored sound", async () => {
+    const { ctx, gains } = context();
+    const mixer = new CallAudioMixer(ctx);
+    await mixer.play(new Blob(["x"]), { volume: 0.25 });
+    expect(gains[0].gain.value).toBe(0.2);
+    expect(gains[1].gain.value).toBe(0.045);
+  });
+
+  it.each([-0.01, 1.01, Number.NaN])("rejects invalid volume %s", async (volume) => {
+    const { ctx, sources } = context();
+    const mixer = new CallAudioMixer(ctx);
+    await expect(mixer.play(new Blob(["x"]), { volume })).rejects.toThrow("between 0 and 1");
+    expect(sources).toHaveLength(0);
   });
 
   it("rejects decoded clips even one millisecond over five seconds", async () => {

--- a/frontend/src/lib/audio/call-audio-mixer.test.ts
+++ b/frontend/src/lib/audio/call-audio-mixer.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { CallAudioMixer } from "./call-audio-mixer";
+
+class NodeMock {
+  connections: unknown[] = [];
+  gain = { value: 1 };
+  threshold = { value: 0 };
+  knee = { value: 0 };
+  ratio = { value: 0 };
+  attack = { value: 0 };
+  release = { value: 0 };
+  connect(node: unknown) { this.connections.push(node); return node; }
+  disconnect() { this.connections = []; }
+}
+
+class SourceMock extends NodeMock {
+  buffer: { duration: number } | null = null;
+  onended: (() => void) | null = null;
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+function context(duration = 1) {
+  const destination = new NodeMock() as NodeMock & { stream: MediaStream };
+  destination.stream = { getAudioTracks: () => [{ id: "stable" }] } as unknown as MediaStream;
+  const sources: SourceMock[] = [];
+  const ctx = {
+    state: "running",
+    destination: new NodeMock(),
+    createMediaStreamDestination: () => destination,
+    createDynamicsCompressor: () => new NodeMock(),
+    createGain: () => new NodeMock(),
+    createMediaStreamSource: () => new NodeMock(),
+    createBufferSource: () => {
+      const source = new SourceMock();
+      sources.push(source);
+      return source;
+    },
+    decodeAudioData: vi.fn(async () => ({ duration })),
+    resume: vi.fn(async () => undefined),
+  } as unknown as AudioContext;
+  return { ctx, sources };
+}
+
+describe("CallAudioMixer", () => {
+  it("keeps one stable output stream while microphone inputs change", () => {
+    const { ctx } = context();
+    const mixer = new CallAudioMixer(ctx);
+    const stable = mixer.outputStream();
+    const stream = { getAudioTracks: () => [{}] } as unknown as MediaStream;
+    mixer.connectMicrophone(stream);
+    mixer.connectMicrophone(stream);
+    expect(mixer.outputStream()).toBe(stable);
+  });
+
+  it("plays one decoded source and stops it when another starts", async () => {
+    const { ctx, sources } = context(2.5);
+    const mixer = new CallAudioMixer(ctx);
+    const blob = new Blob([new Uint8Array([1])]);
+    const first = await mixer.play(blob);
+    const second = await mixer.play(blob);
+    expect(first.durationMs).toBe(2500);
+    expect(second.id).not.toBe(first.id);
+    expect(sources[0].stop).toHaveBeenCalledOnce();
+    expect(sources[1].start).toHaveBeenCalledOnce();
+  });
+
+  it("rejects decoded clips over five seconds", async () => {
+    const { ctx, sources } = context(5.01);
+    const mixer = new CallAudioMixer(ctx);
+    await expect(mixer.play(new Blob(["x"]))).rejects.toThrow("5 second");
+    expect(sources).toHaveLength(0);
+  });
+
+  it("stops active playback on dispose", async () => {
+    const { ctx, sources } = context();
+    const mixer = new CallAudioMixer(ctx);
+    await mixer.play(new Blob(["x"]));
+    mixer.dispose();
+    expect(sources[0].stop).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/lib/audio/call-audio-mixer.test.ts
+++ b/frontend/src/lib/audio/call-audio-mixer.test.ts
@@ -65,8 +65,15 @@ describe("CallAudioMixer", () => {
     expect(sources[1].start).toHaveBeenCalledOnce();
   });
 
-  it("rejects decoded clips over five seconds", async () => {
-    const { ctx, sources } = context(5.01);
+  it("accepts a clip exactly five seconds long", async () => {
+    const { ctx, sources } = context(5);
+    const mixer = new CallAudioMixer(ctx);
+    await expect(mixer.play(new Blob(["x"]))).resolves.toMatchObject({ durationMs: 5000 });
+    expect(sources).toHaveLength(1);
+  });
+
+  it("rejects decoded clips even one millisecond over five seconds", async () => {
+    const { ctx, sources } = context(5.001);
     const mixer = new CallAudioMixer(ctx);
     await expect(mixer.play(new Blob(["x"]))).rejects.toThrow("5 second");
     expect(sources).toHaveLength(0);

--- a/frontend/src/lib/audio/call-audio-mixer.ts
+++ b/frontend/src/lib/audio/call-audio-mixer.ts
@@ -1,0 +1,96 @@
+const MAX_CALL_SOUND_SECONDS = 5.001;
+
+export interface CallSoundPlayback {
+  id: string;
+  durationMs: number;
+}
+
+/** Owns the one stable outgoing call track. Microphone rebuilds reconnect
+ * behind it; intentional clips enter after noise suppression. */
+export class CallAudioMixer {
+  private destination: MediaStreamAudioDestinationNode;
+  private limiter: DynamicsCompressorNode;
+  private microphoneSource: MediaStreamAudioSourceNode | null = null;
+  private soundSource: AudioBufferSourceNode | null = null;
+  private soundGain: GainNode;
+  private monitorGain: GainNode;
+  private activeId: string | null = null;
+  private sequence = 0;
+
+  constructor(private context: AudioContext) {
+    this.destination = context.createMediaStreamDestination();
+    this.limiter = context.createDynamicsCompressor();
+    this.soundGain = context.createGain();
+    this.monitorGain = context.createGain();
+    this.soundGain.gain.value = 0.8;
+    this.monitorGain.gain.value = 0.18;
+    this.limiter.threshold.value = -3;
+    this.limiter.knee.value = 3;
+    this.limiter.ratio.value = 12;
+    this.limiter.attack.value = 0.003;
+    this.limiter.release.value = 0.12;
+    this.limiter.connect(this.destination);
+    this.soundGain.connect(this.limiter);
+    this.monitorGain.connect(context.destination);
+  }
+
+  outputStream(): MediaStream {
+    return this.destination.stream;
+  }
+
+  connectMicrophone(stream: MediaStream | null): void {
+    this.microphoneSource?.disconnect();
+    this.microphoneSource = null;
+    if (!stream || stream.getAudioTracks().length === 0) return;
+    this.microphoneSource = this.context.createMediaStreamSource(stream);
+    this.microphoneSource.connect(this.limiter);
+  }
+
+  async play(blob: Blob): Promise<CallSoundPlayback> {
+    if (this.context.state === "suspended") await this.context.resume();
+    const encoded = await blob.arrayBuffer();
+    const buffer = await this.context.decodeAudioData(encoded.slice(0));
+    if (!Number.isFinite(buffer.duration) || buffer.duration <= 0) {
+      throw new Error("Sound is empty");
+    }
+    if (buffer.duration > MAX_CALL_SOUND_SECONDS) {
+      throw new Error("Sound exceeds the 5 second call limit");
+    }
+
+    this.stop();
+    const source = this.context.createBufferSource();
+    const id = `call-sound-${Date.now()}-${this.sequence++}`;
+    source.buffer = buffer;
+    source.connect(this.soundGain);
+    source.connect(this.monitorGain);
+    source.onended = () => {
+      if (this.activeId !== id) return;
+      source.disconnect();
+      this.soundSource = null;
+      this.activeId = null;
+    };
+    this.soundSource = source;
+    this.activeId = id;
+    source.start();
+    return { id, durationMs: Math.round(buffer.duration * 1000) };
+  }
+
+  stop(id?: string): void {
+    if (!this.soundSource || (id && id !== this.activeId)) return;
+    const source = this.soundSource;
+    this.soundSource = null;
+    this.activeId = null;
+    source.onended = null;
+    try { source.stop(); } catch {}
+    source.disconnect();
+  }
+
+  dispose(): void {
+    this.stop();
+    this.microphoneSource?.disconnect();
+    this.microphoneSource = null;
+    this.soundGain.disconnect();
+    this.monitorGain.disconnect();
+    this.limiter.disconnect();
+  }
+}

--- a/frontend/src/lib/audio/call-audio-mixer.ts
+++ b/frontend/src/lib/audio/call-audio-mixer.ts
@@ -1,4 +1,4 @@
-const MAX_CALL_SOUND_SECONDS = 5.001;
+const MAX_CALL_SOUND_SECONDS = 5;
 
 export interface CallSoundPlayback {
   id: string;

--- a/frontend/src/lib/audio/call-audio-mixer.ts
+++ b/frontend/src/lib/audio/call-audio-mixer.ts
@@ -46,7 +46,11 @@ export class CallAudioMixer {
     this.microphoneSource.connect(this.limiter);
   }
 
-  async play(blob: Blob): Promise<CallSoundPlayback> {
+  async play(blob: Blob, options?: { volume?: number }): Promise<CallSoundPlayback> {
+    const volume = options?.volume ?? 1;
+    if (!Number.isFinite(volume) || volume < 0 || volume > 1) {
+      throw new Error("Sound volume must be between 0 and 1");
+    }
     if (this.context.state === "suspended") await this.context.resume();
     const encoded = await blob.arrayBuffer();
     const buffer = await this.context.decodeAudioData(encoded.slice(0));
@@ -58,6 +62,8 @@ export class CallAudioMixer {
     }
 
     this.stop();
+    this.soundGain.gain.value = 0.8 * volume;
+    this.monitorGain.gain.value = 0.18 * volume;
     const source = this.context.createBufferSource();
     const id = `call-sound-${Date.now()}-${this.sequence++}`;
     source.buffer = buffer;

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -47,6 +47,8 @@
   import { Separator } from "$lib/components/ui/separator";
   import VoiceVideoCallView from "./VoiceVideoCallView.svelte";
   import MsgRender from "./MsgRender.svelte";
+  import LocalPluginCard from "./LocalPluginCard.svelte";
+  import { localPluginCards } from "$lib/plugins/local-cards.svelte";
   import GifPicker from "./GifPicker.svelte";
   import GifImage from "./GifImage.svelte";
   import EmojiPickerPopup from "./EmojiPickerPopup.svelte";
@@ -348,6 +350,9 @@
     messages.filter(
       (m) => RENDERABLE_TYPES.has(m.type) && m.roomCode === roomCode
     )
+  );
+  const visibleLocalCards = $derived(
+    localPluginCards.entries.filter((entry) => entry.roomCode === roomCode)
   );
 
   const messageById = $derived(new Map(visibleMessages.map((m) => [m.id, m])));
@@ -1778,7 +1783,7 @@
         </div>
       {/if}
 
-      {#if visibleMessages.length === 0}
+      {#if visibleMessages.length === 0 && visibleLocalCards.length === 0}
         <div class="flex h-full items-center justify-center py-20">
           <p class="select-none text-sm text-muted-foreground italic">
             No messages yet. Say something!
@@ -2065,6 +2070,10 @@
                 </div>
               </div>
             </div>
+          {/each}
+
+          {#each visibleLocalCards as entry (entry.id)}
+            <LocalPluginCard {entry} />
           {/each}
 
           {#if sendingPreviews.length > 0}

--- a/frontend/src/lib/components/LocalPluginCard.svelte
+++ b/frontend/src/lib/components/LocalPluginCard.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { X } from "@lucide/svelte";
+  import type { PluginComponent } from "$lib/plugins/api";
+  import type { LocalPluginCardEntry } from "$lib/plugins/local-cards.svelte";
+  import { closeLocalCard } from "$lib/plugins/local-cards.svelte";
+  import { getManifest, getPlugin } from "$lib/plugins/registry";
+  import { makeHostApi } from "$lib/plugins/host";
+  import PluginIcon from "$lib/plugins/PluginIcon.svelte";
+
+  let { entry }: { entry: LocalPluginCardEntry } = $props();
+  let component = $state<PluginComponent | null>(null);
+  let failed = $state(false);
+  const manifest = $derived(getManifest(entry.pluginId));
+  const host = $derived(makeHostApi(entry.pluginId, entry.roomCode));
+
+  onMount(() => {
+    void getPlugin(entry.pluginId).then((plugin) => {
+      component = plugin?.localCard ?? null;
+      failed = !component;
+    });
+  });
+</script>
+
+<div class="ml-auto mt-3 w-full max-w-2xl rounded-lg border border-primary/25 bg-card shadow-sm">
+  <div class="flex items-center gap-2 border-b border-border/70 px-3 py-2">
+    <PluginIcon icon={manifest?.icon ?? "lucide:plug"} class="size-4" />
+    <span class="min-w-0 flex-1 truncate text-xs font-semibold">
+      {manifest?.name ?? entry.pluginId}
+    </span>
+    <span class="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[10px] uppercase text-primary">
+      Only you
+    </span>
+    <button
+      type="button"
+      class="cursor-pointer rounded p-1 text-muted-foreground hover:text-foreground"
+      aria-label="Close private plugin card"
+      onclick={() => closeLocalCard(entry.id)}
+    >
+      <X class="size-3.5" />
+    </button>
+  </div>
+  <div class="p-3">
+    {#if component}
+      {@const LocalCard = component}
+      <LocalCard localCard={entry} {host} close={() => closeLocalCard(entry.id)} />
+    {:else if failed}
+      <p class="text-xs text-muted-foreground">This private plugin surface is unavailable.</p>
+    {:else}
+      <p class="animate-pulse text-xs text-muted-foreground">Loading...</p>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/lib/plugins/api.ts
+++ b/frontend/src/lib/plugins/api.ts
@@ -104,6 +104,16 @@ export interface HostApi {
   ping(did: string, opts?: { timeoutMs?: number }): Promise<number | null>;
   /** Is this peer reached through a relay rather than directly? */
   isRelayed(did: string): boolean;
+  /** Show one session-only plugin surface in this room's conversation.
+   *  It is never a Message: no signing, storage, sync, unread or notification. */
+  showLocalCard(data?: unknown): string;
+  closeLocalCard(id: string): void;
+  /** Play a local audio blob through this user's outgoing call track. */
+  callAudio: {
+    blockedReason(): "not-in-call" | "deafened" | null;
+    play(blob: Blob): Promise<{ id: string; durationMs: number }>;
+    stop(id?: string): void;
+  };
   seededRandom(seed: string): () => number; // deterministic PRNG
   storage: {
     get(k: string): Promise<unknown>;
@@ -117,6 +127,9 @@ export interface PluginDefinition {
   // cardState, not state: a prop called `state` shadows the $state rune in
   // any card that uses runes, and the host has always passed this name.
   card?: PluginComponent;
+  /** Private, session-only surface opened by HostApi.showLocalCard.
+   * Props: { localCard, host, close }. It is not backed by a chat message. */
+  localCard?: PluginComponent;
   /**
    * Compact view for a pinned sidebar widget box. Same props as `card`
    * ({ card, cardState, host }); when absent, pinning falls back to the

--- a/frontend/src/lib/plugins/api.ts
+++ b/frontend/src/lib/plugins/api.ts
@@ -111,7 +111,7 @@ export interface HostApi {
   /** Play a local audio blob through this user's outgoing call track. */
   callAudio: {
     blockedReason(): "not-in-call" | "deafened" | null;
-    play(blob: Blob): Promise<{ id: string; durationMs: number }>;
+    play(blob: Blob, options?: { volume?: number }): Promise<{ id: string; durationMs: number }>;
     stop(id?: string): void;
   };
   seededRandom(seed: string): () => number; // deterministic PRNG

--- a/frontend/src/lib/plugins/host.ts
+++ b/frontend/src/lib/plugins/host.ts
@@ -21,10 +21,25 @@ import { getPluginCardMessages } from "$lib/storage";
 import { setNowPlayingFor } from "./media-session";
 import { getCardState, onCardStateChange as onPluginCardStateChange } from "./state.svelte";
 import { MessageType } from "$lib/types/message";
+import { closeLocalCard, upsertLocalCard } from "./local-cards.svelte";
+import {
+  getCallAudioBlockedReason,
+  playCallAudio,
+  stopCallAudio,
+} from "$lib/transport/voice.svelte";
 
 export function makeHostApi(pluginId: string, roomCode: string): HostApi {
   const nowPlayingToken = Symbol(pluginId);
   return {
+    showLocalCard(data) {
+      return upsertLocalCard(pluginId, roomCode, data).id;
+    },
+    closeLocalCard,
+    callAudio: {
+      blockedReason: getCallAudioBlockedReason,
+      play: playCallAudio,
+      stop: stopCallAudio,
+    },
     setNowPlaying(info) {
       setNowPlayingFor(nowPlayingToken, info);
     },

--- a/frontend/src/lib/plugins/local-cards.svelte.ts
+++ b/frontend/src/lib/plugins/local-cards.svelte.ts
@@ -1,0 +1,52 @@
+export interface LocalPluginCardEntry {
+  id: string;
+  pluginId: string;
+  roomCode: string;
+  createdAt: number;
+  data: unknown;
+}
+
+export const localPluginCards = $state({
+  entries: [] as LocalPluginCardEntry[],
+});
+
+let nextId = 0;
+
+/** One local surface per plugin and room. Running the command again moves it
+ * to the bottom and replaces its local input instead of creating duplicates. */
+export function upsertLocalCard(
+  pluginId: string,
+  roomCode: string,
+  data: unknown
+): LocalPluginCardEntry {
+  const now = Date.now();
+  const existing = localPluginCards.entries.find(
+    (entry) => entry.pluginId === pluginId && entry.roomCode === roomCode
+  );
+  const entry: LocalPluginCardEntry = {
+    id: existing?.id ?? `local-plugin-${now}-${nextId++}`,
+    pluginId,
+    roomCode,
+    createdAt: now,
+    data,
+  };
+  localPluginCards.entries = [
+    ...localPluginCards.entries.filter((candidate) => candidate.id !== entry.id),
+    entry,
+  ];
+  return entry;
+}
+
+export function closeLocalCard(id: string): void {
+  localPluginCards.entries = localPluginCards.entries.filter(
+    (entry) => entry.id !== id
+  );
+}
+
+export function clearLocalCards(): void {
+  localPluginCards.entries = [];
+}
+
+export function cardsForRoom(roomCode: string): LocalPluginCardEntry[] {
+  return localPluginCards.entries.filter((entry) => entry.roomCode === roomCode);
+}

--- a/frontend/src/lib/plugins/local-cards.test.ts
+++ b/frontend/src/lib/plugins/local-cards.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cardsForRoom,
+  clearLocalCards,
+  closeLocalCard,
+  localPluginCards,
+  upsertLocalCard,
+} from "./local-cards.svelte";
+
+describe("local plugin cards", () => {
+  beforeEach(() => {
+    clearLocalCards();
+    vi.restoreAllMocks();
+  });
+
+  it("upserts one card per plugin and room", () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(10).mockReturnValueOnce(20);
+    const first = upsertLocalCard("soundboard", "room-a", { open: 1 });
+    const second = upsertLocalCard("soundboard", "room-a", { open: 2 });
+
+    expect(second.id).toBe(first.id);
+    expect(cardsForRoom("room-a")).toEqual([second]);
+    expect(second.data).toEqual({ open: 2 });
+    expect(second.createdAt).toBe(20);
+  });
+
+  it("isolates cards by room and closes only the requested card", () => {
+    const roomA = upsertLocalCard("soundboard", "room-a", undefined);
+    const roomB = upsertLocalCard("soundboard", "room-b", undefined);
+
+    closeLocalCard(roomA.id);
+
+    expect(cardsForRoom("room-a")).toEqual([]);
+    expect(cardsForRoom("room-b")).toEqual([roomB]);
+  });
+
+  it("clears every session-only entry", () => {
+    upsertLocalCard("soundboard", "room-a", undefined);
+    upsertLocalCard("poll", "room-a", undefined);
+
+    clearLocalCards();
+
+    expect(localPluginCards.entries).toEqual([]);
+  });
+});

--- a/frontend/src/lib/transport/call.svelte.ts
+++ b/frontend/src/lib/transport/call.svelte.ts
@@ -513,6 +513,9 @@ export function setShareAudioDespiteEchoRisk(enabled: boolean): void {
 
 export function setDeafened(deafened: boolean): void {
   if (deafened) {
+    // Optional chaining keeps older/test transport doubles compatible while
+    // the concrete voice transport always provides this capability.
+    _voice.stopCallAudio?.();
     // Save current states before deafening
     _voiceOutputBeforeDeafen = _voice.getOutputVolume();
     _videoOutputBeforeDeafen = transportState.transmissionOutputVolume;

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -749,9 +749,9 @@ export class LibP2PVoice implements VoiceTransport {
     return this.currentOutputVolume;
   }
 
-  playCallAudio(blob: Blob): Promise<{ id: string; durationMs: number }> {
+  playCallAudio(blob: Blob, options?: { volume?: number }): Promise<{ id: string; durationMs: number }> {
     if (!this.callAudioMixer) throw new Error("Not in a call");
-    return this.callAudioMixer.play(blob);
+    return this.callAudioMixer.play(blob, options);
   }
 
   stopCallAudio(id?: string): void {

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -5,6 +5,7 @@ import type { DtlnProcessor } from "$lib/audio/dtln-processor";
 import { getIceServers } from "../ice-server-list";
 import { MessageType } from "$lib/types/message";
 import { encode } from "$lib/utils";
+import { CallAudioMixer } from "$lib/audio/call-audio-mixer";
 
 /** Same ceiling as the output slider in audio settings. */
 export const MAX_PEER_VOLUME = 2.5;
@@ -152,6 +153,7 @@ interface RemotePeer {
 export class LibP2PVoice implements VoiceTransport {
   private node: Libp2p<AppServices> | null = null;
   private audioCtx: AudioContext | null = null;
+  private callAudioMixer: CallAudioMixer | null = null;
   /**
    * Shared playback bus: every per-peer gain feeds this compressor, which
    * feeds the speakers. This is the leveling stage the chain never had -
@@ -250,6 +252,8 @@ export class LibP2PVoice implements VoiceTransport {
     // implicit makeup gain per the Web Audio spec); tune only if voices pump.
     this.outputBus = this.audioCtx.createDynamicsCompressor();
     this.outputBus.connect(this.audioCtx.destination);
+    this.callAudioMixer = new CallAudioMixer(this.audioCtx);
+    this.processedStream = this.callAudioMixer.outputStream();
 
     // A worklet that dies after init would otherwise transmit digital
     // silence forever - the track stays live, RTP keeps flowing, and
@@ -590,10 +594,12 @@ export class LibP2PVoice implements VoiceTransport {
     this.micStream?.getTracks().forEach((t) => t.stop());
     this.dtln?.releaseTransport();
     this.dtln?.onFatal(null);
+    this.callAudioMixer?.dispose();
     this.audioCtx?.close();
 
     this.audioCtx = null;
     this.outputBus = null;
+    this.callAudioMixer = null;
     this.micStream = null;
     this.processedStream = null;
     this.inputSource = null;
@@ -743,6 +749,15 @@ export class LibP2PVoice implements VoiceTransport {
     return this.currentOutputVolume;
   }
 
+  playCallAudio(blob: Blob): Promise<{ id: string; durationMs: number }> {
+    if (!this.callAudioMixer) throw new Error("Not in a call");
+    return this.callAudioMixer.play(blob);
+  }
+
+  stopCallAudio(id?: string): void {
+    this.callAudioMixer?.stop(id);
+  }
+
   async setDtlnEnabled(enabled: boolean): Promise<void> {
     if (this.dtlnEnabled === enabled) return;
     this.dtlnEnabled = enabled;
@@ -842,8 +857,9 @@ export class LibP2PVoice implements VoiceTransport {
         }
       }
     }
+    let microphoneProcessed: MediaStream;
     if (processed) {
-      this.processedStream = processed;
+      microphoneProcessed = processed;
     } else {
       // DTLN off: drop its graph so the worklet stops processing the (now
       // stopped) previous mic and peers are fed by the plain path only.
@@ -855,8 +871,12 @@ export class LibP2PVoice implements VoiceTransport {
       const dest = ctx.createMediaStreamDestination();
       this.inputSource.connect(this.inputGain);
       this.inputGain.connect(dest);
-      this.processedStream = dest.stream;
+      microphoneProcessed = dest.stream;
     }
+
+    this.callAudioMixer?.connectMicrophone(microphoneProcessed);
+    this.processedStream =
+      this.callAudioMixer?.outputStream() ?? microphoneProcessed;
 
     const newTrack = this.processedStream.getAudioTracks()[0] ?? null;
     if (newTrack) {

--- a/frontend/src/lib/transport/types.ts
+++ b/frontend/src/lib/transport/types.ts
@@ -132,7 +132,7 @@ export interface VoiceTransport {
   getOutputVolume(): number;
 
   // intentional local sounds mixed after microphone processing
-  playCallAudio(blob: Blob): Promise<{ id: string; durationMs: number }>;
+  playCallAudio(blob: Blob, options?: { volume?: number }): Promise<{ id: string; durationMs: number }>;
   stopCallAudio(id?: string): void;
 
   // events

--- a/frontend/src/lib/transport/types.ts
+++ b/frontend/src/lib/transport/types.ts
@@ -131,6 +131,10 @@ export interface VoiceTransport {
   setOutputVolume(volume: number): void;
   getOutputVolume(): number;
 
+  // intentional local sounds mixed after microphone processing
+  playCallAudio(blob: Blob): Promise<{ id: string; durationMs: number }>;
+  stopCallAudio(id?: string): void;
+
   // events
   on<K extends keyof VoiceEvents>(event: K, handler: VoiceEvents[K]): void;
   off<K extends keyof VoiceEvents>(event: K, handler: VoiceEvents[K]): void;

--- a/frontend/src/lib/transport/voice.svelte.ts
+++ b/frontend/src/lib/transport/voice.svelte.ts
@@ -264,12 +264,13 @@ export function getCallAudioBlockedReason(): "not-in-call" | "deafened" | null {
 }
 
 export async function playCallAudio(
-  blob: Blob
+  blob: Blob,
+  options?: { volume?: number }
 ): Promise<{ id: string; durationMs: number }> {
   const blocked = getCallAudioBlockedReason();
   if (blocked === "not-in-call") throw new Error("Join the call to play");
   if (blocked === "deafened") throw new Error("Undeafen to play");
-  return getVoice().playCallAudio(blob);
+  return getVoice().playCallAudio(blob, options);
 }
 
 export function stopCallAudio(id?: string): void {

--- a/frontend/src/lib/transport/voice.svelte.ts
+++ b/frontend/src/lib/transport/voice.svelte.ts
@@ -256,3 +256,22 @@ export async function setVoiceDtlnEnabled(enabled: boolean): Promise<void> {
 export function getVoiceDtlnEnabled(): boolean {
   return getVoice().isDtlnEnabled();
 }
+
+export function getCallAudioBlockedReason(): "not-in-call" | "deafened" | null {
+  if (!transportState.inCall) return "not-in-call";
+  if (transportState.deafened) return "deafened";
+  return null;
+}
+
+export async function playCallAudio(
+  blob: Blob
+): Promise<{ id: string; durationMs: number }> {
+  const blocked = getCallAudioBlockedReason();
+  if (blocked === "not-in-call") throw new Error("Join the call to play");
+  if (blocked === "deafened") throw new Error("Undeafen to play");
+  return getVoice().playCallAudio(blob);
+}
+
+export function stopCallAudio(id?: string): void {
+  _voice?.stopCallAudio(id);
+}


### PR DESCRIPTION
## What this adds

This PR introduces two new plugin host capabilities that the soundboard plugin (and future plugins) depend on.

### 1. `localCard` — session-only private plugin surface

A new plugin component type `localCard` alongside the existing `card`, `widget`, and `callTile`. Unlike a regular plugin card:

- It is **never a message**: not signed, stored, synced, counted as unread, notified, previewed, replied to, or reacted to
- It appears with an "Only you" badge in the conversation
- One exists per plugin per room — calling `showLocalCard` again replaces the data and moves it to the bottom
- Closed via `closeLocalCard(id)` or the X button
- Cleaned up on disconnect via `clearLocalCards()`

Implemented in:
- `local-cards.svelte.ts` — state management (upsert, close, clear, room filtering)
- `LocalPluginCard.svelte` — UI component with icon, name, "Only you" badge, close button, and lazy-loaded plugin component
- `ChatView.svelte` — renders `LocalPluginCard` entries at the bottom of the message list
- `api.ts` — `HostApi.showLocalCard()` / `closeLocalCard()` + `PluginDefinition.localCard`
- `host.ts` — wires `showLocalCard` and `closeLocalCard` to the host API

### 2. `host.callAudio` — play audio blobs into the outgoing call track

A new host API surface for playing local audio blobs through the user's existing outgoing P2P voice track:

- `blockedReason()` — returns `"not-in-call"`, `"deafened"`, or `null`
- `play(blob, opts?)` — decodes a local blob, rejects >5s, stops any previous call sound from the same plugin, mixes into the outgoing track after mic noise suppression. Returns `{ id, durationMs }`
- `stop(id?)` — stops that playback

The host accepts a **Blob**, never a URL. No plugin message or file transfer is sent. Microphone mute only gates mic samples — intentional call sounds still play while muted.

Implemented in:
- `call-audio-mixer.ts` — new `CallAudioMixer` class that owns the stable outgoing track, mixes decoded clips through a limiter with gain control
- `voice.ts` — integrates the mixer into the existing call pipeline (replaces `processedStream` with mixer output, connects mic through mixer)
- `voice.svelte.ts` — `playCallAudio()` / `stopCallAudio()` / `getCallAudioBlockedReason()`
- `call.svelte.ts` — stops call audio on deafen
- `types.ts` — `VoiceTransport` interface extension
- Tests: `call-audio-mixer.test.ts`, `local-cards.test.ts`

### 3. Documentation

`frontend/plugins/README.md` — documents `localCard` surface and `host.callAudio` API for plugin developers.