### PR TITLE
Telemetry: a flight recorder, three vantages, and an analysis console

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,4 @@ sfu/
 deploy/
 docs/
 .github/
+dashboard/

--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,41 @@ TURN_SECRET=
 #TURN_TLS_DIR=
 #TURN_TLS_ARGS=--cert=/certs/fullchain.pem --pkey=/certs/privkey.pem
 
+# ── Telemetry (optional, off by default) ─────────────────────────────────────
+
+# The diagnostic collector on the relay. "1" makes POST /telemetry accept a
+# bundle from a peer that signed it with its own device key, staple the relay's
+# own view of that peer, and store it for 7 days. Unset makes the route answer
+# 204, store nothing, and the app hides its Upload button.
+#
+# Turning this on is a real disclosure change: the relay gains that peerId's
+# dial and reservation outcomes, ICE candidate TYPES, transport states,
+# timings, counters and error codes. It never gains message or file content, a
+# did:key, a room code, or an ICE candidate address. See docs/spec.md.
+#TELEMETRY_ENABLED=
+
+# Bearer token for GET /telemetry/list and GET /telemetry/get, which the
+# analysis dashboard reads. Unset makes both answer 404, so a console that is
+# not there is never advertised. Use at least 32 random characters: this token
+# reads every bundle every user uploaded.
+#TELEMETRY_ADMIN_TOKEN=
+
+# Where bundles are stored. Defaults to /app/data/telemetry, inside the relay's
+# own data volume. Point it outside the volume and bundles do not survive a
+# redeploy.
+#TELEMETRY_DIR=
+
+# The SFU's half. "1" answers a client's ms:diag with a live snapshot of the
+# room, and prints one [sfu-telemetry] JSON line per room per 10s sweep to the
+# SFU container log. Unset leaves both inert.
+#SFU_TELEMETRY=
+
+# Floor between one peer's ms:diag requests, in milliseconds. Default 10000.
+# Each request calls getStats() on every transport, producer and consumer that
+# peer holds, one worker round-trip each, so too low a value lets one client
+# make the worker sample continuously.
+#SFU_DIAG_MIN_INTERVAL_MS=
+
 # ── Capacity ─────────────────────────────────────────────────────────────────
 
 # SFU WebRTC media ports. ONE pair: it sets both the range mediasoup allocates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Runs on every PR and on every push to main. main is what Dokploy deploys, so
-# nothing reaches it without these four jobs going green: protect the branch
+# nothing reaches it without these five jobs going green: protect the branch
 # and require them as status checks (Settings > Branches > main).
 name: ci
 
@@ -89,6 +89,37 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npm test
+
+  # The operator console. NOT in the images matrix below: it is not deployed,
+  # so there is no Dockerfile to build. It is gated here because its analysis
+  # engine is the thing that reads a bundle, and a broken engine is worse than
+  # no engine - it names the wrong root cause.
+  dashboard:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: dashboard } }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with: { version: 10 }
+      - uses: actions/setup-node@v7
+        with: { node-version: 24, cache: pnpm, cache-dependency-path: dashboard/pnpm-lock.yaml }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm test
+      - run: pnpm build
+
+      # The dashboard has no runtime-config file at all: it is served from a
+      # developer's own machine and the operator types the relay address in.
+      # The same guard as the frontend's, so a build-time address cannot creep
+      # in later.
+      - name: no build-time env reads
+        run: |
+          if grep -rn --include='*.ts' --include='*.svelte' \
+              'import\.meta\.env\.VITE_\|import\.meta\.env\[' src \
+              | grep -vE ':[0-9]+: *(//|\*|/\*)'; then
+            echo "::error::the dashboard has no runtime configuration - the operator supplies the relay address at run time."
+            exit 1
+          fi
 
   # Every image builds from a clean context. Catches a Dockerfile that only
   # worked because of something lying around on the VPS.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ whose context holds no repository declares no commit.
 | `TURN_TOTAL_QUOTA` / `TURN_USER_QUOTA` | no | concurrent TURN allocations, server-wide and per credential |
 | `PLUGIN_PROXY_HOSTS` | no | hostnames plugins may reach through the relay's `/plugin-proxy` |
 | `PLUGIN_PROXY_SECRETS` | no | `NAME@host=value` list; plugins reference `{{secret:NAME}}`, substituted server-side only for that host |
+| `TELEMETRY_ENABLED` | no | `1` makes the relay accept a diagnostic bundle at `POST /telemetry` and staple its own view of the uploader. Unset answers 204, stores nothing, and the app hides its Upload button |
+| `TELEMETRY_ADMIN_TOKEN` | no | bearer token for `GET /telemetry/list` and `/telemetry/get`, which the [dashboard](dashboard/README.md) reads. Unset makes both answer 404 |
+| `TELEMETRY_DIR` | no | where bundles are stored, default `/app/data/telemetry` inside the relay's data volume |
+| `SFU_TELEMETRY` | no | `1` answers a client's `ms:diag` with a live snapshot and prints one `[sfu-telemetry]` line per room per sweep to the SFU log |
+| `SFU_DIAG_MIN_INTERVAL_MS` | no | floor between one peer's `ms:diag` requests, default 10000 |
 
 Firewall: open 80/443 (web), 3478 tcp+udp (TURN), 5349 tcp+udp (TURN TLS,
 when configured), the SFU media range (`SFU_RTC_MIN_PORT`-`SFU_RTC_MAX_PORT`,
@@ -268,6 +273,46 @@ the URL is resolved once at join.
 
 Each SFU needs its own host, its own `ANNOUNCED_IP` and its own open media
 range.
+
+### Diagnosing a connection bug
+
+Connection, peer and call failures used to be undiagnosable after the fact. The
+detail existed - a 17-variant status union, three counter bags, per-peer WebRTC
+state - and every bit of it was destroyed within ten seconds, or swallowed in an
+empty `catch`.
+
+Each tab now keeps a bounded flight recorder in memory, always on from boot. It
+holds the last 4096 structured events and nothing leaves the tab until you say
+so. To read one:
+
+1. Reproduce the failure. Do not reload: a reload starts a new session.
+2. Open **Settings > Diagnostics** and press **Export bundle**. Do this in every
+   tab that saw the problem - the interesting failures are the asymmetric ones,
+   where A sees B and B never saw A, and one bundle cannot show that.
+3. Optional, for a crash or a wedge you cannot catch live: turn **Keep
+   diagnostics across reloads** on first. Chunks are sealed on disk like every
+   other store, three sessions and 8 MB, and never ride device sync or a backup.
+4. Optional, on your own instance: set `TELEMETRY_ENABLED=1` on the relay, and
+   the user turns **Allow upload to this instance** on. The relay then staples
+   its OWN view of that peer to the bundle - registration outcomes and the real
+   reason a rendezvous stream closed, which the client cannot know. Read
+   `docs/spec.md` "Server Privacy" first: this is a real disclosure change.
+5. Set `SFU_TELEMETRY=1` for the third vantage, and capture the container logs
+   with timestamps: `docker logs -t <sfu>` and `docker logs -t <relay>`.
+
+Then open the operator console and drop the bundles and the logs in:
+
+```sh
+cd dashboard && pnpm install && pnpm dev     # http://localhost:5174
+```
+
+It merges the vantages into one clock-corrected timeline, reconstructs the
+topology over time, and names what failed. See [dashboard/README.md](dashboard/README.md).
+The console is NOT deployed and must never be exposed publicly.
+
+A bundle carries no room code, no `did:key`, no message or file content and no
+ICE candidate address. It does carry full peerIds, which the relay and the SFU
+already have.
 
 ## License
 

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,165 @@
+# awful.chat diagnostics console
+
+An operator console. It reads diagnostic bundles and container logs from a
+broken awful.chat session, reconstructs the topology over time, runs a
+deterministic rule engine, and builds a prompt pack for a model.
+
+It is a separate application from the chat app. It ships no service worker, no
+runtime config and no telemetry of its own. It is not deployed.
+
+## Standing warning
+
+**Never expose this console on the public internet.**
+
+It holds a relay admin token and it renders full peer ids. An SFU log also
+carries room codes in clear, and a room code is a room's only membership
+secret. Run the console on your own machine. Point it at a relay over HTTPS.
+Close the tab when you finish.
+
+The console's own output is safe to share. A bundle carries opaque room refs and
+no `did:key:`, and the prompt pack is built from the capture, never from the raw
+log text.
+
+## Run it
+
+```sh
+cd dashboard
+pnpm install
+pnpm dev            # http://localhost:5174
+```
+
+For a static copy:
+
+```sh
+pnpm build          # writes dist/
+open dist/index.html
+```
+
+Checks:
+
+```sh
+pnpm check          # svelte-check plus tsc
+pnpm test           # vitest, the analysis modules
+```
+
+## Load a capture
+
+Drop files on the Sources view, or use the file picker. The console accepts two
+kinds of file and reports what it did with every one of them.
+
+**A client bundle.** The JSON that the chat app's Settings → Diagnostics pane
+exports, named `awful-diag-<bundleId>.json`. A bundle that a peer uploaded also
+carries the relay's stapled vantage, which is a second point of view on the same
+session.
+
+**A container log.** Three shapes are known:
+
+| file | parser | source |
+|---|---|---|
+| `docker logs -t <sfu>` | sfu container log | `[sfu-telemetry]` json plus the free-form `[sfu]` and `[router]` lines |
+| `docker logs -t <relay>` | relay container log | the `[rv]`, `[relay]`, `[http]` and `[peer]` lines |
+| pasted browser output | browser console | the house `[tag] message` shape |
+
+The console picks a parser from the tags a file carries. The choice is a guess,
+so the Sources view shows it as a select and reports the unmatched line count.
+Change the select if the guess is wrong. An unrecognised line is never dropped:
+it survives as a `raw` event, and the Logs view shows it beside the raw text.
+
+### Docker timestamps
+
+**Use `-t`.** Docker writes a timestamp only when you ask for one:
+
+```sh
+docker logs -t awful-relay > relay.log
+docker logs -t awful-sfu   > sfu.log
+```
+
+Without `-t` a log line has no absolute time. The parser then anchors every line
+relative to the first line it matched, and it adds a warning to the file. Such a
+log still shows an order of events, but it cannot be aligned with a client
+bundle, so every cross-vantage finding from it is unreliable.
+
+## Read a relay
+
+A relay exposes two read routes when the operator sets
+`TELEMETRY_ADMIN_TOKEN`. Give the host and the token to the relay form on the
+Sources view, then press **List bundles** and load the ones you want.
+
+The token stays in memory. It is never written to `localStorage`, never put in a
+URL and never logged. A reload loses it. That cost is deliberate.
+
+A 404 from either route means the operator did not set the token, so the console
+says exactly that. The relay answers 404 rather than 403 on purpose: it must not
+advertise a console that does not exist.
+
+## The views
+
+| view | question it answers |
+|---|---|
+| Sources | What is loaded, and what happened to each file? |
+| Sessions | Which captures exist, and which one do I want? |
+| Findings | What is broken, what does it mean, and what do I change? |
+| Timeline | Every vantage's events in one absolute-time stream, in lanes. |
+| Topology | What did the graph look like at one instant? |
+| Matrix | Do two peers disagree about their link? |
+| Peers | Everything one peer did, from every vantage. |
+| Logs | Did the parser read this log correctly? |
+| AI | The prompt pack, and an optional endpoint to send it to. |
+
+Two conventions carry most of the meaning.
+
+**A link is directed.** A link is what one peer *believed* about another. In
+Topology a two-way link draws two solid arcs, and a one-way link draws one
+dashed arc with a hollow arrowhead plus an ✕ stub from the silent peer. In
+Matrix every cell is one square split on its anti-diagonal: the upper-left half
+is what the row peer believed, the lower-right half is what the column peer
+believed. Agreement makes a flat square. Disagreement makes a hard seam.
+
+**Ignorance is not a failure.** A peer that uploaded no bundle cannot report
+anything. Its half of a Matrix cell is faint and marked `?`, and Topology draws
+no ✕ for it.
+
+## Keys
+
+In the Timeline view:
+
+| key | action |
+|---|---|
+| `j` | next event |
+| `k` | previous event |
+| `f` | next finding evidence |
+
+The cursor drives the scrubber, and the scrubber drives the Topology and Matrix
+views. So `j` walks the graph forward one event at a time.
+
+## Layout
+
+```txt
+src/lib/schema.ts            a mirror of frontend/src/lib/telemetry/schema.ts
+src/lib/analysis/merge.ts    vantages -> captures, clock skew corrected
+src/lib/analysis/topology.ts the graph at one instant
+src/lib/analysis/rules.ts    the rule table: meaning, remedy, ai hint
+src/lib/analysis/findings.ts the engine
+src/lib/analysis/logs.ts     the four log parsers
+src/lib/analysis/prompt.ts   the prompt pack
+src/lib/sources.svelte.ts    the only reactive state in the app
+src/lib/views/*.svelte       nine views, render only
+```
+
+Every module under `analysis/` is pure and has a `.test.ts` sibling. Every rune
+lives in `sources.svelte.ts`. A `.svelte` file renders and nothing else. That
+split is what makes the engine testable without a browser.
+
+`schema.ts` is a byte-for-byte mirror of the frontend copy. A change must land
+in both files, and in `sfu/telemetry.ts` for the SFU snapshot types.
+
+## Fixtures
+
+`src/lib/analysis/fixtures/` holds a real capture: two client bundles with the
+relay's vantage stapled, a real SFU snapshot, and the relay's and the SFU's own
+logs. `e2e.test.ts` runs the whole pipeline over it.
+
+Those fixtures are what keep the engine honest. Every other test builds its own
+input, so it can only prove the engine agrees with itself. Read
+`src/lib/analysis/fixtures/README.md` for how the capture was made, what the one
+substitution in `relay.log` is, and how to regenerate it.

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>awful.chat diagnostics</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "awful-dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@tailwindcss/vite": "^4.2.2",
+    "@tsconfig/svelte": "^5.0.8",
+    "@types/node": "^24.10.1",
+    "svelte": "^5.55.1",
+    "svelte-check": "^4.4.6",
+    "tailwindcss": "^4.2.2",
+    "typescript": "~5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^4.1.10"
+  }
+}

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -1,0 +1,1529 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^6.2.4
+        version: 6.2.4(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.3.3(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@tsconfig/svelte':
+        specifier: ^5.0.8
+        version: 5.0.8
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.13.3
+      svelte:
+        specifier: ^5.55.1
+        version: 5.57.0
+      svelte-check:
+        specifier: ^4.4.6
+        version: 4.7.6(picomatch@4.0.7)(svelte@5.57.0)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.3.3
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    resolution: {integrity: sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    resolution: {integrity: sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    resolution: {integrity: sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    resolution: {integrity: sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    resolution: {integrity: sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    resolution: {integrity: sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    resolution: {integrity: sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    resolution: {integrity: sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    resolution: {integrity: sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    resolution: {integrity: sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    resolution: {integrity: sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    resolution: {integrity: sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    resolution: {integrity: sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    resolution: {integrity: sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    resolution: {integrity: sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    resolution: {integrity: sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    resolution: {integrity: sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    resolution: {integrity: sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    resolution: {integrity: sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    resolution: {integrity: sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    resolution: {integrity: sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    resolution: {integrity: sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    resolution: {integrity: sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    resolution: {integrity: sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@sveltejs/acorn-typescript@1.0.13':
+    resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/load-config@0.2.3':
+    resolution: {integrity: sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==}
+    engines: {node: '>= 18.0.0'}
+
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
+    resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
+      svelte: ^5.0.0
+      vite: ^6.3.0 || ^7.0.0
+
+  '@sveltejs/vite-plugin-svelte@6.2.4':
+    resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
+    engines: {node: ^20.19 || ^22.12 || >=24}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.3.0 || ^7.0.0
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tsconfig/svelte@5.0.8':
+    resolution: {integrity: sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devalue@5.9.2:
+    resolution: {integrity: sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==}
+
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
+  esrap@2.3.6:
+    resolution: {integrity: sha512-yc0OC12UjPqLoc+fe+v5GNs4TOjAigUw3sTikfC+xeBPGUw7gDRz3DtYaqEhxyMVJojcSWJw7jT0QWR+CbuE/A==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  rollup@4.63.1:
+    resolution: {integrity: sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  svelte-check@4.7.6:
+    resolution: {integrity: sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0-next.0
+      typescript: ^5.0.0 || ^6.0.0
+
+  svelte@5.57.0:
+    resolution: {integrity: sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg==}
+    engines: {node: '>=18'}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.6.0': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.6.0
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.63.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.1':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
+    dependencies:
+      acorn: 8.18.0
+
+  '@sveltejs/load-config@0.2.3': {}
+
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      obug: 2.1.4
+      svelte: 5.57.0
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)))(svelte@5.57.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      deepmerge: 4.3.1
+      magic-string: 0.30.21
+      obug: 2.1.4
+      svelte: 5.57.0
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+      vitefu: 1.1.3(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tsconfig/svelte@5.0.8': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  acorn@8.18.0: {}
+
+  aria-query@5.3.1: {}
+
+  assertion-error@2.0.1: {}
+
+  axobject-query@4.1.0: {}
+
+  chai@6.2.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  clsx@2.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  deepmerge@4.3.1: {}
+
+  detect-libc@2.1.2: {}
+
+  devalue@5.9.2: {}
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-module-lexer@2.3.2: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  esm-env@1.2.2: {}
+
+  esrap@2.3.6:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  graceful-fs@4.2.11: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  jiti@2.7.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  locate-character@3.0.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.6.0
+
+  mri@1.2.0: {}
+
+  nanoid@3.3.18: {}
+
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.7: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  readdirp@4.1.2: {}
+
+  rollup@4.63.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.1
+      '@rollup/rollup-android-arm64': 4.63.1
+      '@rollup/rollup-darwin-arm64': 4.63.1
+      '@rollup/rollup-darwin-x64': 4.63.1
+      '@rollup/rollup-freebsd-arm64': 4.63.1
+      '@rollup/rollup-freebsd-x64': 4.63.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.1
+      '@rollup/rollup-linux-arm64-gnu': 4.63.1
+      '@rollup/rollup-linux-arm64-musl': 4.63.1
+      '@rollup/rollup-linux-loong64-gnu': 4.63.1
+      '@rollup/rollup-linux-loong64-musl': 4.63.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.1
+      '@rollup/rollup-linux-ppc64-musl': 4.63.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.1
+      '@rollup/rollup-linux-riscv64-musl': 4.63.1
+      '@rollup/rollup-linux-s390x-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-gnu': 4.63.1
+      '@rollup/rollup-linux-x64-musl': 4.63.1
+      '@rollup/rollup-openbsd-x64': 4.63.1
+      '@rollup/rollup-openharmony-arm64': 4.63.1
+      '@rollup/rollup-win32-arm64-msvc': 4.63.1
+      '@rollup/rollup-win32-ia32-msvc': 4.63.1
+      '@rollup/rollup-win32-x64-gnu': 4.63.1
+      '@rollup/rollup-win32-x64-msvc': 4.63.1
+      fsevents: 2.3.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  svelte-check@4.7.6(picomatch@4.0.7)(svelte@5.57.0)(typescript@5.9.3):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@sveltejs/load-config': 0.2.3
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.7)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.57.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - picomatch
+
+  svelte@5.57.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.6.0
+      '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
+      '@types/estree': 1.0.9
+      acorn: 8.18.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.9.2
+      esm-env: 1.2.2
+      esrap: 2.3.6
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinyrainbow@3.1.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
+
+  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rollup: 4.63.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  vitefu@1.1.3(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  vitest@4.1.11(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  zimmerframe@1.1.4: {}

--- a/dashboard/src/App.svelte
+++ b/dashboard/src/App.svelte
@@ -1,0 +1,113 @@
+<!--
+  The shell: a tab bar over nine views, and a header that always names the
+  selected capture and its finding counts. The header is the answer to "what am
+  I looking at", which a nine-tab console must never make the operator hunt for.
+-->
+<script lang="ts">
+  import type { Component } from "svelte";
+  import {
+    TABS,
+    app,
+    fmtDate,
+    fmtDur,
+    goTo,
+    type Tab,
+  } from "$lib/sources.svelte";
+  import Sources from "$lib/views/Sources.svelte";
+  import Sessions from "$lib/views/Sessions.svelte";
+  import Findings from "$lib/views/Findings.svelte";
+  import Timeline from "$lib/views/Timeline.svelte";
+  import Topology from "$lib/views/Topology.svelte";
+  import Matrix from "$lib/views/Matrix.svelte";
+  import PeerDetail from "$lib/views/PeerDetail.svelte";
+  import Logs from "$lib/views/Logs.svelte";
+  import Ai from "$lib/views/Ai.svelte";
+
+  const VIEWS: Record<Tab, Component> = {
+    sources: Sources,
+    sessions: Sessions,
+    findings: Findings,
+    timeline: Timeline,
+    topology: Topology,
+    matrix: Matrix,
+    peers: PeerDetail,
+    logs: Logs,
+    ai: Ai,
+  };
+
+  const Current = $derived(VIEWS[app.tab]);
+  const capture = $derived(app.capture);
+  const counts = $derived(app.findingCounts);
+</script>
+
+<div class="flex h-screen flex-col overflow-hidden">
+  <header
+    class="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 border-b border-line bg-surface px-3 py-1.5"
+  >
+    <span class="font-mono text-[11px] tracking-widest text-faint uppercase">
+      awful.chat diag
+    </span>
+
+    {#if capture}
+      <span class="font-mono text-[11px] text-dim">
+        {fmtDate(capture.window.from)}
+        <span class="text-faint">+{fmtDur(capture.window.to - capture.window.from)}</span>
+      </span>
+      <span class="font-mono text-[11px] text-faint">
+        {capture.vantages.length} vantage{capture.vantages.length === 1 ? "" : "s"}
+        · {app.peers.length} peers · {capture.timeline.length} events
+      </span>
+
+      <span class="flex items-center gap-1.5">
+        <span class="chip" style="color: var(--color-sev-error)">{counts.block} block</span>
+        <span class="chip" style="color: var(--color-sev-warn)">{counts.warn} warn</span>
+        <span class="chip" style="color: var(--color-sev-info)">{counts.info} info</span>
+      </span>
+
+      {#if app.skewSuspect}
+        <span class="chip" style="color: var(--color-sev-warn)">
+          clock skew {Math.round(capture.maxSkewResidualMs)}ms
+        </span>
+      {/if}
+    {:else}
+      <span class="text-dim">
+        No capture. Load a bundle or a container log in <b class="text-key">Sources</b>.
+      </span>
+    {/if}
+  </header>
+
+  <div
+    class="flex shrink-0 gap-px border-b border-line bg-ink px-2"
+    role="tablist"
+    aria-label="views"
+  >
+    {#each TABS as t (t.id)}
+      <button
+        type="button"
+        role="tab"
+        id="tab-{t.id}"
+        aria-selected={app.tab === t.id}
+        aria-controls="view"
+        class="border-b-2 px-3 py-1.5 font-mono text-[11px] tracking-wide
+               {app.tab === t.id
+          ? 'border-key text-key'
+          : 'border-transparent text-dim hover:text-text'}"
+        onclick={() => goTo(t.id)}
+      >
+        {t.label}
+      </button>
+    {/each}
+  </div>
+
+  <main class="min-h-0 flex-1 overflow-auto">
+    <div
+      id="view"
+      role="tabpanel"
+      aria-labelledby="tab-{app.tab}"
+      tabindex="-1"
+      class="h-full p-3"
+    >
+      <Current />
+    </div>
+  </main>
+</div>

--- a/dashboard/src/app.css
+++ b/dashboard/src/app.css
@@ -1,0 +1,219 @@
+@import "tailwindcss";
+
+/*
+ * The operator console's own small theme.
+ *
+ * It deliberately does not copy the chat app's shadcn token set. This app has
+ * one surface, one density and one colour mode, so a short palette is easier
+ * to audit than a long one. Every colour a view needs lives here, so no view
+ * needs a raw hex value and the two scales below stay consistent.
+ *
+ * Two scales carry all the meaning:
+ *   sev-*  event severity, from `DiagEvent.sev`
+ *   ls-*   link state, from `LinkState` in analysis/topology.ts
+ * A view maps a value to `var(--color-ls-proven)` and never to a literal.
+ *
+ * `static` is load-bearing. A view maps a runtime value to a token NAME, so
+ * Tailwind cannot see `--color-ls-lost` in the source and would prune it from
+ * `:root`. A pruned token paints nothing, which silently hides a link.
+ */
+@theme static {
+  /* Neutrals are tinted toward blue, so the console never looks like raw #000. */
+  --color-ink: oklch(0.145 0.012 264);
+  --color-surface: oklch(0.192 0.013 264);
+  --color-raise: oklch(0.248 0.014 264);
+  --color-line: oklch(0.33 0.014 264);
+  --color-text: oklch(0.94 0.006 264);
+  --color-dim: oklch(0.7 0.012 264);
+  --color-faint: oklch(0.52 0.013 264);
+
+  /* One accent. It marks the active tab and the current selection, nothing else. */
+  --color-key: oklch(0.82 0.16 148);
+
+  --color-sev-debug: oklch(0.56 0.015 264);
+  --color-sev-info: oklch(0.74 0.1 232);
+  --color-sev-warn: oklch(0.82 0.15 80);
+  --color-sev-error: oklch(0.68 0.2 18);
+
+  --color-ls-none: oklch(0.4 0.012 264);
+  --color-ls-dialing: oklch(0.72 0.11 240);
+  --color-ls-dial-failed: oklch(0.58 0.19 22);
+  --color-ls-relayed: oklch(0.81 0.14 82);
+  --color-ls-direct: oklch(0.78 0.1 190);
+  --color-ls-proven: oklch(0.82 0.17 148);
+  --color-ls-lost: oklch(0.73 0.17 46);
+  --color-ls-dropped: oklch(0.63 0.19 6);
+
+  --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+@layer base {
+  html {
+    color-scheme: dark;
+  }
+
+  body {
+    margin: 0;
+    background-color: var(--color-ink);
+    color: var(--color-text);
+    font-family: ui-sans-serif, system-ui, sans-serif;
+    /* 13px, because an operator reads tables, not prose. */
+    font-size: 13px;
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers and identifiers must line up, so all data is mono by default. */
+  table,
+  code,
+  pre,
+  input,
+  select,
+  textarea {
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+
+  /* Plain elements only, so the focus ring must be explicit. */
+  :focus-visible {
+    outline: 2px solid var(--color-key);
+    outline-offset: 1px;
+  }
+
+  ::selection {
+    background-color: color-mix(in oklch, var(--color-key) 35%, transparent);
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: var(--color-ink);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--color-raise);
+    border: 2px solid var(--color-ink);
+    border-radius: 5px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-line);
+  }
+}
+
+/*
+ * Five recurring shapes. They exist so nine views describe a panel, a button,
+ * a field, a table and a chip the same way, and so no view repeats a dozen
+ * utilities per element. Every value below is a token from `@theme`.
+ */
+@layer components {
+  .panel {
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-line);
+    border-radius: 6px;
+    min-width: 0;
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.3rem 0.625rem;
+    border-bottom: 1px solid var(--color-line);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-dim);
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    border: 1px solid var(--color-line);
+    border-radius: 4px;
+    background-color: var(--color-raise);
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    cursor: pointer;
+  }
+
+  .btn:hover:not(:disabled) {
+    border-color: var(--color-key);
+    color: var(--color-key);
+  }
+
+  .btn:disabled {
+    color: var(--color-faint);
+    cursor: not-allowed;
+  }
+
+  .btn-on {
+    border-color: var(--color-key);
+    color: var(--color-key);
+  }
+
+  .field {
+    background-color: var(--color-ink);
+    border: 1px solid var(--color-line);
+    border-radius: 4px;
+    padding: 0.2rem 0.45rem;
+    color: var(--color-text);
+    min-width: 0;
+  }
+
+  .field::placeholder {
+    color: var(--color-faint);
+  }
+
+  .tbl {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .tbl th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: var(--color-surface);
+    border-bottom: 1px solid var(--color-line);
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-faint);
+    white-space: nowrap;
+  }
+
+  .tbl td {
+    padding: 0.15rem 0.5rem;
+    border-bottom: 1px solid color-mix(in oklch, var(--color-line) 40%, transparent);
+    vertical-align: top;
+  }
+
+  .tbl tbody tr:hover {
+    background-color: var(--color-raise);
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0 0.35rem;
+    border: 1px solid currentColor;
+    border-radius: 3px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    line-height: 1.5;
+    white-space: nowrap;
+  }
+}

--- a/dashboard/src/lib/analysis/e2e.test.ts
+++ b/dashboard/src/lib/analysis/e2e.test.ts
@@ -1,0 +1,366 @@
+/**
+ * End-to-end proof, on data the real code produced.
+ *
+ * Every other test in this directory builds its own fixture, so it can only
+ * prove the engine agrees with itself. This one reads a capture from a real
+ * session - two browser profiles, a real relay, a real SFU - and asserts that
+ * the engine names what actually happened, and does NOT name what did not.
+ *
+ * The must-not-fire assertions are the load-bearing half. A console that
+ * invents a relay failure for a healthy relay is worse than no console.
+ *
+ * See `fixtures/README.md` for how the capture was made and what the one
+ * substitution in `relay.log` is.
+ */
+
+import { describe, expect, it } from "vitest";
+import { mergeSources } from "./merge";
+import { foldTopology, primaryObserver, topologyKeyframes } from "./topology";
+import { runFindings } from "./findings";
+import { parseRelayLog, parseSfuTelemetry } from "./logs";
+import { buildPromptPack } from "./prompt";
+import type { ClientBundle, SfuSnapshot } from "../schema";
+
+// Loaded through vite's own glob rather than `node:fs`, so the test needs no
+// node types and runs exactly as the app's own code would read them.
+const JSON_FIXTURES = import.meta.glob("./fixtures/*.json", {
+  eager: true,
+  import: "default",
+}) as Record<string, unknown>;
+const LOG_FIXTURES = import.meta.glob("./fixtures/*.log", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+}) as Record<string, string>;
+
+const clientA = JSON_FIXTURES["./fixtures/client-a-stapled.json"] as ClientBundle;
+const clientB = JSON_FIXTURES["./fixtures/client-b-stapled.json"] as ClientBundle;
+const sfuSnapshot = JSON_FIXTURES["./fixtures/sfu-snapshot.json"] as SfuSnapshot;
+const relayLogText = LOG_FIXTURES["./fixtures/relay.log"];
+const sfuLogText = LOG_FIXTURES["./fixtures/sfu-telemetry.log"];
+
+/** Peer A ran with `blockWebrtcDial` on. */
+const PEER_A = "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx";
+const PEER_B = "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC";
+const RELAY = "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD";
+
+function workspace() {
+  return mergeSources([
+    { bundle: clientA, source: "client-a.json" },
+    { bundle: clientB, source: "client-b.json" },
+  ]);
+}
+
+describe("the captured fixtures themselves", () => {
+  it("are real three-vantage bundles", () => {
+    expect(clientA.schemaVersion).toBe(1);
+    expect(clientA.self.peerId).toBe(PEER_A);
+    expect(clientB.self.peerId).toBe(PEER_B);
+    expect(clientA.events.length).toBeGreaterThan(200);
+    expect(clientA.relayView?.relayPeerId).toBe(RELAY);
+    expect(clientA.relayView?.events.length).toBeGreaterThan(0);
+  });
+
+  it("carry no room code and no DID, as the redaction contract requires", () => {
+    for (const bundle of [clientA, clientB]) {
+      const json = JSON.stringify(bundle);
+      expect(json).not.toContain("did:key:");
+      // Every room reference is an ordinal or an HMAC ref.
+      for (const room of bundle.rooms) expect(room.ref).toMatch(/^r\d+$/);
+      for (const room of bundle.relayView?.rooms ?? []) {
+        expect(room.ref).toMatch(/^h:[0-9a-f]{12}$/);
+      }
+    }
+  });
+
+  it("recorded the fault harness in the peer that ran it, and only there", () => {
+    expect(clientA.meta.faultsActive).toBe(true);
+    expect(clientB.meta.faultsActive).toBe(false);
+  });
+
+  it("recorded the throttle suppressing a hot kind", () => {
+    // A real message storm during history sync, bounded to 5/s.
+    expect(clientA.meta.suppressed["app.msg.in"]).toBeGreaterThan(0);
+    expect(clientA.events.some((e) => e.kind === "meta.suppressed")).toBe(true);
+  });
+
+  it("recorded the blocked WebRTC dial that the fault injected", () => {
+    const failed = clientA.events.filter((e) => e.kind === "peer.dial.fail");
+    expect(failed.length).toBeGreaterThan(0);
+    expect(failed[0].d?.form).toBe("webrtc");
+  });
+
+  it("recorded the four silent TURN branches, which reached no UI before", () => {
+    const turn = clientA.events.filter((e) => e.kind.startsWith("ice.turn."));
+    expect(turn.length).toBeGreaterThan(0);
+    expect(new Set(turn.map((e) => e.d?.branch)).size).toBeGreaterThan(0);
+  });
+});
+
+describe("mergeSources on a real capture", () => {
+  it("groups every vantage into ONE capture", () => {
+    const ws = workspace();
+    expect(ws.warnings).toEqual([]);
+    expect(ws.captures).toHaveLength(1);
+    expect(ws.captures[0].vantages.map((v) => `${v.source}:${v.kind}`)).toEqual([
+      "client-a.json:client",
+      "client-a.json#relay:relay",
+      "client-b.json:client",
+      "client-b.json#relay:relay",
+    ]);
+  });
+
+  it("builds one absolute, sorted timeline across all four vantages", () => {
+    const [c] = workspace().captures;
+    expect(c.timeline.length).toBeGreaterThan(400);
+    for (let i = 1; i < c.timeline.length; i++) {
+      expect(c.timeline[i].at).toBeGreaterThanOrEqual(c.timeline[i - 1].at);
+    }
+    expect(new Set(c.timeline.map((e) => e.vantage))).toEqual(
+      new Set(["client", "relay"])
+    );
+  });
+
+  it("names all three peers, and knows which two uploaded a vantage", () => {
+    const [c] = workspace().captures;
+    expect([...c.peers.keys()].sort()).toEqual([PEER_A, PEER_B, RELAY].sort());
+    expect(c.peers.get(PEER_A)?.hasVantage).toBe(true);
+    expect(c.peers.get(PEER_B)?.hasVantage).toBe(true);
+    expect(c.peers.get(RELAY)?.hasVantage).toBe(true);
+  });
+
+  it("warns that no clock sample exists, rather than pretending to be exact", () => {
+    // Neither peer measured the other's clock in this capture, so the offsets
+    // are zero and every cross-vantage finding is suspect. The engine must SAY
+    // so; silently assuming perfect clocks is how a timeline lies.
+    const [c] = workspace().captures;
+    expect(c.maxSkewResidualMs).toBe(0);
+    expect(c.warnings.join(" ")).toContain("No peer.clock samples");
+  });
+});
+
+describe("runFindings on a real capture", () => {
+  const findings = runFindings(workspace().captures[0]);
+  const ids = findings.map((f) => f.id);
+
+  it("names the fault harness, so no other finding is trusted blindly", () => {
+    // `send()` deliberately returns true for a dropped frame, so every other
+    // finding in this capture is suspect and the engine has to say it.
+    expect(ids).toContain("fault-injection-active");
+  });
+
+  it("names a peer that connected without a proven stream", () => {
+    expect(ids).toContain("connected-not-proven");
+    const subjects = findings
+      .filter((f) => f.id === "connected-not-proven")
+      .map((f) => f.subject.peer);
+    expect(subjects).toContain(PEER_A);
+    expect(subjects).toContain(PEER_B);
+  });
+
+  it("names the relay stream that closed for a real reason, not gracefully", () => {
+    // THE relay-side value of this whole change: before it, a liveness
+    // timeout, an idle timeout and a clean close were one log line.
+    expect(ids).toContain("relay-close-unclean");
+    const f = findings.find((x) => x.id === "relay-close-unclean");
+    expect(f?.subject.vantage).toBe(RELAY);
+    expect(f?.detail.reason).toBe("read-error");
+    expect(f?.detail.reason).not.toBe("graceful");
+  });
+
+  it("reports the capture as incomplete, because the throttle dropped events", () => {
+    expect(ids).toContain("capture-incomplete");
+  });
+
+  it("does NOT invent a relay failure: the relay was reachable", () => {
+    // The relay was dialled and answered three times. A console that reports
+    // an unreachable relay here is a console nobody will believe again.
+    expect(ids).not.toContain("relay-unreachable");
+    expect(ids).not.toContain("relay-reservation-never-completed");
+  });
+
+  it("does NOT report rendezvous as wedged: registration worked", () => {
+    // A relay vantage records `rv.register` and never records `rv.peers` - the
+    // PEERS reply is something it sends, not something it logs. Running the
+    // register deadline over a relay vantage fired on every healthy
+    // registration until this capture exposed it.
+    expect(ids).not.toContain("rendezvous-wedged");
+  });
+
+  it("does NOT report an asymmetric link: both peers saw each other", () => {
+    expect(ids).not.toContain("asymmetric-link");
+  });
+
+  it("does NOT report any SFU or voice failure: neither ran in this capture", () => {
+    for (const id of ids) {
+      expect(id.startsWith("sfu-")).toBe(false);
+      expect(id.startsWith("voice-")).toBe(false);
+    }
+  });
+
+  it("reports a stalled sync ONCE per observer, not once per digest", () => {
+    // A stalled sync re-sends a digest every few seconds. One finding per
+    // event buried every other rule under thirty copies of one fact.
+    const stalls = findings.filter((f) => f.id === "sync-stalled");
+    expect(stalls.length).toBeLessThanOrEqual(2);
+    for (const f of stalls) {
+      expect(Number(f.detail.unansweredDigests)).toBeGreaterThan(0);
+      expect(f.evidence.length).toBe(Number(f.detail.unansweredDigests));
+    }
+  });
+
+  it("orders blocking findings before warnings", () => {
+    const rank = { block: 0, warn: 1, info: 2 };
+    const seen = findings.map((f) => rank[f.severity]);
+    expect([...seen].sort((a, b) => a - b)).toEqual(seen);
+  });
+
+  it("points every piece of evidence at a real timeline entry", () => {
+    const [c] = workspace().captures;
+    for (const f of findings) {
+      for (const idx of f.evidence) {
+        expect(c.timeline[idx]).toBeDefined();
+      }
+      // A finding read off the bundle ENVELOPE - `meta.faultsActive`,
+      // `meta.dropped` - honestly has no event to point at. It must then say
+      // what it read instead, or the Findings view has nothing to show.
+      if (f.evidence.length === 0) {
+        expect(Object.keys(f.detail).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("cites the throttle's own marker for an incomplete capture", () => {
+    // `meta.suppressed` is in the envelope, but the ring also emits a
+    // `meta.suppressed` EVENT for exactly this reason: a reader with only the
+    // events must still see the gap.
+    const [c] = workspace().captures;
+    const f = findings.find((x) => x.id === "capture-incomplete");
+    expect(f?.evidence.length).toBeGreaterThan(0);
+    for (const idx of f?.evidence ?? []) {
+      expect(c.timeline[idx].kind).toBe("meta.suppressed");
+    }
+  });
+});
+
+
+describe("foldTopology on a real capture", () => {
+  it("reconstructs the link both peers really had, in both directions", () => {
+    const [c] = workspace().captures;
+    const top = foldTopology(c, c.window.to);
+    expect(top.self).toBe(PEER_A);
+    expect(primaryObserver(c)).toBe(PEER_A);
+
+    const forward = top.links.find((l) => l.from === PEER_A && l.to === PEER_B);
+    const back = top.links.find((l) => l.from === PEER_B && l.to === PEER_A);
+    expect(forward?.state).toBe("proven");
+    expect(back?.state).toBe("proven");
+    expect(forward?.proven).toBe(true);
+  });
+
+  it("reports the relay as connected and reserved, and no SFU at all", () => {
+    const [c] = workspace().captures;
+    const top = foldTopology(c, c.window.to);
+    expect(top.relay).toEqual({ peerId: RELAY, connected: true, reserved: true });
+    expect(top.sfu).toBeNull();
+  });
+
+  it("reports a proven peer online and the relay itself offline", () => {
+    // The relay is a node in the graph but never a proven chat peer, so it
+    // must not render as an online participant.
+    const [c] = workspace().captures;
+    const top = foldTopology(c, c.window.to);
+    const peerB = top.nodes.find((n) => n.peerId === PEER_B);
+    const relay = top.nodes.find((n) => n.peerId === RELAY);
+    expect(peerB).toMatchObject({ online: true, connecting: false });
+    expect(relay).toMatchObject({ online: false, connecting: false });
+  });
+
+  it("reports nothing connected at the start of the window", () => {
+    const [c] = workspace().captures;
+    const top = foldTopology(c, c.window.from);
+    expect(top.relay?.connected ?? false).toBe(false);
+    expect(top.nodes.every((n) => !n.online)).toBe(true);
+  });
+
+  it("finds the instants where the graph really changed", () => {
+    const [c] = workspace().captures;
+    const keys = topologyKeyframes(c);
+    expect(keys.length).toBeGreaterThan(4);
+    expect(keys.length).toBeLessThan(c.timeline.length);
+    expect(keys[0]).toBe(c.window.from);
+    expect(keys[keys.length - 1]).toBe(c.window.to);
+  });
+});
+
+describe("log parsing on real container output", () => {
+  it("reads the SFU's structured sweep and agrees with the SFU's own snapshot", () => {
+    // The two came from the same SFU, one from stdout and one over ms:diag.
+    // If they disagree, one of the two readers is wrong.
+    const parsed = parseSfuTelemetry(sfuLogText, "sfu-telemetry.log");
+    expect(parsed.warnings).toEqual([]);
+    expect(parsed.unmatched).toBe(0);
+    expect(parsed.events.length).toBeGreaterThanOrEqual(1);
+    expect(parsed.events[0].d?.roomPeers).toBe(sfuSnapshot.roomPeerCount);
+    expect(parsed.events[0].d?.producers).toBe(
+      sfuSnapshot.self.producers.length
+    );
+  });
+
+  it("reads the relay's own log, including the new close reason", () => {
+    const parsed = parseRelayLog(relayLogText, "relay.log");
+    expect(parsed.events.length).toBeGreaterThan(20);
+    const kinds = new Set(parsed.events.map((e) => e.kind));
+    expect(kinds).toContain("rv.open");
+    expect(kinds).toContain("rv.register");
+    expect(kinds).toContain("peer.connect");
+  });
+
+  it("keeps a line it did not recognise instead of dropping it", () => {
+    const parsed = parseRelayLog(relayLogText, "relay.log");
+    expect(parsed.unmatched).toBeGreaterThan(0);
+    const raw = parsed.events.filter((e) => e.kind === "log.raw");
+    expect(raw.length).toBe(parsed.unmatched);
+    for (const e of raw) expect(typeof e.d?.raw).toBe("string");
+  });
+
+  it("resolves the relay's 8-character suffixes against the real peer ids", () => {
+    const parsed = parseRelayLog(relayLogText, "relay.log");
+    const suffixes = new Set(
+      parsed.events.map((e) => e.d?.peerSuffix).filter(Boolean)
+    );
+    expect(suffixes).toContain(PEER_A.slice(-8));
+    expect(suffixes).toContain(PEER_B.slice(-8));
+  });
+});
+
+describe("buildPromptPack on a real capture", () => {
+  const [c] = workspace().captures;
+  const pack = buildPromptPack(c, runFindings(c));
+
+  it("leaks no room code, no DID and no message text", () => {
+    // The same gate `frontend/src/lib/telemetry/bundle.test.ts` applies,
+    // turned on the dashboard's own output. `relay.log`'s room code
+    // placeholder is the one string a log parser could have carried through.
+    expect(pack.markdown).not.toContain("did:key:");
+    expect(pack.markdown).not.toContain("ROOMCODEFIXTURE");
+    expect(pack.markdown).not.toContain("capture fixture message");
+  });
+
+  it("is a usable size and reports it", () => {
+    expect(pack.markdown.length).toBeGreaterThan(1000);
+    expect(pack.tokensEstimate).toBeGreaterThan(0);
+    expect(pack.tokensEstimate).toBeLessThan(pack.markdown.length);
+  });
+
+  it("states the contract before the data", () => {
+    const order = [
+      pack.markdown.indexOf("awful.chat"),
+      pack.markdown.indexOf("DiagEvent"),
+      pack.markdown.indexOf("fault-injection-active"),
+    ];
+    expect(order[0]).toBeGreaterThanOrEqual(0);
+    expect(order[1]).toBeGreaterThan(order[0]);
+    expect(order[2]).toBeGreaterThan(order[1]);
+  });
+});

--- a/dashboard/src/lib/analysis/findings.test.ts
+++ b/dashboard/src/lib/analysis/findings.test.ts
@@ -128,8 +128,8 @@ function expectEvidenceValid(capture: Capture, findings: Finding[]): void {
 // ---------------------------------------------------------------------------
 
 describe("RULES", () => {
-  it("has exactly 32 entries, one per FindingId", () => {
-    expect(Object.keys(RULES).length).toBe(32);
+  it("has exactly 33 entries, one per FindingId", () => {
+    expect(Object.keys(RULES).length).toBe(33);
   });
 
   it("every rule has a matching id and non-empty prose", () => {
@@ -958,5 +958,39 @@ describe("producer-never-consumed", () => {
       }),
     ]);
     expect(idsOf(runFindings(capture))).not.toContain("producer-never-consumed");
+  });
+});
+
+describe("turn-unreachable", () => {
+  it("fires when an allocation probe failed", () => {
+    const capture = makeCapture([
+      ev({
+        kind: "ice.turn.fail",
+        at: 2000,
+        sev: "error",
+        d: { branch: "allocate", outcome: "gathered-none", ms: 5000 },
+      }),
+    ]);
+    const findings = runFindings(capture);
+    const hit = findOf(findings, "turn-unreachable");
+    expect(hit).toBeDefined();
+    expect(hit?.detail).toMatchObject({ attempts: 1, outcome: "gathered-none" });
+    expectEvidenceValid(capture, findings);
+  });
+
+  it("ignores a credential failure, which is a different fault", () => {
+    // No credential is a configuration problem and already has its own rule.
+    // Only a refused ALLOCATION is evidence about the network itself.
+    const capture = makeCapture([
+      ev({ kind: "ice.turn.fail", at: 100, sev: "error", d: { branch: "not-ok", status: 500 } }),
+    ]);
+    expect(idsOf(runFindings(capture))).not.toContain("turn-unreachable");
+  });
+
+  it("stays quiet when the probe passed", () => {
+    const capture = makeCapture([
+      ev({ kind: "ice.turn.ok", at: 100, d: { branch: "allocate", ms: 120 } }),
+    ]);
+    expect(idsOf(runFindings(capture))).not.toContain("turn-unreachable");
   });
 });

--- a/dashboard/src/lib/analysis/findings.test.ts
+++ b/dashboard/src/lib/analysis/findings.test.ts
@@ -14,6 +14,7 @@ import {
   ROOM_VIEW_SPLIT_MS,
   SFU_CONSUMER_STALL_THRESHOLD,
   SFU_REJOIN_LOOP_THRESHOLD,
+  PC_LIVE_ALARM,
   SFU_ROOM_SPLIT_MS,
   SYNC_STALL_MS,
   UPGRADE_FAIL_THRESHOLD,
@@ -126,8 +127,8 @@ function expectEvidenceValid(capture: Capture, findings: Finding[]): void {
 // ---------------------------------------------------------------------------
 
 describe("RULES", () => {
-  it("has exactly 29 entries, one per FindingId", () => {
-    expect(Object.keys(RULES).length).toBe(29);
+  it("has exactly 31 entries, one per FindingId", () => {
+    expect(Object.keys(RULES).length).toBe(31);
   });
 
   it("every rule has a matching id and non-empty prose", () => {
@@ -844,5 +845,56 @@ describe("relay-close-unclean", () => {
       ev({ kind: "rv.close", at: 0, vantage: "relay", d: { reason: "graceful" } }),
     ]);
     expect(idsOf(runFindings(c))).not.toContain("relay-close-unclean");
+  });
+});
+
+describe("peerconnection-leak", () => {
+  it("fires once the live gauge crosses the alarm", () => {
+    const capture = makeCapture([
+      ev({ kind: "runtime.resources", at: 1000, d: { pcLive: 4, pcCreated: 4, pcPeak: 4 } }),
+      ev({
+        kind: "runtime.resources",
+        at: 60_000,
+        d: { pcLive: PC_LIVE_ALARM, pcCreated: 300, pcPeak: PC_LIVE_ALARM },
+      }),
+    ]);
+    const findings = runFindings(capture);
+    const hit = findOf(findings, "peerconnection-leak");
+    expect(hit).toBeDefined();
+    // `created` far above `peak` is the rebuild-loop shape, and it is the
+    // number that says which of the two this was.
+    expect(hit?.detail).toMatchObject({ peakLive: PC_LIVE_ALARM, created: 300 });
+    expectEvidenceValid(capture, findings);
+  });
+
+  it("stays quiet for a busy call that closes what it opens", () => {
+    const capture = makeCapture([
+      ev({ kind: "runtime.resources", at: 1000, d: { pcLive: 12, pcCreated: 12, pcPeak: 12 } }),
+      ev({ kind: "runtime.resources", at: 9000, d: { pcLive: 8, pcCreated: 20, pcPeak: 12 } }),
+    ]);
+    // A console that invents a leak is worse than no console: eight peers
+    // joining and leaving is not a fault.
+    expect(idsOf(runFindings(capture))).not.toContain("peerconnection-leak");
+  });
+});
+
+describe("uncaught-error", () => {
+  it("surfaces a single uncaught exception", () => {
+    const capture = makeCapture([
+      ev({
+        kind: "runtime.error",
+        at: 500,
+        sev: "error",
+        d: { source: "uncaught", err: "UnknownError: Cannot create so many PeerConnections" },
+      }),
+    ]);
+    const findings = runFindings(capture);
+    expect(idsOf(findings)).toContain("uncaught-error");
+    expectEvidenceValid(capture, findings);
+  });
+
+  it("stays quiet when nothing threw", () => {
+    const capture = makeCapture([ev({ kind: "peer.connect", at: 10 })]);
+    expect(idsOf(runFindings(capture))).not.toContain("uncaught-error");
   });
 });

--- a/dashboard/src/lib/analysis/findings.test.ts
+++ b/dashboard/src/lib/analysis/findings.test.ts
@@ -15,6 +15,7 @@ import {
   SFU_CONSUMER_STALL_THRESHOLD,
   SFU_REJOIN_LOOP_THRESHOLD,
   PC_LIVE_ALARM,
+  PRODUCER_CONSUME_DEADLINE_MS,
   SFU_ROOM_SPLIT_MS,
   SYNC_STALL_MS,
   UPGRADE_FAIL_THRESHOLD,
@@ -127,8 +128,8 @@ function expectEvidenceValid(capture: Capture, findings: Finding[]): void {
 // ---------------------------------------------------------------------------
 
 describe("RULES", () => {
-  it("has exactly 31 entries, one per FindingId", () => {
-    expect(Object.keys(RULES).length).toBe(31);
+  it("has exactly 32 entries, one per FindingId", () => {
+    expect(Object.keys(RULES).length).toBe(32);
   });
 
   it("every rule has a matching id and non-empty prose", () => {
@@ -896,5 +897,66 @@ describe("uncaught-error", () => {
   it("stays quiet when nothing threw", () => {
     const capture = makeCapture([ev({ kind: "peer.connect", at: 10 })]);
     expect(idsOf(runFindings(capture))).not.toContain("uncaught-error");
+  });
+});
+
+describe("producer-never-consumed", () => {
+  const announce = (at: number, producer: string, source = "camera") =>
+    ev({
+      kind: "sfu.consume",
+      at,
+      peer: "12D3KooWBBB",
+      d: { phase: "announced", producer, source },
+    });
+
+  it("fires when a camera producer is announced and nothing consumes it", () => {
+    const capture = makeCapture([announce(1000, "prod-1")]);
+    const findings = runFindings(capture);
+    const hit = findOf(findings, "producer-never-consumed");
+    expect(hit).toBeDefined();
+    expect(hit?.detail.producer).toBe("prod-1");
+    expectEvidenceValid(capture, findings);
+  });
+
+  it("stays quiet once a consumer exists for it", () => {
+    const capture = makeCapture([
+      announce(1000, "prod-1"),
+      ev({
+        kind: "sfu.consume",
+        at: 1500,
+        peer: "12D3KooWBBB",
+        d: { phase: "ok", producer: "prod-1", source: "camera", kind: "video" },
+      }),
+    ]);
+    expect(idsOf(runFindings(capture))).not.toContain("producer-never-consumed");
+  });
+
+  it("stays quiet for a screen share nobody clicked", () => {
+    // Screen share is opt-in. An unwatched share is the normal case, and a
+    // console that calls it a fault would cry wolf in every single capture.
+    const capture = makeCapture([announce(1000, "prod-screen", "screen")]);
+    expect(idsOf(runFindings(capture))).not.toContain("producer-never-consumed");
+  });
+
+  it("stays quiet when the capture ended before the deadline", () => {
+    const at = 1_000_000 - PRODUCER_CONSUME_DEADLINE_MS + 1000;
+    const capture = makeCapture([announce(at, "prod-late")]);
+    // The consume may have been one second away when the recording stopped.
+    expect(idsOf(runFindings(capture))).not.toContain("producer-never-consumed");
+  });
+
+  it("treats a deduped consume as satisfied", () => {
+    // The in-flight guard shares one consume between two callers: the OTHER
+    // caller reports the outcome, so a dedup is not a missing consumer.
+    const capture = makeCapture([
+      announce(1000, "prod-1"),
+      ev({
+        kind: "sfu.consume",
+        at: 1200,
+        peer: "12D3KooWBBB",
+        d: { phase: "dedup", producer: "prod-1", source: "camera" },
+      }),
+    ]);
+    expect(idsOf(runFindings(capture))).not.toContain("producer-never-consumed");
   });
 });

--- a/dashboard/src/lib/analysis/findings.test.ts
+++ b/dashboard/src/lib/analysis/findings.test.ts
@@ -1,0 +1,848 @@
+import { describe, expect, it } from "vitest";
+import type { ClientBundle } from "../schema";
+import type { Capture, LoadedVantage, MergedEvent, VantageKind } from "./merge";
+import { RULES, type FindingId } from "./rules";
+import {
+  ASYMMETRIC_WINDOW_MS,
+  CONFIRM_FAIL_THRESHOLD,
+  DIAL_FAIL_STREAK_THRESHOLD,
+  FLAP_WINDOW_MS,
+  LIVENESS_FLAP_MIN_COUNT,
+  PROOF_DEADLINE_MS,
+  REGISTER_PEERS_DEADLINE_MS,
+  RESERVATION_COMPLETE_DEADLINE_MS,
+  ROOM_VIEW_SPLIT_MS,
+  SFU_CONSUMER_STALL_THRESHOLD,
+  SFU_REJOIN_LOOP_THRESHOLD,
+  SFU_ROOM_SPLIT_MS,
+  SYNC_STALL_MS,
+  UPGRADE_FAIL_THRESHOLD,
+  VOICE_RESTART_LOOP_THRESHOLD,
+  VOICE_SETUP_DEADLINE_MS,
+  runFindings,
+  type Finding,
+} from "./findings";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers - built locally, no imported fixture file.
+// ---------------------------------------------------------------------------
+
+let seqCounter = 0;
+
+function ev(partial: Partial<MergedEvent> & { kind: MergedEvent["kind"] }): MergedEvent {
+  seqCounter += 1;
+  const at = partial.at ?? 0;
+  return {
+    seq: partial.seq ?? seqCounter,
+    t: partial.t ?? at,
+    kind: partial.kind,
+    sev: partial.sev ?? "info",
+    peer: partial.peer ?? null,
+    room: partial.room ?? null,
+    d: partial.d,
+    at,
+    vantage: partial.vantage ?? "client",
+    source: partial.source ?? partial.observer ?? "self",
+    observer: partial.observer ?? "self",
+  };
+}
+
+function makeBundle(observer: string, overrides?: Partial<ClientBundle>): ClientBundle {
+  return {
+    schemaVersion: 1,
+    bundleId: `${observer}-bundle`,
+    sessionId: `${observer}-session`,
+    createdAt: 0,
+    startedAt: 0,
+    vantage: "client",
+    app: { version: "0", commit: "0" },
+    env: { ua: "" },
+    config: { apiHost: "h", relayPeerId: "r", sfuHosts: [], configured: true },
+    self: { peerId: observer },
+    rooms: [],
+    peers: [],
+    counters: {},
+    events: [],
+    sfuSnapshots: [],
+    meta: { ringCapacity: 4096, dropped: 0, suppressed: {}, faultsActive: false, truncated: false },
+    ...overrides,
+  };
+}
+
+function makeVantage(
+  observer: string,
+  opts?: { kind?: VantageKind; bundle?: Partial<ClientBundle> }
+): LoadedVantage {
+  const kind = opts?.kind ?? "client";
+  return {
+    source: observer,
+    kind,
+    bundleKey: observer,
+    observer,
+    epoch: 0,
+    offset: 0,
+    events: [],
+    window: { from: 0, to: 1_000_000 },
+    bundle: kind === "client" ? makeBundle(observer, opts?.bundle) : undefined,
+  };
+}
+
+function makeCapture(
+  events: MergedEvent[],
+  opts?: { vantages?: LoadedVantage[]; maxSkewResidualMs?: number }
+): Capture {
+  const timeline = [...events].sort((a, b) => a.at - b.at || a.seq - b.seq);
+  return {
+    id: "test-capture",
+    window: { from: 0, to: 1_000_000 },
+    vantages: opts?.vantages ?? [makeVantage("self")],
+    timeline,
+    peers: new Map(),
+    rooms: new Map(),
+    maxSkewResidualMs: opts?.maxSkewResidualMs ?? 0,
+    warnings: [],
+  };
+}
+
+function idsOf(findings: Finding[]): FindingId[] {
+  return findings.map((f) => f.id);
+}
+
+function findOf(findings: Finding[], id: FindingId): Finding | undefined {
+  return findings.find((f) => f.id === id);
+}
+
+function expectEvidenceValid(capture: Capture, findings: Finding[]): void {
+  for (const f of findings) {
+    for (const idx of f.evidence) {
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(capture.timeline.length);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage / structural tests.
+// ---------------------------------------------------------------------------
+
+describe("RULES", () => {
+  it("has exactly 29 entries, one per FindingId", () => {
+    expect(Object.keys(RULES).length).toBe(29);
+  });
+
+  it("every rule has a matching id and non-empty prose", () => {
+    for (const key of Object.keys(RULES) as FindingId[]) {
+      const rule = RULES[key];
+      expect(rule.id).toBe(key);
+      expect(rule.meaning.length).toBeGreaterThan(0);
+      expect(rule.remedy.length).toBeGreaterThan(0);
+      expect(rule.aiHint.length).toBeGreaterThan(0);
+      expect(["block", "warn", "info"]).toContain(rule.severity);
+    }
+  });
+});
+
+describe("runFindings", () => {
+  it("returns [] for a capture with no events", () => {
+    const c = makeCapture([]);
+    expect(runFindings(c)).toEqual([]);
+  });
+
+  it("sorts findings block, then warn, then info", () => {
+    const c = makeCapture([
+      ev({ kind: "storage.locked", at: 0 }), // warn
+      ev({ kind: "app.msg.reject", at: 1, d: { reason: "no-did" } }), // block
+      ev({ kind: "meta.suppressed", at: 2 }), // info
+    ]);
+    const findings = runFindings(c);
+    const ranks: Record<string, number> = { block: 0, warn: 1, info: 2 };
+    for (let i = 1; i < findings.length; i++) {
+      expect(ranks[findings[i - 1].severity]).toBeLessThanOrEqual(ranks[findings[i].severity]);
+    }
+    expectEvidenceValid(c, findings);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. relay-reservation-never-completed
+// ---------------------------------------------------------------------------
+
+describe("relay-reservation-never-completed", () => {
+  it("fires when no reservation.ok follows within the deadline", () => {
+    const c = makeCapture([ev({ kind: "relay.reservation.request", at: 0 })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("relay-reservation-never-completed");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when reservation.ok arrives in time", () => {
+    const c = makeCapture([
+      ev({ kind: "relay.reservation.request", at: 0 }),
+      ev({ kind: "relay.reservation.ok", at: RESERVATION_COMPLETE_DEADLINE_MS - 1000 }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("relay-reservation-never-completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. relay-unreachable
+// ---------------------------------------------------------------------------
+
+describe("relay-unreachable", () => {
+  it(`fires after ${DIAL_FAIL_STREAK_THRESHOLD} dial fails in a row`, () => {
+    const events = Array.from({ length: DIAL_FAIL_STREAK_THRESHOLD }, (_, i) =>
+      ev({ kind: "relay.dial.fail", at: i * 100 })
+    );
+    const c = makeCapture(events);
+    const findings = runFindings(c);
+    const f = findOf(findings, "relay-unreachable");
+    expect(f).toBeDefined();
+    expect(f?.detail.count).toBe(DIAL_FAIL_STREAK_THRESHOLD);
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when the relay dialled and then succeeded", () => {
+    const c = makeCapture([
+      ev({ kind: "relay.dial.fail", at: 0 }),
+      ev({ kind: "relay.dial.fail", at: 100 }),
+      ev({ kind: "relay.dial.fail", at: 200 }),
+      ev({ kind: "relay.dial.ok", at: 300 }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("relay-unreachable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. relay-flapping
+// ---------------------------------------------------------------------------
+
+describe("relay-flapping", () => {
+  it("fires on 3 disconnects inside 5 minutes", () => {
+    const c = makeCapture([
+      ev({ kind: "relay.disconnect", at: 0 }),
+      ev({ kind: "relay.disconnect", at: 60_000 }),
+      ev({ kind: "relay.disconnect", at: 120_000 }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("relay-flapping");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when disconnects are spread beyond the window", () => {
+    const c = makeCapture([
+      ev({ kind: "relay.disconnect", at: 0 }),
+      ev({ kind: "relay.disconnect", at: FLAP_WINDOW_MS }),
+      ev({ kind: "relay.disconnect", at: 2 * FLAP_WINDOW_MS }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("relay-flapping");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. rendezvous-wedged
+// ---------------------------------------------------------------------------
+
+describe("rendezvous-wedged", () => {
+  it("fires when rv.register gets no rv.peers in time", () => {
+    const c = makeCapture([ev({ kind: "rv.register", at: 0, room: "r1" })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("rendezvous-wedged");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("fires on a relay-vantage liveness-timeout close", () => {
+    const c = makeCapture([
+      ev({ kind: "rv.close", at: 0, vantage: "relay", d: { reason: "liveness-timeout" } }),
+    ]);
+    expect(idsOf(runFindings(c))).toContain("rendezvous-wedged");
+  });
+
+  it("does not fire when rv.peers answers in time and no bad close occurs", () => {
+    const c = makeCapture([
+      ev({ kind: "rv.register", at: 0, room: "r1" }),
+      ev({ kind: "rv.peers", at: REGISTER_PEERS_DEADLINE_MS - 500, room: "r1", d: { count: 2 } }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("rendezvous-wedged");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. turn-missing-and-needed
+// ---------------------------------------------------------------------------
+
+describe("turn-missing-and-needed", () => {
+  it("fires when TURN failed and a relayed peer never proved", () => {
+    const c = makeCapture([
+      ev({ kind: "ice.turn.fail", at: 0 }),
+      ev({ kind: "peer.relayed", at: 100, peer: "p1" }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("turn-missing-and-needed");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when the relayed peer eventually proved", () => {
+    const c = makeCapture([
+      ev({ kind: "ice.turn.fail", at: 0 }),
+      ev({ kind: "peer.relayed", at: 100, peer: "p1" }),
+      ev({ kind: "stream.proven", at: 200, peer: "p1" }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("turn-missing-and-needed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. connected-not-proven
+// ---------------------------------------------------------------------------
+
+describe("connected-not-proven", () => {
+  it("fires when connect has no proof within the deadline", () => {
+    const c = makeCapture([ev({ kind: "peer.connect", at: 0, peer: "p1" })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("connected-not-proven");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when the stream is proven in time", () => {
+    const c = makeCapture([
+      ev({ kind: "peer.connect", at: 0, peer: "p1" }),
+      ev({ kind: "stream.proven", at: PROOF_DEADLINE_MS - 1000, peer: "p1" }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("connected-not-proven");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. asymmetric-link
+// ---------------------------------------------------------------------------
+
+describe("asymmetric-link", () => {
+  it("fires when B's own vantage never saw the reciprocal connect", () => {
+    const c = makeCapture(
+      [ev({ kind: "peer.connect", at: 1000, observer: "a", peer: "b" })],
+      { vantages: [makeVantage("a"), makeVantage("b")] }
+    );
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("asymmetric-link");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when both sides see the connect within the window", () => {
+    const c = makeCapture(
+      [
+        ev({ kind: "peer.connect", at: 1000, observer: "a", peer: "b" }),
+        ev({ kind: "peer.connect", at: 1000 + ASYMMETRIC_WINDOW_MS / 2, observer: "b", peer: "a" }),
+      ],
+      { vantages: [makeVantage("a"), makeVantage("b")] }
+    );
+    expect(idsOf(runFindings(c))).not.toContain("asymmetric-link");
+  });
+
+  it("never fires with a single client vantage", () => {
+    const c = makeCapture(
+      [ev({ kind: "peer.connect", at: 1000, observer: "a", peer: "b" })],
+      { vantages: [makeVantage("a")] }
+    );
+    expect(idsOf(runFindings(c))).not.toContain("asymmetric-link");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. upgrade-starved
+// ---------------------------------------------------------------------------
+
+describe("upgrade-starved", () => {
+  it(`fires after ${UPGRADE_FAIL_THRESHOLD} upgrade fails for one peer`, () => {
+    const events = Array.from({ length: UPGRADE_FAIL_THRESHOLD }, (_, i) =>
+      ev({ kind: "peer.upgrade.fail", at: i * 10, peer: "p1" })
+    );
+    const c = makeCapture(events);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("upgrade-starved");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire with one fewer failure", () => {
+    const events = Array.from({ length: UPGRADE_FAIL_THRESHOLD - 1 }, (_, i) =>
+      ev({ kind: "peer.upgrade.fail", at: i * 10, peer: "p1" })
+    );
+    const c = makeCapture(events);
+    expect(idsOf(runFindings(c))).not.toContain("upgrade-starved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. liveness-flap
+// ---------------------------------------------------------------------------
+
+describe("liveness-flap", () => {
+  it(`fires on ${LIVENESS_FLAP_MIN_COUNT} drops in 5 minutes for one peer`, () => {
+    const c = makeCapture([
+      ev({ kind: "peer.drop.liveness", at: 0, peer: "p1" }),
+      ev({ kind: "peer.drop.liveness", at: 60_000, peer: "p1" }),
+      ev({ kind: "peer.drop.liveness", at: 120_000, peer: "p1" }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("liveness-flap");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when drops are spread beyond the window", () => {
+    const c = makeCapture([
+      ev({ kind: "peer.drop.liveness", at: 0, peer: "p1" }),
+      ev({ kind: "peer.drop.liveness", at: FLAP_WINDOW_MS, peer: "p1" }),
+      ev({ kind: "peer.drop.liveness", at: 2 * FLAP_WINDOW_MS, peer: "p1" }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("liveness-flap");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. stream-confirm-starved
+// ---------------------------------------------------------------------------
+
+describe("stream-confirm-starved", () => {
+  it(`fires after ${CONFIRM_FAIL_THRESHOLD} confirm fails for one peer`, () => {
+    const events = Array.from({ length: CONFIRM_FAIL_THRESHOLD }, (_, i) =>
+      ev({ kind: "stream.confirm.fail", at: i * 10, peer: "p1" })
+    );
+    const c = makeCapture(events);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("stream-confirm-starved");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire on a single confirm fail", () => {
+    const c = makeCapture([ev({ kind: "stream.confirm.fail", at: 0, peer: "p1" })]);
+    expect(idsOf(runFindings(c))).not.toContain("stream-confirm-starved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. room-view-split
+// ---------------------------------------------------------------------------
+
+describe("room-view-split", () => {
+  it("fires when rv.peers and app.roomusers disagree for over 30s", () => {
+    const c = makeCapture([
+      ev({ kind: "rv.peers", at: 0, d: { count: 2 } }),
+      ev({ kind: "app.roomusers", at: 0, d: { count: 3 } }),
+      ev({ kind: "app.roomusers", at: ROOM_VIEW_SPLIT_MS + 10_000, d: { count: 3 } }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("room-view-split");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when the counts agree", () => {
+    const c = makeCapture([
+      ev({ kind: "rv.peers", at: 0, d: { count: 2 } }),
+      ev({ kind: "app.roomusers", at: 0, d: { count: 2 } }),
+      ev({ kind: "app.roomusers", at: ROOM_VIEW_SPLIT_MS + 10_000, d: { count: 2 } }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("room-view-split");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. message-rejected
+// ---------------------------------------------------------------------------
+
+describe("message-rejected", () => {
+  it("fires and groups by reason", () => {
+    const c = makeCapture([
+      ev({ kind: "app.msg.reject", at: 0, peer: "p1", d: { reason: "bad-signature" } }),
+    ]);
+    const findings = runFindings(c);
+    const f = findOf(findings, "message-rejected");
+    expect(f).toBeDefined();
+    expect(f?.detail.reason).toBe("bad-signature");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when no message was rejected", () => {
+    const c = makeCapture([ev({ kind: "app.msg.in", at: 0, peer: "p1" })]);
+    expect(idsOf(runFindings(c))).not.toContain("message-rejected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. sync-stalled
+// ---------------------------------------------------------------------------
+
+describe("sync-stalled", () => {
+  it("fires when digest.out gets no reply while a peer is proven", () => {
+    const c = makeCapture([
+      ev({ kind: "stream.proven", at: 0, peer: "p1" }),
+      ev({ kind: "app.digest.out", at: 1000 }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("sync-stalled");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when digest.in answers in time", () => {
+    const c = makeCapture([
+      ev({ kind: "stream.proven", at: 0, peer: "p1" }),
+      ev({ kind: "app.digest.out", at: 1000 }),
+      ev({ kind: "app.digest.in", at: 1000 + SYNC_STALL_MS - 1000 }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("sync-stalled");
+  });
+
+  it("does not fire when no peer is proven", () => {
+    const c = makeCapture([ev({ kind: "app.digest.out", at: 1000 })]);
+    expect(idsOf(runFindings(c))).not.toContain("sync-stalled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. voice-never-connected
+// ---------------------------------------------------------------------------
+
+describe("voice-never-connected", () => {
+  it("fires when ICE never connects within the deadline", () => {
+    const c = makeCapture([ev({ kind: "voice.pc.new", at: 0, peer: "p1" })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("voice-never-connected");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when ICE connects in time", () => {
+    const c = makeCapture([
+      ev({ kind: "voice.pc.new", at: 0, peer: "p1" }),
+      ev({ kind: "voice.ice.connected", at: VOICE_SETUP_DEADLINE_MS - 1000, peer: "p1" }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("voice-never-connected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. voice-media-stalled
+// ---------------------------------------------------------------------------
+
+describe("voice-media-stalled", () => {
+  it("fires when media never resumes", () => {
+    const c = makeCapture([ev({ kind: "voice.media.stall", at: 0, peer: "p1" })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("voice-media-stalled");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when media resumes", () => {
+    const c = makeCapture([
+      ev({ kind: "voice.media.stall", at: 0, peer: "p1" }),
+      ev({ kind: "voice.media.resume", at: 500, peer: "p1" }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("voice-media-stalled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 16. voice-relayed-only
+// ---------------------------------------------------------------------------
+
+describe("voice-relayed-only", () => {
+  it("fires when every voice connection was relayed", () => {
+    const c = makeCapture([
+      ev({ kind: "voice.ice.connected", at: 0, peer: "p1", d: { relayed: true } }),
+      ev({ kind: "voice.ice.connected", at: 10, peer: "p2", d: { relayed: true } }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("voice-relayed-only");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when at least one connection was direct", () => {
+    const c = makeCapture([
+      ev({ kind: "voice.ice.connected", at: 0, peer: "p1", d: { relayed: true } }),
+      ev({ kind: "voice.ice.connected", at: 10, peer: "p2", d: { relayed: false } }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("voice-relayed-only");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 17. voice-restart-loop
+// ---------------------------------------------------------------------------
+
+describe("voice-restart-loop", () => {
+  it(`fires after ${VOICE_RESTART_LOOP_THRESHOLD} restarts for one peer`, () => {
+    const events = Array.from({ length: VOICE_RESTART_LOOP_THRESHOLD }, (_, i) =>
+      ev({ kind: "voice.restart", at: i * 10, peer: "p1" })
+    );
+    const c = makeCapture(events);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("voice-restart-loop");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire with one fewer restart", () => {
+    const events = Array.from({ length: VOICE_RESTART_LOOP_THRESHOLD - 1 }, (_, i) =>
+      ev({ kind: "voice.restart", at: i * 10, peer: "p1" })
+    );
+    const c = makeCapture(events);
+    expect(idsOf(runFindings(c))).not.toContain("voice-restart-loop");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 18. sfu-session-latched
+// ---------------------------------------------------------------------------
+
+describe("sfu-session-latched", () => {
+  it("fires on a latching sfu.error reason", () => {
+    const c = makeCapture([ev({ kind: "sfu.error", at: 0, d: { reason: "producer-limit" } })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("sfu-session-latched");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire on an unrelated sfu.error reason", () => {
+    const c = makeCapture([ev({ kind: "sfu.error", at: 0, d: { reason: "transport-error" } })]);
+    expect(idsOf(runFindings(c))).not.toContain("sfu-session-latched");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 19. sfu-transport-timeout
+// ---------------------------------------------------------------------------
+
+describe("sfu-transport-timeout", () => {
+  it("fires and reports the direction", () => {
+    const c = makeCapture([ev({ kind: "sfu.transport.timeout", at: 0, d: { direction: "send" } })]);
+    const findings = runFindings(c);
+    const f = findOf(findings, "sfu-transport-timeout");
+    expect(f).toBeDefined();
+    expect(f?.detail.direction).toBe("send");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when there is no timeout", () => {
+    const c = makeCapture([ev({ kind: "sfu.transport.state", at: 0, d: { state: "connected" } })]);
+    expect(idsOf(runFindings(c))).not.toContain("sfu-transport-timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 20. sfu-rejoin-loop
+// ---------------------------------------------------------------------------
+
+describe("sfu-rejoin-loop", () => {
+  it(`fires after ${SFU_REJOIN_LOOP_THRESHOLD} rejoins`, () => {
+    const events = Array.from({ length: SFU_REJOIN_LOOP_THRESHOLD }, (_, i) =>
+      ev({ kind: "sfu.rejoin", at: i * 10 })
+    );
+    const c = makeCapture(events);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("sfu-rejoin-loop");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire with one fewer rejoin", () => {
+    const events = Array.from({ length: SFU_REJOIN_LOOP_THRESHOLD - 1 }, (_, i) =>
+      ev({ kind: "sfu.rejoin", at: i * 10 })
+    );
+    const c = makeCapture(events);
+    expect(idsOf(runFindings(c))).not.toContain("sfu-rejoin-loop");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 21. sfu-consumer-stalled
+// ---------------------------------------------------------------------------
+
+describe("sfu-consumer-stalled", () => {
+  it(`fires after ${SFU_CONSUMER_STALL_THRESHOLD} stalls for one producer`, () => {
+    const events = Array.from({ length: SFU_CONSUMER_STALL_THRESHOLD }, (_, i) =>
+      ev({ kind: "sfu.track.stalled", at: i * 10, peer: "p1" })
+    );
+    const c = makeCapture(events);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("sfu-consumer-stalled");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire on a single stall", () => {
+    const c = makeCapture([ev({ kind: "sfu.track.stalled", at: 0, peer: "p1" })]);
+    expect(idsOf(runFindings(c))).not.toContain("sfu-consumer-stalled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 22. sfu-room-split
+// ---------------------------------------------------------------------------
+
+describe("sfu-room-split", () => {
+  it("fires when the sfu room count disagrees with the voice roster for over 30s", () => {
+    const c = makeCapture([
+      ev({ kind: "sfu.diag", at: 0, d: { roomPeers: 5 } }),
+      ev({ kind: "sfu.diag", at: SFU_ROOM_SPLIT_MS + 10_000, d: { roomPeers: 5 } }),
+    ]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("sfu-room-split");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when the counts agree", () => {
+    const c = makeCapture([
+      ev({ kind: "voice.join", at: 0, peer: "p1" }),
+      ev({ kind: "sfu.diag", at: 100, d: { roomPeers: 2 } }),
+      ev({ kind: "sfu.diag", at: SFU_ROOM_SPLIT_MS + 10_000, d: { roomPeers: 2 } }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("sfu-room-split");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 23. sfu-placement-disagreement
+// ---------------------------------------------------------------------------
+
+describe("sfu-placement-disagreement", () => {
+  it("fires when two client vantages picked different hosts", () => {
+    const c = makeCapture(
+      [
+        ev({ kind: "sfu.pick", at: 0, observer: "a", d: { host: "h1" } }),
+        ev({ kind: "sfu.pick", at: 0, observer: "b", d: { host: "h2" } }),
+      ],
+      { vantages: [makeVantage("a"), makeVantage("b")] }
+    );
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("sfu-placement-disagreement");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when both vantages picked the same host", () => {
+    const c = makeCapture(
+      [
+        ev({ kind: "sfu.pick", at: 0, observer: "a", d: { host: "h1" } }),
+        ev({ kind: "sfu.pick", at: 0, observer: "b", d: { host: "h1" } }),
+      ],
+      { vantages: [makeVantage("a"), makeVantage("b")] }
+    );
+    expect(idsOf(runFindings(c))).not.toContain("sfu-placement-disagreement");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 24. clock-skew
+// ---------------------------------------------------------------------------
+
+describe("clock-skew", () => {
+  it("fires when the residual exceeds the acceptable limit", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })], { maxSkewResidualMs: 3000 });
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("clock-skew");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when the residual is within the limit", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })], { maxSkewResidualMs: 500 });
+    expect(idsOf(runFindings(c))).not.toContain("clock-skew");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 25. fault-injection-active
+// ---------------------------------------------------------------------------
+
+describe("fault-injection-active", () => {
+  it("fires when a bundle reports an active fault", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })], {
+      vantages: [makeVantage("self", { bundle: { meta: { ringCapacity: 4096, dropped: 0, suppressed: {}, faultsActive: true, truncated: false } } })],
+    });
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("fault-injection-active");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when no fault was active", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })]);
+    expect(idsOf(runFindings(c))).not.toContain("fault-injection-active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 26. unconfigured-instance
+// ---------------------------------------------------------------------------
+
+describe("unconfigured-instance", () => {
+  it("fires when session.config reports configured: false", () => {
+    const c = makeCapture([ev({ kind: "session.config", at: 0, d: { configured: false } })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("unconfigured-instance");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when configured is true", () => {
+    const c = makeCapture([ev({ kind: "session.config", at: 0, d: { configured: true } })]);
+    expect(idsOf(runFindings(c))).not.toContain("unconfigured-instance");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 27. storage-locked-writes
+// ---------------------------------------------------------------------------
+
+describe("storage-locked-writes", () => {
+  it("fires on any storage.locked event", () => {
+    const c = makeCapture([ev({ kind: "storage.locked", at: 0, d: { what: "dm-queue" } })]);
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("storage-locked-writes");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire when storage was never locked", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })]);
+    expect(idsOf(runFindings(c))).not.toContain("storage-locked-writes");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 28. capture-incomplete
+// ---------------------------------------------------------------------------
+
+describe("capture-incomplete", () => {
+  it("fires when a bundle reports dropped events", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })], {
+      vantages: [makeVantage("self", { bundle: { meta: { ringCapacity: 4096, dropped: 5, suppressed: {}, faultsActive: false, truncated: false } } })],
+    });
+    const findings = runFindings(c);
+    expect(idsOf(findings)).toContain("capture-incomplete");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("fires on a meta.suppressed event even with no dropped count", () => {
+    const c = makeCapture([ev({ kind: "meta.suppressed", at: 0 })]);
+    expect(idsOf(runFindings(c))).toContain("capture-incomplete");
+  });
+
+  it("does not fire on a clean capture", () => {
+    const c = makeCapture([ev({ kind: "session.start", at: 0 })]);
+    expect(idsOf(runFindings(c))).not.toContain("capture-incomplete");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 29. relay-close-unclean
+// ---------------------------------------------------------------------------
+
+describe("relay-close-unclean", () => {
+  it("fires and names the reason when the close was not graceful", () => {
+    const c = makeCapture([
+      ev({ kind: "rv.close", at: 0, vantage: "relay", d: { reason: "idle-timeout" } }),
+    ]);
+    const findings = runFindings(c);
+    const f = findOf(findings, "relay-close-unclean");
+    expect(f).toBeDefined();
+    expect(f?.detail.reason).toBe("idle-timeout");
+    expectEvidenceValid(c, findings);
+  });
+
+  it("does not fire on a graceful close", () => {
+    const c = makeCapture([
+      ev({ kind: "rv.close", at: 0, vantage: "relay", d: { reason: "graceful" } }),
+    ]);
+    expect(idsOf(runFindings(c))).not.toContain("relay-close-unclean");
+  });
+});

--- a/dashboard/src/lib/analysis/findings.ts
+++ b/dashboard/src/lib/analysis/findings.ts
@@ -92,6 +92,9 @@ export const SFU_CONSUMER_STALL_THRESHOLD = 2;
 /** How long the SFU room count and the voice roster may disagree. */
 export const SFU_ROOM_SPLIT_MS = 30_000;
 
+/** Live RTCPeerConnections that mean a leak, not a busy call. */
+export const PC_LIVE_ALARM = 50;
+
 // ---------------------------------------------------------------------------
 // Small, side-effect-free readers for the `d` bag. Never throw.
 // ---------------------------------------------------------------------------
@@ -494,6 +497,43 @@ function messageRejected(timeline: MergedEvent[]): Finding[] {
   return out;
 }
 
+/**
+ * The gauge climbed past anything a real call needs.
+ *
+ * A call holds a few connections per peer: one for voice, one or two for
+ * libp2p, two for the SFU. Fifty is far above every legitimate shape and far
+ * below the 500 at which the browser starts to refuse them, so this fires
+ * while the session can still be explained rather than after voice, the SFU
+ * and libp2p have all failed on the same line.
+ */
+function peerConnectionLeak(timeline: MergedEvent[]): Finding[] {
+  const seen = new Map<
+    string,
+    { evidence: number[]; peak: number; created: number }
+  >();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "runtime.resources") return;
+    const live = num(e.d, "pcLive");
+    if (live === null) return;
+    const hit = seen.get(e.observer) ?? { evidence: [], peak: 0, created: 0 };
+    if (live >= PC_LIVE_ALARM) hit.evidence.push(i);
+    hit.peak = Math.max(hit.peak, live);
+    hit.created = Math.max(hit.created, num(e.d, "pcCreated") ?? 0);
+    seen.set(e.observer, hit);
+  });
+  const out: Finding[] = [];
+  for (const [observer, hit] of seen) {
+    if (hit.evidence.length === 0) continue;
+    out.push(
+      make("peerconnection-leak", { vantage: observer }, hit.evidence, {
+        peakLive: hit.peak,
+        created: hit.created,
+      })
+    );
+  }
+  return out;
+}
+
 /** Per-`(observer, peer)` proof transitions, in time order. */
 function provenTransitions(timeline: MergedEvent[]): Map<string, Array<{ at: number; proven: boolean }>> {
   const map = new Map<string, Array<{ at: number; proven: boolean }>>();
@@ -866,6 +906,8 @@ export function runFindings(c: Capture): Finding[] {
     ...storageLockedWrites(timeline),
     ...captureIncomplete(c),
     ...relayCloseUnclean(timeline),
+    ...peerConnectionLeak(timeline),
+    ...thresholdByObserver(timeline, "runtime.error", 1, "uncaught-error"),
   ];
 
   return findings

--- a/dashboard/src/lib/analysis/findings.ts
+++ b/dashboard/src/lib/analysis/findings.ts
@@ -95,6 +95,9 @@ export const SFU_ROOM_SPLIT_MS = 30_000;
 /** Live RTCPeerConnections that mean a leak, not a busy call. */
 export const PC_LIVE_ALARM = 50;
 
+/** How long a camera producer may stay announced and unconsumed. */
+export const PRODUCER_CONSUME_DEADLINE_MS = 15_000;
+
 // ---------------------------------------------------------------------------
 // Small, side-effect-free readers for the `d` bag. Never throw.
 // ---------------------------------------------------------------------------
@@ -534,6 +537,61 @@ function peerConnectionLeak(timeline: MergedEvent[]): Finding[] {
   return out;
 }
 
+/**
+ * A camera producer was announced and no consumer ever followed.
+ *
+ * Camera is consumed automatically, so the announcement is a promise the
+ * client makes to itself. Screen share is deliberately NOT covered here: it
+ * is opt-in, and a share nobody clicks is the normal case, not a fault.
+ *
+ * This is the shape a wedged receive transport takes from the outside. Every
+ * other signal stays healthy - the socket is open, the transport reads
+ * connected, the roster is right - and the only visible fact is that a stream
+ * everyone else can see never arrives.
+ */
+function producerNeverConsumed(c: Capture, timeline: MergedEvent[]): Finding[] {
+  const announced = new Map<
+    string,
+    { at: number; index: number; peer: string | null; observer: string }
+  >();
+  const satisfied = new Set<string>();
+
+  timeline.forEach((e, i) => {
+    if (e.kind !== "sfu.consume") return;
+    const producer = str(e.d, "producer");
+    if (!producer) return;
+    const key = `${e.observer}|${producer}`;
+    const phase = str(e.d, "phase");
+    if (phase === "announced") {
+      if (str(e.d, "source") === "screen") return;
+      if (!announced.has(key)) {
+        announced.set(key, { at: e.at, index: i, peer: e.peer, observer: e.observer });
+      }
+      return;
+    }
+    // "ok" is a consumer that exists; "dedup" means another consume for the
+    // same producer was already in flight and will report its own outcome.
+    if (phase === "ok" || phase === "dedup") satisfied.add(key);
+  });
+
+  const out: Finding[] = [];
+  for (const [key, hit] of announced) {
+    if (satisfied.has(key)) continue;
+    // A capture that ends inside the deadline proves nothing: the consume
+    // may have been seconds away when the recording stopped.
+    if (c.window.to - hit.at < PRODUCER_CONSUME_DEADLINE_MS) continue;
+    out.push(
+      make(
+        "producer-never-consumed",
+        { vantage: hit.observer, peer: hit.peer ?? undefined },
+        [hit.index],
+        { producer: key.split("|")[1] ?? "", waitedMs: c.window.to - hit.at }
+      )
+    );
+  }
+  return out;
+}
+
 /** Per-`(observer, peer)` proof transitions, in time order. */
 function provenTransitions(timeline: MergedEvent[]): Map<string, Array<{ at: number; proven: boolean }>> {
   const map = new Map<string, Array<{ at: number; proven: boolean }>>();
@@ -907,6 +965,7 @@ export function runFindings(c: Capture): Finding[] {
     ...captureIncomplete(c),
     ...relayCloseUnclean(timeline),
     ...peerConnectionLeak(timeline),
+    ...producerNeverConsumed(c, timeline),
     ...thresholdByObserver(timeline, "runtime.error", 1, "uncaught-error"),
   ];
 

--- a/dashboard/src/lib/analysis/findings.ts
+++ b/dashboard/src/lib/analysis/findings.ts
@@ -1,0 +1,875 @@
+/**
+ * The deterministic finding engine.
+ *
+ * Every detector below walks `capture.timeline` (already skew-corrected and
+ * sorted by `merge.ts`) and is a total, pure function of the capture: same
+ * input, same findings, every time. No detector reaches outside the
+ * `Capture` it is given, and none throws on a malformed `d` bag - a `d`
+ * value can be any JSON primitive or absent, so every read below goes
+ * through a `typeof` guard instead of assuming a shape.
+ */
+
+import type { Capture, MergedEvent } from "./merge";
+import { MAX_ACCEPTABLE_SKEW_MS } from "./merge";
+import { PEER_PROOF_GRACE_MS } from "./topology";
+import type { DiagKind } from "../schema";
+import type { FindingId, Rule } from "./rules";
+import { RULES } from "./rules";
+
+export interface Finding {
+  id: FindingId;
+  severity: Rule["severity"];
+  subject: { peer?: string; pair?: [string, string]; room?: string; vantage?: string };
+  /** Indices into `capture.timeline`. Clicking one jumps the Timeline view. */
+  evidence: number[];
+  detail: Record<string, string | number | boolean | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Thresholds - every one named and derived, per the rule table.
+// ---------------------------------------------------------------------------
+
+/** Mirrors the relay's own reservation timeout in `libp2p/transport.ts`. */
+export const RESERVATION_COMPLETE_DEADLINE_MS = 10_000;
+
+/** Four dial failures in a row with no intervening success. */
+export const DIAL_FAIL_STREAK_THRESHOLD = 4;
+
+/** The window "in five minutes" is measured over, for both flap rules. */
+export const FLAP_WINDOW_MS = 5 * 60_000;
+
+/** Three relay disconnects inside `FLAP_WINDOW_MS`. */
+export const RELAY_FLAP_MIN_COUNT = 3;
+
+/** Three liveness drops inside `FLAP_WINDOW_MS`. */
+export const LIVENESS_FLAP_MIN_COUNT = 3;
+
+/** How long a room registration can go without a peer list before it is wedged. */
+export const REGISTER_PEERS_DEADLINE_MS = 5_000;
+
+/**
+ * `4 * PEER_PROOF_GRACE_MS`: one grace window for the ordinary handshake, plus
+ * three more before "still unproven" stops being a flicker and starts being a
+ * real finding. `PEER_PROOF_GRACE_MS` is topology's own online/connecting
+ * cutoff (`frontend/src/lib/peer-online-status.ts`).
+ */
+export const PROOF_DEADLINE_MS = 4 * PEER_PROOF_GRACE_MS;
+
+/** How far apart two observers' `peer.connect` views of one pair may drift. */
+export const ASYMMETRIC_WINDOW_MS = 10_000;
+
+/** Three failed upgrade attempts for one peer. */
+export const UPGRADE_FAIL_THRESHOLD = 3;
+
+/** Two failed stream-confirm attempts for one peer. */
+export const CONFIRM_FAIL_THRESHOLD = 2;
+
+/** How long the rendezvous and gossip room counts may disagree. */
+export const ROOM_VIEW_SPLIT_MS = 30_000;
+
+/** How long a digest may go unanswered while a peer is proven. */
+export const SYNC_STALL_MS = 60_000;
+
+/** Mirrors `VOICE_SETUP_DEADLINE_MS` in the plan: 30s to reach ICE connected. */
+export const VOICE_SETUP_DEADLINE_MS = 30_000;
+
+/** Three ICE restarts for one voice peer. */
+export const VOICE_RESTART_LOOP_THRESHOLD = 3;
+
+/** `sfu.error` reasons that fall through to `failSession` with no branch. */
+export const SFU_LATCHING_REASONS: readonly string[] = [
+  "invalid-produce",
+  "producer-limit",
+  "consumer-limit",
+];
+
+/** Three SFU rejoins with no attempt cap in the client's ladder. */
+export const SFU_REJOIN_LOOP_THRESHOLD = 3;
+
+/** Two stalled tracks for one producer/peer. */
+export const SFU_CONSUMER_STALL_THRESHOLD = 2;
+
+/** How long the SFU room count and the voice roster may disagree. */
+export const SFU_ROOM_SPLIT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Small, side-effect-free readers for the `d` bag. Never throw.
+// ---------------------------------------------------------------------------
+
+type DetailBag = MergedEvent["d"];
+
+function str(d: DetailBag, key: string): string | null {
+  const v = d?.[key];
+  return typeof v === "string" ? v : null;
+}
+
+function num(d: DetailBag, key: string): number | null {
+  const v = d?.[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function bool(d: DetailBag, key: string): boolean | null {
+  const v = d?.[key];
+  return typeof v === "boolean" ? v : null;
+}
+
+function make(
+  id: FindingId,
+  subject: Finding["subject"],
+  evidence: number[],
+  detail: Finding["detail"]
+): Finding {
+  return { id, severity: RULES[id].severity, subject, evidence, detail };
+}
+
+// ---------------------------------------------------------------------------
+// Generic detectors, reused by several rules.
+// ---------------------------------------------------------------------------
+
+type KeyMode = "observer" | "observer+peer" | "observer+room";
+
+function keyOf(e: MergedEvent, mode: KeyMode): string | null {
+  if (mode === "observer") return e.observer;
+  if (mode === "observer+peer") return e.peer ? `${e.observer}|${e.peer}` : null;
+  return e.room ? `${e.observer}|${e.room}` : null;
+}
+
+/**
+ * Every `startKind` event that has no `endKinds` event, from the same key,
+ * within `deadlineMs` at or after it. `deadlineMs` may be `Infinity` for "no
+ * following event at all, ever".
+ */
+function findUnmatchedDeadline(
+  timeline: MergedEvent[],
+  startKind: DiagKind,
+  endKinds: DiagKind[],
+  deadlineMs: number,
+  keyMode: KeyMode
+): Array<{ startIndex: number; key: string }> {
+  const endsByKey = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    // `MergedKind` is wider than `DiagKind`: a log line a parser did not
+    // recognise carries `LOG_RAW_KIND`, and it matches no wire kind.
+    if (!(endKinds as string[]).includes(e.kind)) return;
+    const k = keyOf(e, keyMode);
+    if (k === null) return;
+    const list = endsByKey.get(k);
+    if (list) list.push(i);
+    else endsByKey.set(k, [i]);
+  });
+
+  const out: Array<{ startIndex: number; key: string }> = [];
+  timeline.forEach((e, i) => {
+    if (e.kind !== startKind) return;
+    const k = keyOf(e, keyMode);
+    if (k === null) return;
+    const ends = endsByKey.get(k) ?? [];
+    const matched = ends.some((endIdx) => {
+      const endE = timeline[endIdx];
+      return endE.at >= e.at && endE.at - e.at <= deadlineMs;
+    });
+    if (!matched) out.push({ startIndex: i, key: k });
+  });
+  return out;
+}
+
+function unmatchedDeadlineFindings(
+  timeline: MergedEvent[],
+  startKind: DiagKind,
+  endKinds: DiagKind[],
+  deadlineMs: number,
+  keyMode: KeyMode,
+  id: FindingId
+): Finding[] {
+  return findUnmatchedDeadline(timeline, startKind, endKinds, deadlineMs, keyMode).map(
+    ({ startIndex, key }) => {
+      const parts = key.split("|");
+      const subject: Finding["subject"] =
+        keyMode === "observer"
+          ? { vantage: parts[0] }
+          : keyMode === "observer+peer"
+            ? { peer: parts[1], vantage: parts[0] }
+            : { vantage: parts[0], room: parts[1] };
+      return make(id, subject, [startIndex], {
+        deadlineMs: Number.isFinite(deadlineMs) ? deadlineMs : null,
+      });
+    }
+  );
+}
+
+/** `>= threshold` occurrences of `kind` for one `(observer, peer)` pair. */
+function thresholdByPeerObserver(
+  timeline: MergedEvent[],
+  kind: DiagKind,
+  threshold: number,
+  id: FindingId
+): Finding[] {
+  const groups = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== kind || !e.peer) return;
+    const key = `${e.observer}|${e.peer}`;
+    const list = groups.get(key);
+    if (list) list.push(i);
+    else groups.set(key, [i]);
+  });
+  const out: Finding[] = [];
+  for (const [key, indices] of groups) {
+    if (indices.length < threshold) continue;
+    const [observer, peer] = key.split("|");
+    out.push(make(id, { peer, vantage: observer }, indices, { count: indices.length }));
+  }
+  return out;
+}
+
+/** `>= threshold` occurrences of `kind` for one observer (no peer involved). */
+function thresholdByObserver(
+  timeline: MergedEvent[],
+  kind: DiagKind,
+  threshold: number,
+  id: FindingId
+): Finding[] {
+  const groups = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== kind) return;
+    const list = groups.get(e.observer);
+    if (list) list.push(i);
+    else groups.set(e.observer, [i]);
+  });
+  const out: Finding[] = [];
+  for (const [observer, indices] of groups) {
+    if (indices.length < threshold) continue;
+    out.push(make(id, { vantage: observer }, indices, { count: indices.length }));
+  }
+  return out;
+}
+
+/** `>= minCount` occurrences of `kind` within `windowMs`, for one key. */
+function windowedThreshold(
+  timeline: MergedEvent[],
+  kind: DiagKind,
+  minCount: number,
+  windowMs: number,
+  id: FindingId,
+  keyMode: "observer" | "observer+peer"
+): Finding[] {
+  const groups = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== kind) return;
+    if (keyMode === "observer+peer" && !e.peer) return;
+    const key = keyMode === "observer" ? e.observer : `${e.observer}|${e.peer}`;
+    const list = groups.get(key);
+    if (list) list.push(i);
+    else groups.set(key, [i]);
+  });
+
+  const out: Finding[] = [];
+  for (const [key, indices] of groups) {
+    for (let start = 0; start + minCount - 1 < indices.length; start++) {
+      const end = start + minCount - 1;
+      const startAt = timeline[indices[start]].at;
+      const endAt = timeline[indices[end]].at;
+      if (endAt - startAt <= windowMs) {
+        const [observer, peer] = key.split("|");
+        out.push(
+          make(
+            id,
+            peer ? { peer, vantage: observer } : { vantage: observer },
+            indices.slice(start, end + 1),
+            { count: minCount, windowMs: endAt - startAt }
+          )
+        );
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/** A fail-kind streak per observer, reset by an ok-kind. Fires once per streak. */
+function failStreakFindings(
+  timeline: MergedEvent[],
+  okKind: DiagKind,
+  failKind: DiagKind,
+  threshold: number,
+  id: FindingId
+): Finding[] {
+  const streaks = new Map<string, number[]>();
+  const fired = new Set<string>();
+  const out: Finding[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind === okKind) {
+      streaks.set(e.observer, []);
+      return;
+    }
+    if (e.kind !== failKind) return;
+    const list = streaks.get(e.observer) ?? [];
+    list.push(i);
+    streaks.set(e.observer, list);
+    if (list.length >= threshold && !fired.has(e.observer)) {
+      fired.add(e.observer);
+      out.push(make(id, { vantage: e.observer }, list.slice(-threshold), { count: list.length }));
+    }
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Bespoke detectors.
+// ---------------------------------------------------------------------------
+
+function turnMissingAndNeeded(timeline: MergedEvent[]): Finding[] {
+  const turnFailIdx: number[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind === "ice.turn.unavailable" || e.kind === "ice.turn.fail") turnFailIdx.push(i);
+  });
+  if (turnFailIdx.length === 0) return [];
+
+  const relayedFirstIdx = new Map<string, number>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "peer.relayed" || !e.peer) return;
+    const key = `${e.observer}|${e.peer}`;
+    if (!relayedFirstIdx.has(key)) relayedFirstIdx.set(key, i);
+  });
+
+  const proven = new Set<string>();
+  timeline.forEach((e) => {
+    if (e.kind === "stream.proven" && e.peer) proven.add(`${e.observer}|${e.peer}`);
+  });
+
+  const out: Finding[] = [];
+  for (const [key, idx] of relayedFirstIdx) {
+    if (proven.has(key)) continue;
+    const [observer, peer] = key.split("|");
+    out.push(
+      make("turn-missing-and-needed", { peer, vantage: observer }, [...turnFailIdx, idx], {
+        turnFailures: turnFailIdx.length,
+      })
+    );
+  }
+  return out;
+}
+
+function asymmetricLink(c: Capture): Finding[] {
+  const clientObservers = new Set(
+    c.vantages.filter((v) => v.kind === "client").map((v) => v.observer)
+  );
+  if (clientObservers.size < 2) return [];
+
+  const timeline = c.timeline;
+  const connectsByObserver = new Map<string, Array<{ peer: string; at: number; idx: number }>>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "peer.connect" || !e.peer) return;
+    const list = connectsByObserver.get(e.observer) ?? [];
+    list.push({ peer: e.peer, at: e.at, idx: i });
+    connectsByObserver.set(e.observer, list);
+  });
+
+  const out: Finding[] = [];
+  const firedPairs = new Set<string>();
+  for (const [observer, list] of connectsByObserver) {
+    if (!clientObservers.has(observer)) continue;
+    for (const { peer, at, idx } of list) {
+      if (!clientObservers.has(peer)) continue;
+      const pairKey = [observer, peer].sort().join("|");
+      if (firedPairs.has(pairKey)) continue;
+      const reverse = connectsByObserver.get(peer) ?? [];
+      const hasReciprocal = reverse.some(
+        (x) => x.peer === observer && Math.abs(x.at - at) <= ASYMMETRIC_WINDOW_MS
+      );
+      if (!hasReciprocal) {
+        firedPairs.add(pairKey);
+        out.push(
+          make("asymmetric-link", { pair: [observer, peer] }, [idx], {
+            windowMs: ASYMMETRIC_WINDOW_MS,
+          })
+        );
+      }
+    }
+  }
+  return out;
+}
+
+function rendezvousWedged(timeline: MergedEvent[]): Finding[] {
+  // The register -> peers deadline is a CLIENT observation. A relay vantage
+  // records `rv.register` and never records `rv.peers` at all - the PEERS
+  // reply is something the relay sends, not something it logs - so running
+  // this clause over a relay vantage fires on every healthy registration.
+  // Captured fixtures made that false positive obvious: four findings for a
+  // session where rendezvous worked.
+  // Evidence indices must keep pointing into the FULL timeline, so the filter
+  // carries an index map rather than renumbering the events.
+  const keep: number[] = [];
+  const clientOnly: MergedEvent[] = [];
+  timeline.forEach((e, i) => {
+    if (e.vantage !== "client") return;
+    keep.push(i);
+    clientOnly.push(e);
+  });
+  const out: Finding[] = unmatchedDeadlineFindings(
+    clientOnly,
+    "rv.register",
+    ["rv.peers"],
+    REGISTER_PEERS_DEADLINE_MS,
+    "observer+room",
+    "rendezvous-wedged"
+  ).map((f): Finding => ({
+    ...f,
+    evidence: f.evidence.map((idx) => keep[idx] ?? idx),
+    detail: { ...f.detail, reason: "register-timeout" },
+  }));
+
+  timeline.forEach((e, i) => {
+    if (e.kind !== "rv.close" || e.vantage !== "relay") return;
+    if (str(e.d, "reason") === "liveness-timeout") {
+      out.push(
+        make("rendezvous-wedged", { vantage: e.observer }, [i], { reason: "liveness-timeout" })
+      );
+    }
+  });
+  return out;
+}
+
+function roomViewSplit(timeline: MergedEvent[]): Finding[] {
+  interface State {
+    rv: number | null;
+    app: number | null;
+    mismatchStart: number | null;
+    startIdx: number;
+    fired: boolean;
+  }
+  const state = new Map<string, State>();
+  const out: Finding[] = [];
+
+  timeline.forEach((e, i) => {
+    if (e.kind !== "rv.peers" && e.kind !== "app.roomusers") return;
+    const s: State = state.get(e.observer) ?? {
+      rv: null,
+      app: null,
+      mismatchStart: null,
+      startIdx: -1,
+      fired: false,
+    };
+    const count = num(e.d, "count");
+    if (e.kind === "rv.peers") s.rv = count;
+    else s.app = count;
+
+    if (s.rv !== null && s.app !== null) {
+      if (s.rv !== s.app) {
+        if (s.mismatchStart === null) {
+          s.mismatchStart = e.at;
+          s.startIdx = i;
+        } else if (!s.fired && e.at - s.mismatchStart > ROOM_VIEW_SPLIT_MS) {
+          s.fired = true;
+          out.push(
+            make("room-view-split", { vantage: e.observer }, [s.startIdx, i], {
+              rv: s.rv,
+              app: s.app,
+              sinceMs: e.at - s.mismatchStart,
+            })
+          );
+        }
+      } else {
+        s.mismatchStart = null;
+        s.fired = false;
+      }
+    }
+    state.set(e.observer, s);
+  });
+  return out;
+}
+
+function messageRejected(timeline: MergedEvent[]): Finding[] {
+  const groups = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "app.msg.reject") return;
+    const reason = str(e.d, "reason") ?? "unknown";
+    const list = groups.get(reason);
+    if (list) list.push(i);
+    else groups.set(reason, [i]);
+  });
+  const out: Finding[] = [];
+  for (const [reason, indices] of groups) {
+    out.push(make("message-rejected", {}, indices, { reason, count: indices.length }));
+  }
+  return out;
+}
+
+/** Per-`(observer, peer)` proof transitions, in time order. */
+function provenTransitions(timeline: MergedEvent[]): Map<string, Array<{ at: number; proven: boolean }>> {
+  const map = new Map<string, Array<{ at: number; proven: boolean }>>();
+  for (const e of timeline) {
+    if (!e.peer) continue;
+    let next: boolean | null = null;
+    if (e.kind === "stream.proven") next = true;
+    else if (e.kind === "stream.lost" || e.kind === "peer.disconnect" || e.kind === "peer.drop.liveness") {
+      next = false;
+    }
+    if (next === null) continue;
+    const key = `${e.observer}|${e.peer}`;
+    const list = map.get(key);
+    if (list) list.push({ at: e.at, proven: next });
+    else map.set(key, [{ at: e.at, proven: next }]);
+  }
+  return map;
+}
+
+function anyPeerProvenAt(
+  transitions: Map<string, Array<{ at: number; proven: boolean }>>,
+  observer: string,
+  at: number
+): boolean {
+  for (const [key, list] of transitions) {
+    if (!key.startsWith(`${observer}|`)) continue;
+    let proven = false;
+    for (const t of list) {
+      if (t.at > at) break;
+      proven = t.proven;
+    }
+    if (proven) return true;
+  }
+  return false;
+}
+
+function syncStalled(timeline: MergedEvent[]): Finding[] {
+  const transitions = provenTransitions(timeline);
+  const insByObserver = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "app.digest.in") return;
+    const list = insByObserver.get(e.observer) ?? [];
+    list.push(i);
+    insByObserver.set(e.observer, list);
+  });
+
+  // ONE finding per observer, not one per unanswered digest. A stalled sync
+  // sends a digest every few seconds, so a per-event finding buried every
+  // other rule under thirty copies of the same fact in a captured fixture.
+  const stalls = new Map<string, { evidence: number[]; firstAt: number }>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "app.digest.out") return;
+    if (!anyPeerProvenAt(transitions, e.observer, e.at)) return;
+    const ins = insByObserver.get(e.observer) ?? [];
+    const matched = ins.some((idx) => {
+      const inE = timeline[idx];
+      return inE.at >= e.at && inE.at - e.at <= SYNC_STALL_MS;
+    });
+    if (matched) return;
+    const hit = stalls.get(e.observer);
+    if (hit) hit.evidence.push(i);
+    else stalls.set(e.observer, { evidence: [i], firstAt: e.at });
+  });
+
+  const out: Finding[] = [];
+  for (const [observer, { evidence, firstAt }] of stalls) {
+    out.push(
+      make("sync-stalled", { vantage: observer }, evidence, {
+        deadlineMs: SYNC_STALL_MS,
+        unansweredDigests: evidence.length,
+        firstAt,
+      })
+    );
+  }
+  return out;
+}
+
+function voiceRelayedOnly(timeline: MergedEvent[]): Finding[] {
+  const indices: number[] = [];
+  let allRelayed = true;
+  timeline.forEach((e, i) => {
+    if (e.kind !== "voice.ice.connected") return;
+    indices.push(i);
+    if (bool(e.d, "relayed") !== true) allRelayed = false;
+  });
+  if (indices.length === 0 || !allRelayed) return [];
+  return [make("voice-relayed-only", {}, indices, { count: indices.length })];
+}
+
+function sfuSessionLatched(timeline: MergedEvent[]): Finding[] {
+  const out: Finding[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind !== "sfu.error") return;
+    const reason = str(e.d, "reason");
+    if (reason && SFU_LATCHING_REASONS.includes(reason)) {
+      out.push(make("sfu-session-latched", { vantage: e.observer }, [i], { reason }));
+    }
+  });
+  return out;
+}
+
+function sfuTransportTimeout(timeline: MergedEvent[]): Finding[] {
+  const out: Finding[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind !== "sfu.transport.timeout") return;
+    out.push(
+      make("sfu-transport-timeout", { vantage: e.observer }, [i], {
+        direction: str(e.d, "direction"),
+      })
+    );
+  });
+  return out;
+}
+
+function sfuRoomSplit(timeline: MergedEvent[]): Finding[] {
+  interface State {
+    mismatchStart: number | null;
+    startIdx: number;
+    fired: boolean;
+  }
+  const voiceActive = new Map<string, Set<string>>();
+  const state = new Map<string, State>();
+  const out: Finding[] = [];
+
+  timeline.forEach((e, i) => {
+    if (e.peer && (e.kind === "voice.join" || e.kind === "voice.pc.new")) {
+      const set = voiceActive.get(e.observer) ?? new Set<string>();
+      set.add(e.peer);
+      voiceActive.set(e.observer, set);
+    } else if (e.peer && (e.kind === "voice.leave" || e.kind === "voice.teardown")) {
+      voiceActive.get(e.observer)?.delete(e.peer);
+    }
+
+    if (e.kind !== "sfu.diag") return;
+    const roomPeers = num(e.d, "roomPeers");
+    if (roomPeers === null) return;
+    // The observer's own voice roster, plus itself, is the call's peer count
+    // as libp2p sees it - the SFU's room count should agree with it.
+    const roster = (voiceActive.get(e.observer)?.size ?? 0) + 1;
+
+    const s: State = state.get(e.observer) ?? { mismatchStart: null, startIdx: -1, fired: false };
+    if (roster !== roomPeers) {
+      if (s.mismatchStart === null) {
+        s.mismatchStart = e.at;
+        s.startIdx = i;
+      } else if (!s.fired && e.at - s.mismatchStart > SFU_ROOM_SPLIT_MS) {
+        s.fired = true;
+        out.push(
+          make("sfu-room-split", { vantage: e.observer }, [s.startIdx, i], {
+            roster,
+            roomPeers,
+            sinceMs: e.at - s.mismatchStart,
+          })
+        );
+      }
+    } else {
+      s.mismatchStart = null;
+      s.fired = false;
+    }
+    state.set(e.observer, s);
+  });
+  return out;
+}
+
+function sfuPlacementDisagreement(c: Capture): Finding[] {
+  const clientObservers = new Set(
+    c.vantages.filter((v) => v.kind === "client").map((v) => v.observer)
+  );
+  const lastHost = new Map<string, { host: string; idx: number }>();
+  c.timeline.forEach((e, i) => {
+    if (e.kind !== "sfu.pick" || !clientObservers.has(e.observer)) return;
+    const host = str(e.d, "host");
+    if (host) lastHost.set(e.observer, { host, idx: i });
+  });
+
+  const entries = [...lastHost.entries()];
+  const out: Finding[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const [obsA, a] = entries[i];
+      const [obsB, b] = entries[j];
+      if (a.host !== b.host) {
+        out.push(
+          make("sfu-placement-disagreement", { pair: [obsA, obsB] }, [a.idx, b.idx], {
+            hostA: a.host,
+            hostB: b.host,
+          })
+        );
+      }
+    }
+  }
+  return out;
+}
+
+function clockSkew(c: Capture): Finding[] {
+  if (c.maxSkewResidualMs <= MAX_ACCEPTABLE_SKEW_MS) return [];
+  return [
+    make("clock-skew", {}, [], {
+      residualMs: Math.round(c.maxSkewResidualMs),
+      thresholdMs: MAX_ACCEPTABLE_SKEW_MS,
+    }),
+  ];
+}
+
+function faultInjectionActive(c: Capture): Finding[] {
+  const evidence: number[] = [];
+  c.timeline.forEach((e, i) => {
+    if (e.kind === "fault.injected") evidence.push(i);
+  });
+  const activeSources = c.vantages
+    .filter((v) => v.bundle?.meta.faultsActive === true)
+    .map((v) => v.source);
+  if (evidence.length === 0 && activeSources.length === 0) return [];
+  return [
+    make("fault-injection-active", {}, evidence, {
+      activeSources: activeSources.length > 0 ? activeSources.join(",") : null,
+      injectedEvents: evidence.length,
+    }),
+  ];
+}
+
+function unconfiguredInstance(timeline: MergedEvent[]): Finding[] {
+  const out: Finding[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind !== "session.config") return;
+    if (bool(e.d, "configured") === false) {
+      out.push(make("unconfigured-instance", { vantage: e.observer }, [i], {}));
+    }
+  });
+  return out;
+}
+
+function storageLockedWrites(timeline: MergedEvent[]): Finding[] {
+  const out: Finding[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind !== "storage.locked") return;
+    out.push(make("storage-locked-writes", { vantage: e.observer }, [i], { what: str(e.d, "what") }));
+  });
+  return out;
+}
+
+function captureIncomplete(c: Capture): Finding[] {
+  const evidence: number[] = [];
+  c.timeline.forEach((e, i) => {
+    if (e.kind === "meta.suppressed") evidence.push(i);
+  });
+  let droppedTotal = 0;
+  let suppressedKinds = 0;
+  for (const v of c.vantages) {
+    if (!v.bundle) continue;
+    droppedTotal += v.bundle.meta.dropped;
+    suppressedKinds += Object.keys(v.bundle.meta.suppressed).length;
+  }
+  if (evidence.length === 0 && droppedTotal === 0 && suppressedKinds === 0) return [];
+  return [make("capture-incomplete", {}, evidence, { droppedTotal, suppressedKinds })];
+}
+
+function relayCloseUnclean(timeline: MergedEvent[]): Finding[] {
+  const out: Finding[] = [];
+  timeline.forEach((e, i) => {
+    if (e.kind !== "rv.close" || e.vantage !== "relay") return;
+    const reason = str(e.d, "reason");
+    if (reason && reason !== "graceful") {
+      out.push(make("relay-close-unclean", { vantage: e.observer }, [i], { reason }));
+    }
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point.
+// ---------------------------------------------------------------------------
+
+const SEVERITY_RANK: Record<Rule["severity"], number> = { block: 0, warn: 1, info: 2 };
+
+export function runFindings(c: Capture): Finding[] {
+  const timeline = c.timeline;
+  if (timeline.length === 0) return [];
+
+  const findings: Finding[] = [
+    ...unmatchedDeadlineFindings(
+      timeline,
+      "relay.reservation.request",
+      ["relay.reservation.ok"],
+      RESERVATION_COMPLETE_DEADLINE_MS,
+      "observer",
+      "relay-reservation-never-completed"
+    ),
+    ...failStreakFindings(
+      timeline,
+      "relay.dial.ok",
+      "relay.dial.fail",
+      DIAL_FAIL_STREAK_THRESHOLD,
+      "relay-unreachable"
+    ),
+    ...windowedThreshold(
+      timeline,
+      "relay.disconnect",
+      RELAY_FLAP_MIN_COUNT,
+      FLAP_WINDOW_MS,
+      "relay-flapping",
+      "observer"
+    ),
+    ...rendezvousWedged(timeline),
+    ...turnMissingAndNeeded(timeline),
+    ...unmatchedDeadlineFindings(
+      timeline,
+      "peer.connect",
+      ["stream.proven"],
+      PROOF_DEADLINE_MS,
+      "observer+peer",
+      "connected-not-proven"
+    ),
+    ...asymmetricLink(c),
+    ...thresholdByPeerObserver(timeline, "peer.upgrade.fail", UPGRADE_FAIL_THRESHOLD, "upgrade-starved"),
+    ...windowedThreshold(
+      timeline,
+      "peer.drop.liveness",
+      LIVENESS_FLAP_MIN_COUNT,
+      FLAP_WINDOW_MS,
+      "liveness-flap",
+      "observer+peer"
+    ),
+    ...thresholdByPeerObserver(
+      timeline,
+      "stream.confirm.fail",
+      CONFIRM_FAIL_THRESHOLD,
+      "stream-confirm-starved"
+    ),
+    ...roomViewSplit(timeline),
+    ...messageRejected(timeline),
+    ...syncStalled(timeline),
+    ...unmatchedDeadlineFindings(
+      timeline,
+      "voice.pc.new",
+      ["voice.ice.connected"],
+      VOICE_SETUP_DEADLINE_MS,
+      "observer+peer",
+      "voice-never-connected"
+    ),
+    ...unmatchedDeadlineFindings(
+      timeline,
+      "voice.media.stall",
+      ["voice.media.resume"],
+      Infinity,
+      "observer+peer",
+      "voice-media-stalled"
+    ),
+    ...voiceRelayedOnly(timeline),
+    ...thresholdByPeerObserver(
+      timeline,
+      "voice.restart",
+      VOICE_RESTART_LOOP_THRESHOLD,
+      "voice-restart-loop"
+    ),
+    ...sfuSessionLatched(timeline),
+    ...sfuTransportTimeout(timeline),
+    ...thresholdByObserver(timeline, "sfu.rejoin", SFU_REJOIN_LOOP_THRESHOLD, "sfu-rejoin-loop"),
+    ...thresholdByPeerObserver(
+      timeline,
+      "sfu.track.stalled",
+      SFU_CONSUMER_STALL_THRESHOLD,
+      "sfu-consumer-stalled"
+    ),
+    ...sfuRoomSplit(timeline),
+    ...sfuPlacementDisagreement(c),
+    ...clockSkew(c),
+    ...faultInjectionActive(c),
+    ...unconfiguredInstance(timeline),
+    ...storageLockedWrites(timeline),
+    ...captureIncomplete(c),
+    ...relayCloseUnclean(timeline),
+  ];
+
+  return findings
+    .map((f, i) => ({ f, i }))
+    .sort((a, b) => SEVERITY_RANK[a.f.severity] - SEVERITY_RANK[b.f.severity] || a.i - b.i)
+    .map((x) => x.f);
+}

--- a/dashboard/src/lib/analysis/findings.ts
+++ b/dashboard/src/lib/analysis/findings.ts
@@ -592,6 +592,37 @@ function producerNeverConsumed(c: Capture, timeline: MergedEvent[]): Finding[] {
   return out;
 }
 
+/**
+ * The one verdict in this table that does not depend on the app being correct.
+ *
+ * `probeTurn` asks the TURN server for an allocation over a connection that
+ * uses no transport code, no signalling and no peer, so a failure here is the
+ * network and nothing else. Its true value is the opposite case: a probe that
+ * PASSED, next to voice that never connected, removes the network from the
+ * list of suspects entirely - which no other event in this bundle can do.
+ */
+function turnUnreachable(timeline: MergedEvent[]): Finding[] {
+  const byObserver = new Map<string, number[]>();
+  timeline.forEach((e, i) => {
+    if (e.kind !== "ice.turn.fail") return;
+    if (str(e.d, "branch") !== "allocate") return;
+    const list = byObserver.get(e.observer);
+    if (list) list.push(i);
+    else byObserver.set(e.observer, [i]);
+  });
+  const out: Finding[] = [];
+  for (const [observer, evidence] of byObserver) {
+    const last = timeline[evidence[evidence.length - 1]];
+    out.push(
+      make("turn-unreachable", { vantage: observer }, evidence, {
+        attempts: evidence.length,
+        outcome: str(last.d, "outcome") ?? "",
+      })
+    );
+  }
+  return out;
+}
+
 /** Per-`(observer, peer)` proof transitions, in time order. */
 function provenTransitions(timeline: MergedEvent[]): Map<string, Array<{ at: number; proven: boolean }>> {
   const map = new Map<string, Array<{ at: number; proven: boolean }>>();
@@ -966,6 +997,7 @@ export function runFindings(c: Capture): Finding[] {
     ...relayCloseUnclean(timeline),
     ...peerConnectionLeak(timeline),
     ...producerNeverConsumed(c, timeline),
+    ...turnUnreachable(timeline),
     ...thresholdByObserver(timeline, "runtime.error", 1, "uncaught-error"),
   ];
 

--- a/dashboard/src/lib/analysis/fixtures/README.md
+++ b/dashboard/src/lib/analysis/fixtures/README.md
@@ -1,0 +1,70 @@
+# Captured fixtures
+
+Real data, produced by the real code. The rule engine must be validated
+against what the app actually emits: a hand-built fixture only proves the
+engine agrees with itself.
+
+Every file here came from one local capture session on 2026-09-01.
+
+| File | Vantage | How |
+| --- | --- | --- |
+| `client-a-stapled.json` | client + relay | Peer A's bundle, exported and uploaded from **Settings > Diagnostics**, with the relay's own vantage stapled at ingest. Read back through `GET /telemetry/get`. |
+| `client-b-stapled.json` | client + relay | The same, from Peer B, a separate browser profile in the same room. |
+| `sfu-snapshot.json` | sfu | A real `ms:diag` reply from a real mediasoup router, two peers in one room, one producing audio. Captured by `sfu/scripts/capture-sfu-vantage.ts`. |
+| `sfu-telemetry.log` | sfu | The `[sfu-telemetry]` sweep line the same SFU printed for the same room. |
+| `relay.log` | relay | The relay's own stdout for the same session, including the new `reason=` on every stream close. |
+
+## The one substitution
+
+`relay.log` had its room code replaced by the literal `ROOMCODEFIXTURE`.
+
+The SFU and the relay log full peer ids and room codes in clear - that is the
+established precedent for an operator's own container log, and `logs.ts` is
+the one place a room code can enter the dashboard. A committed fixture is not
+an operator's private log, so the code does not belong in the repository. The
+substitution changes nothing the parsers read: `parseRelayLog` matches the
+line shape and captures whatever the bracket holds.
+
+Peer id suffixes (`TBsh4Aqx`, `SH4gDmtC`) are REAL and must stay real. They
+are what `resolveSuffix` resolves against the full ids in the two bundles, and
+a fake suffix would make that test prove nothing.
+
+`sfu-telemetry.log` keeps its room name (`fixturecapture01`): the capture
+script chose it, so it never named a real room.
+
+## What the capture did
+
+1. A relay with `TELEMETRY_ENABLED=1` and `TELEMETRY_ADMIN_TOKEN=dev`, an SFU
+   with `SFU_TELEMETRY=1`, and `pnpm dev` for the app.
+2. Two browser profiles, one identity each, both in one room, one real
+   message sent between them.
+3. `window.__faults.set({ blockWebrtcDial: true })` in Peer A, so a direct
+   upgrade cannot complete and the pair stays on a relay circuit.
+4. The relay was restarted mid-session. That was not planned, and it is the
+   most useful part of the capture: it produced real `relay.disconnect`,
+   `relay.reconnect.schedule`, `rv.close` and re-registration events.
+5. Both peers uploaded from the Diagnostics pane. Both bundles were read back
+   through the operator endpoint.
+
+## Regenerating
+
+```sh
+# relay, from a checkout, with a writable data dir
+TELEMETRY_ENABLED=1 TELEMETRY_ADMIN_TOKEN=dev TELEMETRY_DIR=/tmp/awful-telemetry go run ./relay
+
+# sfu
+cd sfu && SFU_TELEMETRY=1 npx tsx index.ts
+
+# app, pointed at the relay's printed multiaddr
+cd frontend && VITE_API_URL=http://localhost:8081 \
+  VITE_RELAY_MULTIADDR=/ip4/127.0.0.1/tcp/8080/ws/p2p/<id> pnpm dev
+
+# the sfu vantage
+cd sfu && npx tsx scripts/capture-sfu-vantage.ts
+```
+
+Then follow the five steps above and copy the two bundles out through
+`GET /telemetry/list` and `GET /telemetry/get`.
+
+Note: the relay hardcodes `/app/data` for its key. A local run needs that path
+to exist, or a dev-only override.

--- a/dashboard/src/lib/analysis/fixtures/client-a-stapled.json
+++ b/dashboard/src/lib/analysis/fixtures/client-a-stapled.json
@@ -1,0 +1,2863 @@
+{
+    "app": {
+        "version": "0.0.0",
+        "commit": "aba5bbc"
+    },
+    "bundleId": "ed7af73e78e922a8e97ea2e6dbf2620b",
+    "config": {
+        "apiHost": "localhost:8081",
+        "relayPeerId": "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD",
+        "sfuHosts": [
+            "localhost:3000"
+        ],
+        "configured": true
+    },
+    "counters": {
+        "t.identifies": 3,
+        "t.connects": 3,
+        "t.disconnects": 0,
+        "t.relayUpgradeAttempts": 0,
+        "t.relayUpgrades": 0,
+        "t.livenessDrops": 0,
+        "t.outboundResets": 0,
+        "t.liveStreamOpens": 1,
+        "t.dialStreamOpens": 1,
+        "t.openFailures": 0,
+        "t.confirmFailures": 0,
+        "t.framesOut": 67,
+        "t.framesIn": 90,
+        "t.pingsIn": 26,
+        "t.pongsIn": 12,
+        "t.suppressedStreamErrors": 0,
+        "a.profilesOut": 11,
+        "a.profilesIn": 7,
+        "a.profilesRejected": 0,
+        "a.digestsOut": 16,
+        "a.digestsIn": 38,
+        "f.droppedFrames": 0,
+        "f.blockedDials": 1,
+        "f.suppressedEvents": 0
+    },
+    "createdAt": 1788234084637,
+    "env": {
+        "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36"
+    },
+    "events": [
+        {
+            "kind": "session.start",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "bus": "main"
+            },
+            "seq": 1,
+            "t": 0
+        },
+        {
+            "kind": "session.config",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "selfId": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+                "relayPeerId": "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD",
+                "configured": true
+            },
+            "seq": 2,
+            "t": 30
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 3,
+            "t": 36
+        },
+        {
+            "kind": "session.config",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "d": {
+                "warning": true
+            },
+            "seq": 4,
+            "t": 51
+        },
+        {
+            "kind": "relay.dial.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 5,
+            "t": 84
+        },
+        {
+            "kind": "relay.reservation.request",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 6,
+            "t": 84
+        },
+        {
+            "kind": "relay.reservation.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "circuit": true
+            },
+            "seq": 7,
+            "t": 99
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "a.profilesOut": 1
+            },
+            "seq": 8,
+            "t": 13289
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 9,
+            "t": 20041
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 10,
+            "t": 40044
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 11,
+            "t": 60049
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 12,
+            "t": 74535
+        },
+        {
+            "kind": "app.join",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 13,
+            "t": 74543
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 0
+            },
+            "seq": 14,
+            "t": 74579
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "a.profilesOut": 2
+            },
+            "seq": 15,
+            "t": 78289
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 16,
+            "t": 80054
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 17,
+            "t": 100062
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 18,
+            "t": 120069
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 19,
+            "t": 140097
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 20,
+            "t": 160102
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 21,
+            "t": 180106
+        },
+        {
+            "kind": "peer.dial.start",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "attempt": 0,
+                "viaWebrtc": true
+            },
+            "seq": 22,
+            "t": 192911
+        },
+        {
+            "kind": "peer.dial.fail",
+            "sev": "error",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "form": "webrtc",
+                "err": "Error: webrtc dial blocked"
+            },
+            "seq": 23,
+            "t": 192912
+        },
+        {
+            "kind": "peer.relayed",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 24,
+            "t": 192981
+        },
+        {
+            "kind": "peer.connect",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 25,
+            "t": 192981
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 26,
+            "t": 193559
+        },
+        {
+            "kind": "peer.connect",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 27,
+            "t": 193565
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.identifies": 2,
+                "t.connects": 2,
+                "t.dialStreamOpens": 1,
+                "t.framesOut": 1,
+                "a.profilesOut": 1,
+                "a.digestsOut": 1,
+                "f.blockedDials": 1
+            },
+            "seq": 28,
+            "t": 193567
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 29,
+            "t": 193570
+        },
+        {
+            "kind": "stream.proven",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 30,
+            "t": 193571
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 70
+            },
+            "seq": 31,
+            "t": 193573
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 128
+            },
+            "seq": 32,
+            "t": 193574
+        },
+        {
+            "kind": "app.roomusers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 33,
+            "t": 193574
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 335
+            },
+            "seq": 34,
+            "t": 193574
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 35,
+            "t": 193577
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 65
+            },
+            "seq": 36,
+            "t": 193578
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 37,
+            "t": 193578
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 70
+            },
+            "seq": 38,
+            "t": 193578
+        },
+        {
+            "kind": "app.roomusers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 39,
+            "t": 193579
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 40,
+            "t": 193580
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 41,
+            "t": 193580
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 42,
+            "t": 193583
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 43,
+            "t": 193592
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 44,
+            "t": 193593
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 45,
+            "t": 193596
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 46,
+            "t": 193601
+        },
+        {
+            "kind": "peer.direct",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 47,
+            "t": 193646
+        },
+        {
+            "kind": "peer.connect",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 48,
+            "t": 193654
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 49,
+            "t": 193655
+        },
+        {
+            "kind": "app.roomusers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 2
+            },
+            "seq": 50,
+            "t": 193657
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 51,
+            "t": 193661
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 52,
+            "t": 193662
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 53,
+            "t": 193665
+        },
+        {
+            "kind": "meta.suppressed",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "app.msg.in": 12
+            },
+            "seq": 54,
+            "t": 198293
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.identifies": 1,
+                "t.connects": 1,
+                "t.framesOut": 18,
+                "t.framesIn": 19,
+                "t.pingsIn": 1,
+                "t.pongsIn": 1,
+                "a.profilesOut": 6,
+                "a.profilesIn": 7,
+                "a.digestsOut": 3,
+                "a.digestsIn": 4
+            },
+            "seq": 55,
+            "t": 198293
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 56,
+            "t": 200115
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 57,
+            "t": 208288
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 65
+            },
+            "seq": 58,
+            "t": 217634
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 59,
+            "t": 217634
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 60,
+            "t": 218291
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 61,
+            "t": 220119
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 62,
+            "t": 223289
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 556
+            },
+            "seq": 63,
+            "t": 223461
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "bytes": 450
+            },
+            "seq": 64,
+            "t": 223485
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1
+            },
+            "seq": 65,
+            "t": 228293
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 66,
+            "t": 232632
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 67,
+            "t": 232632
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 68,
+            "t": 233290
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 69,
+            "t": 238291
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 70,
+            "t": 240125
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 71,
+            "t": 247636
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 72,
+            "t": 247637
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 73,
+            "t": 248289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 74,
+            "t": 253288
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 75,
+            "t": 260138
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 76,
+            "t": 262630
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 77,
+            "t": 262630
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 78,
+            "t": 263293
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 79,
+            "t": 268292
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 80,
+            "t": 277630
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 81,
+            "t": 277630
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 82,
+            "t": 278288
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 83,
+            "t": 280144
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 84,
+            "t": 283293
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 85,
+            "t": 292635
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 86,
+            "t": 292637
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 87,
+            "t": 293294
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 88,
+            "t": 298291
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 89,
+            "t": 300151
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 90,
+            "t": 307635
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 91,
+            "t": 307635
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 92,
+            "t": 308293
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 93,
+            "t": 313289
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 94,
+            "t": 320167
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 95,
+            "t": 322634
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 96,
+            "t": 322634
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 97,
+            "t": 323289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 98,
+            "t": 328292
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 99,
+            "t": 337645
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 100,
+            "t": 337645
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 101,
+            "t": 338289
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 102,
+            "t": 340171
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 103,
+            "t": 343292
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 104,
+            "t": 352631
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 105,
+            "t": 352631
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 106,
+            "t": 353292
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 107,
+            "t": 358293
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 108,
+            "t": 360178
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 109,
+            "t": 367632
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 110,
+            "t": 367632
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 111,
+            "t": 368288
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 112,
+            "t": 373292
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 113,
+            "t": 380187
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 114,
+            "t": 382642
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 115,
+            "t": 382643
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 116,
+            "t": 383297
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 117,
+            "t": 388295
+        },
+        {
+            "kind": "rv.close",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "seq": 118,
+            "t": 390592
+        },
+        {
+            "kind": "rv.open",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "d": {
+                "reconnecting": true
+            },
+            "seq": 119,
+            "t": 390593
+        },
+        {
+            "kind": "stream.lost",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 120,
+            "t": 390593
+        },
+        {
+            "kind": "relay.disconnect",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 121,
+            "t": 390594
+        },
+        {
+            "kind": "relay.reconnect.schedule",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 122,
+            "t": 390594
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 123,
+            "t": 397638
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 124,
+            "t": 397638
+        },
+        {
+            "kind": "stream.proven",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "seq": 125,
+            "t": 397638
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.liveStreamOpens": 1,
+                "t.framesOut": 3,
+                "t.framesIn": 4,
+                "t.pingsIn": 2,
+                "t.pongsIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 126,
+            "t": 398291
+        },
+        {
+            "kind": "ice.turn.unavailable",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "no-secret",
+                "status": 204
+            },
+            "seq": 127,
+            "t": 400214
+        },
+        {
+            "kind": "rv.open.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "seq": 128,
+            "t": 402601
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 129,
+            "t": 412637
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 130,
+            "t": 412639
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 2,
+                "t.pongsIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 131,
+            "t": 413291
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 132,
+            "t": 427630
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 133,
+            "t": 427630
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 2,
+                "t.pongsIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 134,
+            "t": 428293
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 135,
+            "t": 442636
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 136,
+            "t": 442636
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 2,
+                "t.pongsIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 137,
+            "t": 443293
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 138,
+            "t": 457635
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 139,
+            "t": 457636
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 2,
+                "t.pongsIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 140,
+            "t": 458293
+        },
+        {
+            "kind": "relay.dial.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 141,
+            "t": 467643
+        },
+        {
+            "kind": "relay.reservation.request",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 142,
+            "t": 467643
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 143,
+            "t": 467650
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 144,
+            "t": 467651
+        },
+        {
+            "kind": "relay.reservation.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "circuit": true
+            },
+            "seq": 145,
+            "t": 467655
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 146,
+            "t": 467656
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 147,
+            "t": 467657
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 148,
+            "t": 467658
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 149,
+            "t": 467658
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 150,
+            "t": 467659
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 151,
+            "t": 467660
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 152,
+            "t": 467667
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 153,
+            "t": 467667
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 154,
+            "t": 467668
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 155,
+            "t": 467668
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 156,
+            "t": 467672
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 157,
+            "t": 467672
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 4,
+                "t.framesIn": 2,
+                "a.digestsOut": 4,
+                "a.digestsIn": 2
+            },
+            "seq": 158,
+            "t": 468289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 159,
+            "t": 483289
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 160,
+            "t": 487632
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 161,
+            "t": 487633
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 162,
+            "t": 488290
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 163,
+            "t": 498293
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 164,
+            "t": 502633
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 165,
+            "t": 502633
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 166,
+            "t": 503292
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 167,
+            "t": 513289
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 168,
+            "t": 517636
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 169,
+            "t": 517636
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 170,
+            "t": 518292
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 171,
+            "t": 528292
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 172,
+            "t": 532632
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 173,
+            "t": 532632
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 174,
+            "t": 533288
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 175,
+            "t": 543289
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 176,
+            "t": 547633
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 177,
+            "t": 547633
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 178,
+            "t": 548289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 179,
+            "t": 558292
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 180,
+            "t": 562635
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 181,
+            "t": 562635
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 182,
+            "t": 563290
+        },
+        {
+            "kind": "rv.close",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "seq": 183,
+            "t": 563879
+        },
+        {
+            "kind": "rv.open",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "d": {
+                "reconnecting": true
+            },
+            "seq": 184,
+            "t": 563881
+        },
+        {
+            "kind": "relay.disconnect",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 185,
+            "t": 563882
+        },
+        {
+            "kind": "relay.reconnect.schedule",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 186,
+            "t": 563883
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 187,
+            "t": 573292
+        },
+        {
+            "kind": "rv.open.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "seq": 188,
+            "t": 575889
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 189,
+            "t": 577632
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 190,
+            "t": 577632
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 191,
+            "t": 578289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 192,
+            "t": 588291
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 193,
+            "t": 592633
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 194,
+            "t": 592633
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 195,
+            "t": 593293
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 196,
+            "t": 603290
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 197,
+            "t": 607633
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 198,
+            "t": 607633
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 199,
+            "t": 608289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 200,
+            "t": 618290
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 201,
+            "t": 622639
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 202,
+            "t": 622639
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 203,
+            "t": 623288
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 204,
+            "t": 633290
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 205,
+            "t": 637636
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 206,
+            "t": 637636
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 207,
+            "t": 638290
+        },
+        {
+            "kind": "relay.dial.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 208,
+            "t": 640924
+        },
+        {
+            "kind": "relay.reservation.request",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 209,
+            "t": 640924
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 210,
+            "t": 640939
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 211,
+            "t": 640941
+        },
+        {
+            "kind": "relay.reservation.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "circuit": true
+            },
+            "seq": 212,
+            "t": 640943
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 213,
+            "t": 640945
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 214,
+            "t": 640945
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 215,
+            "t": 640945
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 216,
+            "t": 640945
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 217,
+            "t": 640945
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 218,
+            "t": 640947
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 219,
+            "t": 640947
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 220,
+            "t": 640948
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 221,
+            "t": 640954
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 222,
+            "t": 640954
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 223,
+            "t": 640954
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 224,
+            "t": 640954
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 225,
+            "t": 640954
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 226,
+            "t": 640957
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 3,
+                "t.framesIn": 4,
+                "a.digestsOut": 3,
+                "a.digestsIn": 4
+            },
+            "seq": 227,
+            "t": 643289
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 228,
+            "t": 658289
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 229,
+            "t": 658290
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 230,
+            "t": 663293
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 231,
+            "t": 673290
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 232,
+            "t": 673292
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 233,
+            "t": 678290
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 234,
+            "t": 688290
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 235,
+            "t": 688291
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 236,
+            "t": 693292
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 237,
+            "t": 703294
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 238,
+            "t": 703296
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 239,
+            "t": 708291
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 240,
+            "t": 718297
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 241,
+            "t": 718299
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 242,
+            "t": 723289
+        }
+    ],
+    "meta": {
+        "ringCapacity": 4096,
+        "dropped": 0,
+        "suppressed": {
+            "app.msg.in": 12
+        },
+        "faultsActive": true,
+        "truncated": false
+    },
+    "peers": [
+        {
+            "peerId": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+            "identityRef": "i1",
+            "firstSeen": 192911.3999999985,
+            "lastSeen": 718299.3999999985
+        }
+    ],
+    "relayView": {
+        "vantage": "relay",
+        "relayPeerId": "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD",
+        "observedPeerId": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+        "registry": {
+            "totalRegistrations": 2,
+            "streamsForPeer": 1,
+            "atTotalCap": false
+        },
+        "rooms": [
+            {
+                "ref": "h:0c81aaed1569",
+                "size": 2,
+                "members": [
+                    "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                    "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx"
+                ]
+            }
+        ],
+        "streams": [
+            {
+                "ref": "s18d11557cc51f9a0",
+                "openedAt": 1788233993877,
+                "closedAt": null,
+                "closeReason": null,
+                "rooms": 1,
+                "registers": 1,
+                "unregisters": 0,
+                "capped": 0,
+                "oracleSilenced": 0
+            }
+        ],
+        "events": [
+            {
+                "seq": 1,
+                "t": 1788233993856,
+                "kind": "rv.open",
+                "sev": "info",
+                "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+                "room": ""
+            },
+            {
+                "seq": 2,
+                "t": 1788233993872,
+                "kind": "rv.register",
+                "sev": "info",
+                "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+                "room": "h:0c81aaed1569"
+            },
+            {
+                "seq": 3,
+                "t": 1788233993877,
+                "kind": "rv.open",
+                "sev": "info",
+                "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+                "room": ""
+            },
+            {
+                "seq": 4,
+                "t": 1788233993879,
+                "kind": "rv.close",
+                "sev": "warn",
+                "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+                "room": "",
+                "d": {
+                    "reason": "read-error"
+                }
+            },
+            {
+                "seq": 5,
+                "t": 1788233993879,
+                "kind": "rv.register",
+                "sev": "info",
+                "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+                "room": "h:0c81aaed1569"
+            }
+        ]
+    },
+    "rooms": [
+        {
+            "ref": "r1",
+            "kind": "text",
+            "joinedAt": 1788233427459
+        }
+    ],
+    "schemaVersion": 1,
+    "self": {
+        "peerId": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx"
+    },
+    "sessionId": "9cbfb7df8c4a78f3db7e519923506dec",
+    "sfuSnapshots": [],
+    "startedAt": 1788233352924,
+    "vantage": "client"
+}

--- a/dashboard/src/lib/analysis/fixtures/client-b-stapled.json
+++ b/dashboard/src/lib/analysis/fixtures/client-b-stapled.json
@@ -1,0 +1,2657 @@
+{
+    "app": {
+        "version": "0.0.0",
+        "commit": "aba5bbc"
+    },
+    "bundleId": "975542516647d7257b27885c62ed859a",
+    "config": {
+        "apiHost": "localhost:8081",
+        "relayPeerId": "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD",
+        "sfuHosts": [
+            "localhost:3000"
+        ],
+        "configured": true
+    },
+    "counters": {
+        "t.identifies": 3,
+        "t.connects": 3,
+        "t.disconnects": 0,
+        "t.relayUpgradeAttempts": 0,
+        "t.relayUpgrades": 0,
+        "t.livenessDrops": 0,
+        "t.outboundResets": 1,
+        "t.liveStreamOpens": 1,
+        "t.dialStreamOpens": 2,
+        "t.openFailures": 0,
+        "t.confirmFailures": 0,
+        "t.framesOut": 96,
+        "t.framesIn": 79,
+        "t.pingsIn": 18,
+        "t.pongsIn": 26,
+        "t.suppressedStreamErrors": 0,
+        "a.profilesOut": 10,
+        "a.profilesIn": 7,
+        "a.profilesRejected": 0,
+        "a.digestsOut": 38,
+        "a.digestsIn": 22,
+        "f.droppedFrames": 0,
+        "f.blockedDials": 0,
+        "f.suppressedEvents": 0
+    },
+    "createdAt": 1788234172641,
+    "env": {
+        "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/152.0.0.0 Safari/537.36"
+    },
+    "events": [
+        {
+            "kind": "session.start",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "bus": "main"
+            },
+            "seq": 1,
+            "t": 0
+        },
+        {
+            "kind": "session.config",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "selfId": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                "relayPeerId": "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD",
+                "configured": true
+            },
+            "seq": 2,
+            "t": 25
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 3,
+            "t": 37
+        },
+        {
+            "kind": "session.config",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "d": {
+                "warning": true
+            },
+            "seq": 4,
+            "t": 63
+        },
+        {
+            "kind": "relay.dial.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 5,
+            "t": 78
+        },
+        {
+            "kind": "relay.reservation.request",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 6,
+            "t": 79
+        },
+        {
+            "kind": "relay.reservation.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "circuit": true
+            },
+            "seq": 7,
+            "t": 94
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 8,
+            "t": 20046
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 9,
+            "t": 36146
+        },
+        {
+            "kind": "app.join",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 10,
+            "t": 36151
+        },
+        {
+            "kind": "peer.dial.start",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "attempt": 0,
+                "viaWebrtc": true
+            },
+            "seq": 11,
+            "t": 36188
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 0
+            },
+            "seq": 12,
+            "t": 36189
+        },
+        {
+            "kind": "peer.relayed",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 13,
+            "t": 36221
+        },
+        {
+            "kind": "peer.connect",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 14,
+            "t": 36221
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 15,
+            "t": 36227
+        },
+        {
+            "kind": "peer.connect",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 16,
+            "t": 36242
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 17,
+            "t": 36807
+        },
+        {
+            "kind": "stream.proven",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 18,
+            "t": 36813
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 64
+            },
+            "seq": 19,
+            "t": 36815
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 128
+            },
+            "seq": 20,
+            "t": 36816
+        },
+        {
+            "kind": "app.roomusers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 21,
+            "t": 36816
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 335
+            },
+            "seq": 22,
+            "t": 36817
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 23,
+            "t": 36819
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 65
+            },
+            "seq": 24,
+            "t": 36820
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 25,
+            "t": 36820
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 64
+            },
+            "seq": 26,
+            "t": 36820
+        },
+        {
+            "kind": "app.roomusers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 27,
+            "t": 36821
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 28,
+            "t": 36823
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 29,
+            "t": 36823
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 30,
+            "t": 36824
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 31,
+            "t": 36830
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 32,
+            "t": 36830
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 33,
+            "t": 36832
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 34,
+            "t": 36836
+        },
+        {
+            "kind": "peer.direct",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 35,
+            "t": 36890
+        },
+        {
+            "kind": "peer.connect",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 36,
+            "t": 36897
+        },
+        {
+            "kind": "app.roomusers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 2
+            },
+            "seq": 37,
+            "t": 36899
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 38,
+            "t": 36900
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 39,
+            "t": 36901
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 40,
+            "t": 36902
+        },
+        {
+            "kind": "app.profile.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 41,
+            "t": 36906
+        },
+        {
+            "kind": "meta.suppressed",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "app.msg.in": 12
+            },
+            "seq": 42,
+            "t": 40051
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 43,
+            "t": 40051
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.identifies": 3,
+                "t.connects": 3,
+                "t.dialStreamOpens": 1,
+                "t.framesOut": 19,
+                "t.framesIn": 19,
+                "t.pingsIn": 1,
+                "t.pongsIn": 1,
+                "a.profilesOut": 9,
+                "a.profilesIn": 7,
+                "a.digestsOut": 4,
+                "a.digestsIn": 4
+            },
+            "seq": 44,
+            "t": 40869
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 45,
+            "t": 50870
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 46,
+            "t": 60059
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 0
+            },
+            "seq": 47,
+            "t": 60874
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 48,
+            "t": 65873
+        },
+        {
+            "kind": "app.msg.out",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "bytes": 450
+            },
+            "seq": 49,
+            "t": 66701
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1
+            },
+            "seq": 50,
+            "t": 70870
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 51,
+            "t": 75871
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 52,
+            "t": 80070
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 53,
+            "t": 80872
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 54,
+            "t": 90876
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 55,
+            "t": 95873
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 56,
+            "t": 100083
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 57,
+            "t": 105870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 58,
+            "t": 110869
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 59,
+            "t": 120088
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 60,
+            "t": 120870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 61,
+            "t": 125874
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 62,
+            "t": 135873
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 63,
+            "t": 140093
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 64,
+            "t": 140870
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 65,
+            "t": 150875
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 66,
+            "t": 155872
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 67,
+            "t": 160101
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 68,
+            "t": 165874
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 69,
+            "t": 170874
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 70,
+            "t": 180107
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 71,
+            "t": 180876
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 72,
+            "t": 185869
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 73,
+            "t": 195871
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 74,
+            "t": 200119
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 75,
+            "t": 200869
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 76,
+            "t": 210873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 77,
+            "t": 215872
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 78,
+            "t": 220135
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 79,
+            "t": 225881
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 1,
+                "t.pongsIn": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 80,
+            "t": 230871
+        },
+        {
+            "kind": "rv.close",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "seq": 81,
+            "t": 233833
+        },
+        {
+            "kind": "rv.open",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "d": {
+                "reconnecting": true
+            },
+            "seq": 82,
+            "t": 233833
+        },
+        {
+            "kind": "stream.lost",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 83,
+            "t": 233834
+        },
+        {
+            "kind": "relay.disconnect",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 84,
+            "t": 233835
+        },
+        {
+            "kind": "relay.reconnect.schedule",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 85,
+            "t": 233835
+        },
+        {
+            "kind": "ice.turn.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "threw",
+                "err": "TypeError: Failed to fetch"
+            },
+            "seq": 86,
+            "t": 240144
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 87,
+            "t": 240871
+        },
+        {
+            "kind": "stream.reset",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 88,
+            "t": 240876
+        },
+        {
+            "kind": "stream.proven",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "seq": 89,
+            "t": 240879
+        },
+        {
+            "kind": "rv.open.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "seq": 90,
+            "t": 245842
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.outboundResets": 1,
+                "t.liveStreamOpens": 1,
+                "t.dialStreamOpens": 1,
+                "t.framesOut": 4,
+                "t.framesIn": 3,
+                "t.pingsIn": 1,
+                "t.pongsIn": 2,
+                "a.digestsOut": 1
+            },
+            "seq": 91,
+            "t": 245874
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 92,
+            "t": 255874
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 93,
+            "t": 255877
+        },
+        {
+            "kind": "ice.turn.unavailable",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "d": {
+                "branch": "no-secret",
+                "status": 204
+            },
+            "seq": 94,
+            "t": 260154
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 95,
+            "t": 260870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 96,
+            "t": 270869
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 97,
+            "t": 270870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 98,
+            "t": 275870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 99,
+            "t": 285870
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 100,
+            "t": 285875
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 101,
+            "t": 290871
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 102,
+            "t": 300873
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 103,
+            "t": 300875
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 104,
+            "t": 305873
+        },
+        {
+            "kind": "relay.dial.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 105,
+            "t": 310885
+        },
+        {
+            "kind": "relay.reservation.request",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 106,
+            "t": 310886
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 107,
+            "t": 310898
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 108,
+            "t": 310900
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 109,
+            "t": 310900
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 110,
+            "t": 310902
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 111,
+            "t": 310902
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 112,
+            "t": 310902
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 113,
+            "t": 310903
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 114,
+            "t": 310903
+        },
+        {
+            "kind": "relay.reservation.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "circuit": true
+            },
+            "seq": 115,
+            "t": 310905
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 116,
+            "t": 310908
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 117,
+            "t": 310909
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 118,
+            "t": 310909
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 119,
+            "t": 310912
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 120,
+            "t": 310912
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 121,
+            "t": 310912
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 2,
+                "t.framesIn": 4,
+                "a.digestsOut": 2,
+                "a.digestsIn": 4
+            },
+            "seq": 122,
+            "t": 315870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 123,
+            "t": 325871
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 124,
+            "t": 330873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 125,
+            "t": 335869
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 126,
+            "t": 340872
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 127,
+            "t": 345873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 128,
+            "t": 350874
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 129,
+            "t": 355872
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 130,
+            "t": 360876
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 131,
+            "t": 365871
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 132,
+            "t": 370874
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 133,
+            "t": 375872
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 134,
+            "t": 380870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 135,
+            "t": 385872
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 136,
+            "t": 390873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 137,
+            "t": 395870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 138,
+            "t": 400872
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 139,
+            "t": 405875
+        },
+        {
+            "kind": "rv.close",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "seq": 140,
+            "t": 407120
+        },
+        {
+            "kind": "rv.open",
+            "sev": "warn",
+            "peer": null,
+            "room": null,
+            "d": {
+                "reconnecting": true
+            },
+            "seq": 141,
+            "t": 407122
+        },
+        {
+            "kind": "relay.disconnect",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 142,
+            "t": 407124
+        },
+        {
+            "kind": "relay.reconnect.schedule",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 143,
+            "t": 407124
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 144,
+            "t": 410872
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 145,
+            "t": 415872
+        },
+        {
+            "kind": "rv.open.fail",
+            "sev": "error",
+            "peer": null,
+            "room": null,
+            "seq": 146,
+            "t": 419126
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 147,
+            "t": 420872
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 148,
+            "t": 425873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 149,
+            "t": 430874
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 150,
+            "t": 435873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 151,
+            "t": 440869
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 152,
+            "t": 445874
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 153,
+            "t": 450873
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 154,
+            "t": 455872
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 155,
+            "t": 460870
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 156,
+            "t": 465877
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "a.digestsOut": 1
+            },
+            "seq": 157,
+            "t": 470870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pongsIn": 1
+            },
+            "seq": 158,
+            "t": 475873
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 159,
+            "t": 480876
+        },
+        {
+            "kind": "relay.dial.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 160,
+            "t": 484167
+        },
+        {
+            "kind": "relay.reservation.request",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "seq": 161,
+            "t": 484169
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 162,
+            "t": 484178
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 163,
+            "t": 484179
+        },
+        {
+            "kind": "relay.reservation.ok",
+            "sev": "info",
+            "peer": null,
+            "room": null,
+            "d": {
+                "circuit": true
+            },
+            "seq": 164,
+            "t": 484182
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 165,
+            "t": 484183
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 166,
+            "t": 484183
+        },
+        {
+            "kind": "rv.register",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "seq": 167,
+            "t": 484184
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 168,
+            "t": 484184
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 169,
+            "t": 484186
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 170,
+            "t": 484188
+        },
+        {
+            "kind": "rv.peers",
+            "sev": "info",
+            "peer": null,
+            "room": "r1",
+            "d": {
+                "count": 1
+            },
+            "seq": 171,
+            "t": 484189
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 172,
+            "t": 484189
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 173,
+            "t": 484189
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 174,
+            "t": 484189
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 175,
+            "t": 484189
+        },
+        {
+            "kind": "app.digest.out",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 176,
+            "t": 484190
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 177,
+            "t": 484199
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 178,
+            "t": 484199
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 5,
+                "t.framesIn": 3,
+                "a.digestsOut": 5,
+                "a.digestsIn": 3
+            },
+            "seq": 179,
+            "t": 485874
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 180,
+            "t": 500869
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 181,
+            "t": 501532
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 182,
+            "t": 501532
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 183,
+            "t": 505872
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 184,
+            "t": 515871
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 185,
+            "t": 516536
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 186,
+            "t": 516536
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 187,
+            "t": 520874
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 188,
+            "t": 530873
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 189,
+            "t": 531533
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 190,
+            "t": 531533
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 191,
+            "t": 535870
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 192,
+            "t": 545877
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 193,
+            "t": 546538
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 194,
+            "t": 546538
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 195,
+            "t": 550876
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 196,
+            "t": 560875
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 197,
+            "t": 561542
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 198,
+            "t": 561542
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 199,
+            "t": 565871
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 200,
+            "t": 575879
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 201,
+            "t": 576542
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 202,
+            "t": 576543
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 203,
+            "t": 580878
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 204,
+            "t": 590876
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 205,
+            "t": 591537
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 206,
+            "t": 591538
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 207,
+            "t": 595877
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 208,
+            "t": 605877
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 209,
+            "t": 606542
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 210,
+            "t": 606542
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 211,
+            "t": 610875
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 212,
+            "t": 620869
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 213,
+            "t": 621537
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 214,
+            "t": 621537
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 215,
+            "t": 625878
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 216,
+            "t": 635875
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 217,
+            "t": 636539
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 218,
+            "t": 636539
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 219,
+            "t": 640881
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesOut": 1,
+                "t.framesIn": 1,
+                "t.pingsIn": 1
+            },
+            "seq": 220,
+            "t": 650878
+        },
+        {
+            "kind": "app.msg.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": null,
+            "d": {
+                "bytes": 124
+            },
+            "seq": 221,
+            "t": 651542
+        },
+        {
+            "kind": "app.digest.in",
+            "sev": "info",
+            "peer": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "room": "r1",
+            "d": {
+                "watermarks": 1
+            },
+            "seq": 222,
+            "t": 651542
+        },
+        {
+            "kind": "counters",
+            "sev": "debug",
+            "peer": null,
+            "room": null,
+            "d": {
+                "t.framesIn": 1,
+                "a.digestsIn": 1
+            },
+            "seq": 223,
+            "t": 655878
+        }
+    ],
+    "meta": {
+        "ringCapacity": 4096,
+        "dropped": 0,
+        "suppressed": {
+            "app.msg.in": 12
+        },
+        "faultsActive": false,
+        "truncated": false
+    },
+    "peers": [
+        {
+            "peerId": "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx",
+            "identityRef": "i1",
+            "firstSeen": 36188,
+            "lastSeen": 651542
+        }
+    ],
+    "relayView": {
+        "vantage": "relay",
+        "relayPeerId": "12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD",
+        "observedPeerId": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+        "registry": {
+            "totalRegistrations": 2,
+            "streamsForPeer": 1,
+            "atTotalCap": false
+        },
+        "rooms": [
+            {
+                "ref": "h:0c81aaed1569",
+                "size": 2,
+                "members": [
+                    "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                    "12D3KooWEDgQn3CXpBD8fA6PHunKzgwfBv39zK3BkQWBTBsh4Aqx"
+                ]
+            }
+        ],
+        "streams": [
+            {
+                "ref": "s18d11557cc1e6a68",
+                "openedAt": 1788233993873,
+                "closedAt": null,
+                "closeReason": null,
+                "rooms": 1,
+                "registers": 1,
+                "unregisters": 0,
+                "capped": 0,
+                "oracleSilenced": 0
+            }
+        ],
+        "events": [
+            {
+                "seq": 1,
+                "t": 1788233993859,
+                "kind": "rv.open",
+                "sev": "info",
+                "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                "room": ""
+            },
+            {
+                "seq": 2,
+                "t": 1788233993870,
+                "kind": "rv.register",
+                "sev": "info",
+                "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                "room": "h:0c81aaed1569"
+            },
+            {
+                "seq": 3,
+                "t": 1788233993873,
+                "kind": "rv.open",
+                "sev": "info",
+                "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                "room": ""
+            },
+            {
+                "seq": 4,
+                "t": 1788233993875,
+                "kind": "rv.close",
+                "sev": "warn",
+                "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                "room": "",
+                "d": {
+                    "reason": "read-error"
+                }
+            },
+            {
+                "seq": 5,
+                "t": 1788233993875,
+                "kind": "rv.register",
+                "sev": "info",
+                "peer": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC",
+                "room": "h:0c81aaed1569"
+            }
+        ]
+    },
+    "rooms": [
+        {
+            "ref": "r1",
+            "kind": "text",
+            "joinedAt": 1788233545831
+        }
+    ],
+    "schemaVersion": 1,
+    "self": {
+        "peerId": "12D3KooWNQD8Z3CKkw1CSgCURpqkyYPVLxEn64fpPyaESH4gDmtC"
+    },
+    "sessionId": "4ec6ea5525ab493c286bd7e79f4f5e3c",
+    "sfuSnapshots": [],
+    "startedAt": 1788233509685,
+    "vantage": "client"
+}

--- a/dashboard/src/lib/analysis/fixtures/relay.log
+++ b/dashboard/src/lib/analysis/fixtures/relay.log
@@ -1,0 +1,35 @@
+2026/09/01 00:35:52 [relay] connection limits: connmgr 256/512, per-subnet cap 1024
+2026/09/01 00:35:52 PeerID: 12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD
+2026/09/01 00:35:52  /ip4/127.0.0.1/tcp/8080/ws/p2p/12D3KooWMM79wZwhXBK6yfwaFoGumZNRxrZVWdyc3eVzvyuEEgaD
+2026/09/01 00:35:52 [relay] this service must run as exactly ONE replica; see deploy/README.md
+2026/09/01 00:35:52 [http] Starting API server on port 8081
+2026/09/01 00:37:00 [peer] connect TBsh4Aqx
+2026/09/01 00:37:00 [peer] connect SH4gDmtC
+2026/09/01 00:37:00 [rv] TBsh4Aqx opened rendezvous stream
+2026/09/01 00:37:00 [rv] SH4gDmtC opened rendezvous stream
+2026/09/01 00:37:00 [rv] TBsh4Aqx joined room [ROOMCODEFIXTURE] (1 peers)
+2026/09/01 00:37:00 [rv] TBsh4Aqx opened rendezvous stream
+2026/09/01 00:37:00 [rv] TBsh4Aqx left room [ROOMCODEFIXTURE] (0 peers)
+2026/09/01 00:37:00 [rv] TBsh4Aqx stream closed (1 still open, reason=read-error)
+2026/09/01 00:37:00 [rv] TBsh4Aqx joined room [ROOMCODEFIXTURE] (1 peers)
+2026/09/01 00:37:00 [rv] SH4gDmtC joined room [ROOMCODEFIXTURE] (2 peers)
+2026/09/01 00:37:00 [rv] SH4gDmtC opened rendezvous stream
+2026/09/01 00:37:00 [rv] SH4gDmtC left room [ROOMCODEFIXTURE] (1 peers)
+2026/09/01 00:37:00 [rv] SH4gDmtC stream closed (1 still open, reason=read-error)
+2026/09/01 00:37:00 [rv] SH4gDmtC joined room [ROOMCODEFIXTURE] (2 peers)
+2026/09/01 00:38:41 [relay] connection limits: connmgr 256/512, per-subnet cap 1024
+2026/09/01 00:38:41 [http] Starting API server on port 8081
+2026/09/01 00:39:53 [peer] connect TBsh4Aqx
+2026/09/01 00:39:53 [peer] connect SH4gDmtC
+2026/09/01 00:39:53 [rv] TBsh4Aqx opened rendezvous stream
+2026/09/01 00:39:53 [rv] SH4gDmtC opened rendezvous stream
+2026/09/01 00:39:53 [rv] SH4gDmtC joined room [ROOMCODEFIXTURE] (1 peers)
+2026/09/01 00:39:53 [rv] TBsh4Aqx joined room [ROOMCODEFIXTURE] (2 peers)
+2026/09/01 00:39:53 [rv] SH4gDmtC opened rendezvous stream
+2026/09/01 00:39:53 [rv] SH4gDmtC left room [ROOMCODEFIXTURE] (1 peers)
+2026/09/01 00:39:53 [rv] SH4gDmtC stream closed (1 still open, reason=read-error)
+2026/09/01 00:39:53 [rv] SH4gDmtC joined room [ROOMCODEFIXTURE] (2 peers)
+2026/09/01 00:39:53 [rv] TBsh4Aqx opened rendezvous stream
+2026/09/01 00:39:53 [rv] TBsh4Aqx left room [ROOMCODEFIXTURE] (1 peers)
+2026/09/01 00:39:53 [rv] TBsh4Aqx stream closed (1 still open, reason=read-error)
+2026/09/01 00:39:53 [rv] TBsh4Aqx joined room [ROOMCODEFIXTURE] (2 peers)

--- a/dashboard/src/lib/analysis/fixtures/sfu-snapshot.json
+++ b/dashboard/src/lib/analysis/fixtures/sfu-snapshot.json
@@ -1,0 +1,57 @@
+{
+ "schemaVersion": 1,
+ "takenAt": 1788234314587,
+ "roomPeerCount": 2,
+ "self": {
+  "peerId": "capture-peer-a",
+  "transports": [
+   {
+    "dir": "send",
+    "iceState": "new",
+    "dtlsState": "new",
+    "tuple": null,
+    "bytesSent": 0,
+    "bytesReceived": 0,
+    "rtt": null
+   }
+  ],
+  "producers": [
+   {
+    "id": "20ad9aff-ed40-49c8-a747-086c07d0192b",
+    "kind": "audio",
+    "source": "camera",
+    "score": 0,
+    "consumers": 0,
+    "bitrate": 0,
+    "packetsLost": 0
+   }
+  ],
+  "consumers": [],
+  "cumulativeProduces": 1,
+  "backpressured": false
+ },
+ "room": [
+  {
+   "peerId": "capture-peer-a",
+   "producers": [
+    {
+     "id": "20ad9aff-ed40-49c8-a747-086c07d0192b",
+     "source": "camera",
+     "kind": "audio",
+     "consumers": 0
+    }
+   ]
+  },
+  {
+   "peerId": "capture-peer-b",
+   "producers": []
+  }
+ ],
+ "ceilings": {
+  "peersPerRoom": 32,
+  "producersPerPeer": 8,
+  "consumersPerPeer": 256,
+  "rooms": 1,
+  "maxRooms": 250
+ }
+}

--- a/dashboard/src/lib/analysis/fixtures/sfu-telemetry.log
+++ b/dashboard/src/lib/analysis/fixtures/sfu-telemetry.log
@@ -1,0 +1,1 @@
+[sfu-telemetry] {"v":1,"t":1788234311057,"room":"fixturecapture01","peers":[{"peerId":"capture-peer-a","producers":[{"id":"20ad9aff-ed40-49c8-a747-086c07d0192b","source":"camera","kind":"audio","consumers":0}],"send":{"iceState":"new","dtlsState":"new"},"recv":null},{"peerId":"capture-peer-b","producers":[],"send":null,"recv":null}]}

--- a/dashboard/src/lib/analysis/logs.test.ts
+++ b/dashboard/src/lib/analysis/logs.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseConsoleLog,
+  parseRelayLog,
+  parseSfuLog,
+  parseSfuTelemetry,
+  resolveSuffix,
+} from "./logs";
+
+const TS = "2026-09-01T02:03:04.500000000Z";
+const TS_MS = Date.parse("2026-09-01T02:03:04.500Z");
+
+function withTs(line: string): string {
+  return `${TS} ${line}`;
+}
+
+// ---------------------------------------------------------------------------
+// parseSfuLog - one real sample line per template, verbatim from sfu/index.ts
+// ---------------------------------------------------------------------------
+
+interface Case {
+  line: string;
+  kind: string;
+  peer?: string | null;
+  d?: Record<string, unknown>;
+}
+
+const SFU_CASES: Case[] = [
+  { line: "[sfu] join with invalid roomCode or peerId, closing", kind: "sfu.join", d: { reason: "invalid-ids" } },
+  {
+    line: "[sfu] room ceiling reached (64); refusing new room room-9f3a",
+    kind: "sfu.join",
+    d: { reason: "server-full", maxRooms: 64, roomRaw: "room-9f3a" },
+  },
+  {
+    line: "[sfu] room room-9f3a is at the peer ceiling (32); refusing peer peer-b",
+    kind: "sfu.join",
+    peer: "peer-b",
+    d: { reason: "room-full", roomRaw: "room-9f3a", maxPeers: 32 },
+  },
+  {
+    line: "[sfu] duplicate peerId peer-a in room room-9f3a answered a liveness probe; refusing the new connection",
+    kind: "sfu.join",
+    peer: "peer-a",
+    d: { reason: "peer-id-in-use", phase: "liveness-probe", roomRaw: "room-9f3a" },
+  },
+  {
+    line: "[sfu] peerId peer-a in room room-9f3a was claimed while probing; refusing the new connection",
+    kind: "sfu.join",
+    peer: "peer-a",
+    d: { reason: "peer-id-in-use", phase: "claimed-while-probing", roomRaw: "room-9f3a" },
+  },
+  {
+    line: "[sfu] duplicate peerId peer-a in room room-9f3a; the previous session is dead, replacing it",
+    kind: "sfu.join",
+    peer: "peer-a",
+    d: { reason: "replaced-dead-session", roomRaw: "room-9f3a" },
+  },
+  {
+    line: "[sfu] peer peer-a joined room room-9f3a",
+    kind: "sfu.join",
+    peer: "peer-a",
+    d: { roomRaw: "room-9f3a" },
+  },
+  {
+    line: "[sfu] create-transport: bad direction from peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "bad-direction", op: "create-transport" },
+  },
+  {
+    line: "[sfu] create-transport: a send transport is already being created for peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "duplicate-transport-creating", direction: "send" },
+  },
+  {
+    line: "[sfu] duplicate recv transport for peer peer-a; closing the previous one",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "duplicate-transport", direction: "recv" },
+  },
+  {
+    line: "[sfu] connect-transport: bad direction from peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "bad-direction", op: "connect-transport" },
+  },
+  {
+    line: "[sfu] connect-transport: send transport is already connected for peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "already-connected", direction: "send" },
+  },
+  {
+    line: "[sfu] connect-transport: no recv transport for peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "no-transport", op: "connect-transport", direction: "recv" },
+  },
+  {
+    line: "[sfu] produce: no send transport for peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "no-send-transport", op: "produce" },
+  },
+  {
+    line: "[sfu] produce: invalid source from peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "invalid-produce", op: "produce" },
+  },
+  {
+    line: "[sfu] peer peer-a is at the producer ceiling (16); refusing produce",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "producer-limit", ceiling: 16 },
+  },
+  {
+    line: "[sfu] peer peer-a has exceeded cumulative produce limit (200); refusing produce",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "producer-limit", cumulative: true, ceiling: 200 },
+  },
+  {
+    line: "[sfu] peer peer-a produced prod-1 (camera)",
+    kind: "sfu.produce",
+    peer: "peer-a",
+    d: { producerId: "prod-1", source: "camera" },
+  },
+  {
+    line: "[sfu] consume: no recv transport for peer peer-a",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "no-recv-transport", op: "consume" },
+  },
+  {
+    line: "[sfu] peer peer-a already consuming producer prod-1; resending consumer options",
+    kind: "sfu.consume",
+    peer: "peer-a",
+    d: { producerId: "prod-1", resent: true },
+  },
+  {
+    line: "[sfu] peer peer-a is at the consumer ceiling (256); refusing consume",
+    kind: "sfu.error",
+    peer: "peer-a",
+    d: { reason: "consumer-limit", ceiling: 256 },
+  },
+  {
+    line: "[sfu] cannot consume producer prod-1 for peer peer-a",
+    kind: "sfu.consume.failed",
+    peer: "peer-a",
+    d: { producerId: "prod-1" },
+  },
+  {
+    line: "[sfu] peer peer-a consuming prod-1 (camera)",
+    kind: "sfu.consume",
+    peer: "peer-a",
+    d: { producerId: "prod-1", source: "camera" },
+  },
+  {
+    line: "[sfu] resume-consumer failed for peer peer-a: Error: boom",
+    kind: "sfu.consume.failed",
+    peer: "peer-a",
+    d: { reason: "resume-failed" },
+  },
+  { line: "[sfu] oversized frame, closing", kind: "sfu.ws.error", d: { reason: "oversized-frame" } },
+  { line: "[sfu] malformed frame from client", kind: "sfu.ws.error", d: { reason: "malformed-frame" } },
+  { line: "[sfu] invalid JSON from client", kind: "sfu.ws.error", d: { reason: "invalid-json" } },
+  {
+    line: "[sfu] expected join as first message, got: ping",
+    kind: "sfu.ws.error",
+    d: { reason: "expected-join-first" },
+  },
+  { line: "[sfu] unknown message type: foo", kind: "sfu.ws.error", d: { reason: "unknown-type" } },
+  { line: "[sfu] ws error: socket hang up", kind: "sfu.ws.error", d: { reason: "ws-error" } },
+];
+
+describe("parseSfuLog templates", () => {
+  it.each(SFU_CASES)("maps: $line", ({ line, kind, peer, d }) => {
+    const result = parseSfuLog(withTs(line), "sfu.log");
+    expect(result.unmatched).toBe(0);
+    expect(result.events).toHaveLength(1);
+    const [event] = result.events;
+    expect(event.kind).toBe(kind);
+    expect(event.at).toBe(TS_MS);
+    expect(event.t).toBe(TS_MS);
+    expect(event.vantage).toBe("log");
+    expect(event.source).toBe("sfu.log");
+    expect(event.observer).toBe("sfu");
+    if (peer !== undefined) expect(event.peer).toBe(peer);
+    if (d) expect(event.d).toMatchObject(d);
+  });
+
+  it("skips a [sfu-telemetry] line entirely: no event, not counted as unmatched", () => {
+    const text = [
+      withTs('[sfu-telemetry] {"v":1,"t":1750000000000,"room":"room-9f3a","peers":[]}'),
+      withTs("[sfu] peer peer-a joined room room-9f3a"),
+    ].join("\n");
+    const result = parseSfuLog(text, "sfu.log");
+    expect(result.unmatched).toBe(0);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("sfu.join");
+  });
+
+  it("an unmatched line survives as a raw event and increments unmatched", () => {
+    const line = "[sfu] mediasoup worker started (pid 4242)";
+    const result = parseSfuLog(withTs(line), "sfu.log");
+    expect(result.unmatched).toBe(1);
+    expect(result.events).toHaveLength(1);
+    const [event] = result.events;
+    expect(event.d?.raw).toBe(line);
+    expect(event.vantage).toBe("log");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRelayLog - one real sample line per template, verbatim from relay/main.go
+// ---------------------------------------------------------------------------
+
+const RELAY_CASES: Case[] = [
+  {
+    line: "[rv] a1b2c3d4 left room [room-xyz] (2 peers)",
+    kind: "rv.unregister",
+    d: { peerSuffix: "a1b2c3d4", roomRaw: "room-xyz", remaining: 2 },
+  },
+  {
+    line: "[rv] BUG: outbound PEERS frame to a1b2c3d4 is 5000 bytes (> 4096), dropping",
+    kind: "rv.send.fail",
+    d: { peerSuffix: "a1b2c3d4", reason: "oversize-outbound", msgType: "PEERS", bytes: 5000, maxBytes: 4096 },
+  },
+  {
+    line: "[rv] a1b2c3d4 is not reading its stream, dropping it",
+    kind: "rv.close",
+    d: { peerSuffix: "a1b2c3d4", reason: "outbox-full" },
+  },
+  {
+    line: "[rv] registry is at its 100000-registration ceiling, ignoring further REGISTERs",
+    kind: "rv.register",
+    d: { refused: "capped", scope: "global", ceiling: 100000 },
+  },
+  {
+    line: "[rv] a1b2c3d4 hit the 64-room cap, ignoring further REGISTERs",
+    kind: "rv.register",
+    d: { peerSuffix: "a1b2c3d4", refused: "capped", scope: "peer", ceiling: 64 },
+  },
+  {
+    line: "[rv] a1b2c3d4 joined room [room-xyz] (3 peers)",
+    kind: "rv.register",
+    d: { peerSuffix: "a1b2c3d4", roomRaw: "room-xyz", peers: 3 },
+  },
+  { line: "[rv] a1b2c3d4 disconnected", kind: "peer.disconnect", d: { peerSuffix: "a1b2c3d4" } },
+  { line: "[rv] a1b2c3d4 opened rendezvous stream", kind: "rv.open", d: { peerSuffix: "a1b2c3d4" } },
+  {
+    line: "[rv] a1b2c3d4 already holds 4 rendezvous streams, refusing another",
+    kind: "rv.open.fail",
+    d: { peerSuffix: "a1b2c3d4", reason: "stream-cap", maxStreams: 4 },
+  },
+  {
+    line: "[rv] a1b2c3d4 stream closed (1 still open)",
+    kind: "rv.close",
+    d: { peerSuffix: "a1b2c3d4", reason: "unknown", remainingStreams: 1 },
+  },
+  {
+    line: "[rv] message too large from a1b2c3d4: 70000 bytes, closing stream",
+    kind: "rv.frame.oversize",
+    d: { peerSuffix: "a1b2c3d4", bytes: 70000 },
+  },
+  {
+    line: "[rv] bad message from a1b2c3d4: invalid character",
+    kind: "rv.send.fail",
+    d: { peerSuffix: "a1b2c3d4", reason: "bad-message", phase: "inbound" },
+  },
+  {
+    line: "[rv] a1b2c3d4 sent an unusable room id (300 bytes), ignoring",
+    kind: "rv.send.fail",
+    d: { peerSuffix: "a1b2c3d4", reason: "invalid-room-id", bytes: 300 },
+  },
+  {
+    line: "[rv] unknown type from a1b2c3d4: FOO",
+    kind: "rv.send.fail",
+    d: { peerSuffix: "a1b2c3d4", reason: "unknown-type", msgType: "FOO" },
+  },
+  {
+    line: "[rv] a1b2c3d4 is changing rooms faster than 5/1s, ignoring",
+    kind: "rv.send.fail",
+    d: { peerSuffix: "a1b2c3d4", reason: "membership-rate-limited", limit: 5, window: "1s" },
+  },
+  {
+    line: "[rv] a1b2c3d4 exhausted its empty-room register budget (3/1m0s), ignoring",
+    kind: "rv.register",
+    d: { peerSuffix: "a1b2c3d4", refused: "oracle", limit: 3, window: "1m0s" },
+  },
+  { line: "[peer] connect a1b2c3d4", kind: "peer.connect", d: { peerSuffix: "a1b2c3d4" } },
+  { line: "[peer] disconnect a1b2c3d4", kind: "peer.disconnect", d: { peerSuffix: "a1b2c3d4" } },
+];
+
+describe("parseRelayLog templates", () => {
+  it.each(RELAY_CASES)("maps: $line", ({ line, kind, d }) => {
+    const result = parseRelayLog(withTs(line), "relay.log");
+    expect(result.unmatched).toBe(0);
+    expect(result.events).toHaveLength(1);
+    const [event] = result.events;
+    expect(event.kind).toBe(kind);
+    expect(event.at).toBe(TS_MS);
+    expect(event.peer).toBeNull(); // relay never resolves a suffix inline
+    expect(event.observer).toBe("relay");
+    if (d) expect(event.d).toMatchObject(d);
+  });
+
+  it("strips a Go std-log date/time prefix ahead of the docker timestamp for matching, but never uses it as the clock", () => {
+    // Go's default log flags stamp `YYYY/MM/DD HH:MM:SS ` ahead of every
+    // relay line - a second, coarser clock than docker's own `-t` wrapper.
+    const line = `${TS} 2026/09/01 02:03:04 [rv] a1b2c3d4 disconnected`;
+    const result = parseRelayLog(line, "relay.log");
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("peer.disconnect");
+    expect(result.events[0]?.at).toBe(TS_MS);
+  });
+
+  it("accepts the +00:00 numeric-offset docker timestamp form, not only Z", () => {
+    const line = "2026-09-01T02:03:04+00:00 [rv] a1b2c3d4 opened rendezvous stream";
+    const result = parseRelayLog(line, "relay.log");
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.at).toBe(Date.parse("2026-09-01T02:03:04+00:00"));
+  });
+
+  it("anchors relative to line order and warns when no docker -t timestamp is present", () => {
+    const text = ["[rv] a1b2c3d4 opened rendezvous stream", "[rv] a1b2c3d4 disconnected"].join("\n");
+    const result = parseRelayLog(text, "relay.log");
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]?.at).toBe(0);
+    expect(result.events[1]?.at).toBe(1);
+    expect(result.warnings.some((w) => w.includes("relative"))).toBe(true);
+  });
+
+  it("an unmatched line survives as a raw event and increments unmatched", () => {
+    const line = "[relay] this service must run as exactly ONE replica; see deploy/README.md";
+    const result = parseRelayLog(withTs(line), "relay.log");
+    expect(result.unmatched).toBe(1);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.d?.raw).toBe(line);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseConsoleLog
+// ---------------------------------------------------------------------------
+
+describe("parseConsoleLog", () => {
+  it("maps a house-style [tag] line to its DiagKind", () => {
+    const result = parseConsoleLog(withTs("[Transport] relay connected"), "console.txt");
+    expect(result.unmatched).toBe(0);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.kind).toBe("relay.dial.ok");
+    expect(result.events[0]?.observer).toBe("");
+  });
+
+  it("carries a peer suffix in d.peerSuffix, never resolving it inline", () => {
+    const result = parseConsoleLog(withTs("[Transport] stream never confirmed for a1b2c3d4"), "console.txt");
+    expect(result.events[0]?.kind).toBe("stream.confirm.fail");
+    expect(result.events[0]?.peer).toBeNull();
+    expect(result.events[0]?.d?.peerSuffix).toBe("a1b2c3d4");
+  });
+
+  it("maps a mailbox delivery-failed line with delivered:false", () => {
+    const result = parseConsoleLog(withTs("[mailbox] delivery failed, keeping blob: Error: timeout"), "console.txt");
+    expect(result.events[0]?.kind).toBe("dm.mailbox.collect");
+    expect(result.events[0]?.d).toMatchObject({ delivered: false });
+  });
+
+  it("an unmatched line survives as a raw event and increments unmatched", () => {
+    const result = parseConsoleLog(withTs("[voice] setSinkId failed for peer-a: NotFoundError"), "console.txt");
+    expect(result.unmatched).toBe(1);
+    expect(result.events).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSfuTelemetry
+// ---------------------------------------------------------------------------
+
+describe("parseSfuTelemetry", () => {
+  it("summarises a structured sweep line into one sfu.diag event, never leaking the room code into the room field", () => {
+    const payload = {
+      v: 1,
+      t: 1750000000000,
+      room: "room-9f3a",
+      peers: [
+        {
+          peerId: "peer-a",
+          producers: [
+            { id: "prod-1", source: "camera", kind: "video", consumers: 2 },
+            { id: "prod-2", source: "mic", kind: "audio", consumers: 1 },
+          ],
+        },
+        { peerId: "peer-b", producers: [{ id: "prod-3", source: "screen", kind: "video", consumers: 0 }] },
+      ],
+    };
+    const line = `[sfu-telemetry] ${JSON.stringify(payload)}`;
+    const result = parseSfuTelemetry(line, "sfu.log");
+    expect(result.unmatched).toBe(0);
+    expect(result.events).toHaveLength(1);
+    const [event] = result.events;
+    expect(event.kind).toBe("sfu.diag");
+    expect(event.sev).toBe("debug");
+    expect(event.room).toBeNull();
+    expect(event.at).toBe(1750000000000);
+    expect(event.t).toBe(1750000000000);
+    expect(event.observer).toBe("sfu");
+    expect(event.d).toMatchObject({
+      roomRaw: "room-9f3a",
+      roomPeers: 2,
+      producers: 3,
+      consumers: 3,
+    });
+  });
+
+  it("ignores a non-telemetry line entirely (parseSfuLog's job), not counting it as unmatched", () => {
+    const result = parseSfuTelemetry(withTs("[sfu] peer peer-a joined room room-9f3a"), "sfu.log");
+    expect(result.events).toHaveLength(0);
+    expect(result.unmatched).toBe(0);
+  });
+
+  it("a [sfu-telemetry] line with malformed JSON is counted as unmatched, and does not throw", () => {
+    expect(() => parseSfuTelemetry("[sfu-telemetry] {not valid json", "sfu.log")).not.toThrow();
+    const result = parseSfuTelemetry("[sfu-telemetry] {not valid json", "sfu.log");
+    expect(result.unmatched).toBe(1);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.d?.raw).toContain("[sfu-telemetry]");
+  });
+
+  it("concatenates with parseSfuLog on the same text with no double counting", () => {
+    const text = [
+      '[sfu-telemetry] {"v":1,"t":1750000000000,"room":"room-9f3a","peers":[{"peerId":"peer-a","producers":[{"id":"p1","source":"camera","kind":"video","consumers":1}]}]}',
+      "[sfu] peer peer-a joined room room-9f3a",
+    ].join("\n");
+    const telemetry = parseSfuTelemetry(text, "sfu.log");
+    const freeform = parseSfuLog(text, "sfu.log");
+    expect(telemetry.events).toHaveLength(1);
+    expect(telemetry.events[0]?.kind).toBe("sfu.diag");
+    expect(freeform.events).toHaveLength(1);
+    expect(freeform.events[0]?.kind).toBe("sfu.join");
+    expect(freeform.unmatched).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSuffix
+// ---------------------------------------------------------------------------
+
+describe("resolveSuffix", () => {
+  const peerA = "12D3KooWAlphaAlphaAlphaAlphaAlphaAlphaAAAAAAAA1a2b3c4d";
+  const peerB = "12D3KooWBetaBetaBetaBetaBetaBetaBetaBetaBBBBBBB1a2b3c4d";
+
+  it("resolves a unique suffix to its full peerId", () => {
+    expect(resolveSuffix("1a2b3c4d", [peerA, "12D3KooWSomeoneElseZZZZZZZZZ"])).toEqual({
+      peerId: peerA,
+      ambiguous: false,
+    });
+  });
+
+  it("returns null with no attribution when nothing matches", () => {
+    expect(resolveSuffix("deadbeef", [peerA])).toEqual({ peerId: null, ambiguous: false });
+  });
+
+  it("an ambiguous 8-character suffix produces no attribution, so a caller can warn instead of guessing wrong", () => {
+    // peerA and peerB share the same last 8 characters by construction.
+    const { peerId, ambiguous } = resolveSuffix("1a2b3c4d", [peerA, peerB]);
+    expect(peerId).toBeNull();
+    expect(ambiguous).toBe(true);
+
+    // The integration pattern a downstream caller (e.g. sources.svelte.ts,
+    // once bundles are loaded) is expected to follow: push a warning rather
+    // than attribute the event to either peer.
+    const warnings: string[] = [];
+    if (ambiguous) warnings.push(`ambiguous peer suffix "1a2b3c4d" matches more than one known peer`);
+    expect(warnings).toHaveLength(1);
+  });
+});

--- a/dashboard/src/lib/analysis/logs.ts
+++ b/dashboard/src/lib/analysis/logs.ts
@@ -1,0 +1,811 @@
+/**
+ * Log parsers: turn raw container/browser output into `MergedEvent[]` that
+ * merge into the same timeline as a bundle, via `mergeSources`'s `logEvents`
+ * parameter (see `merge.ts`).
+ *
+ * `mergeSources` always forces every log-sourced vantage's `kind` to `"log"`
+ * - distinguishing an SFU log from a relay log from a console paste is by
+ * `source` (the file name each parser is called with), never by `vantage`.
+ * That is why every event below carries `vantage: "log"` regardless of which
+ * parser produced it: the tag that matters downstream is `source`.
+ *
+ * PRIVACY: `sfu/index.ts` and `relay/main.go` log FULL peer ids and room
+ * codes in clear - that is the established precedent for the operator's own
+ * container log, not a client-facing surface (see `docs/spec.md`). This file
+ * is the ONE place in the dashboard a room code can enter memory. A room
+ * code found in a log line goes into `d.roomRaw` ONLY, NEVER into the frozen
+ * `room` field (`room` is reserved for a bundle-local ordinal ref like "r1"
+ * and must never carry a real code - `findings.ts` and `topology.ts` both
+ * treat it that way). It stays in memory for this session; an exporter
+ * (prompt pack, saved workspace) MUST strip every `d.roomRaw` key before
+ * anything leaves the process. That stripping is a downstream obligation on
+ * the exporter, not something this file can enforce.
+ *
+ * PEER SUFFIXES: the relay (`short()`) and some frontend console lines
+ * truncate a peerId to its last 8 characters before logging it. Neither
+ * `parseRelayLog` nor `parseConsoleLog` receives a known-peer-id list (their
+ * contract is exactly `(text, source)`), so they cannot resolve a suffix to
+ * a full id themselves - they record it as `d.peerSuffix` and leave `peer`
+ * `null`. `resolveSuffix` is exported for whatever loads both the bundles
+ * and the logs (and therefore knows the capture's full peer ids) to do that
+ * resolution afterwards, additively, without ever guessing wrong.
+ */
+
+import type { DiagKind, DiagSeverity } from "../schema";
+import { LOG_RAW_KIND, type MergedEvent } from "./merge";
+
+export interface ParsedLog {
+  events: MergedEvent[];
+  warnings: string[];
+  unmatched: number;
+}
+
+// ---------------------------------------------------------------------------
+// The raw-line sentinel
+// ---------------------------------------------------------------------------
+
+/**
+ * `DiagKind` is a closed, frozen 112-literal WIRE contract, deliberately with
+ * no generic "unknown" member: every kind on the wire is a choice made by code
+ * that knows what it records. Log parsing faces the opposite problem - an
+ * operator's container output is open-world text this dashboard did not write,
+ * and an unrecognised line must still surface rather than be forced into a
+ * kind that misrepresents it.
+ *
+ * `LOG_RAW_KIND` is therefore NOT a member of `DiagKind`. `MergedEvent.kind` is
+ * `MergedKind`, which is `DiagKind` plus this one marker, so the widening is in
+ * the type and not in a cast.
+ */
+const RAW_LOG_KIND = LOG_RAW_KIND;
+
+const MAX_DETAIL_STRING = 200;
+
+function truncate(s: string): string {
+  return s.length > MAX_DETAIL_STRING ? s.slice(0, MAX_DETAIL_STRING) : s;
+}
+
+function inferSeverity(body: string): DiagSeverity {
+  if (/fatal|panic|uncaught|unhandled/i.test(body)) return "error";
+  if (/\berror\b|failed|refus(?:ed|ing)|bug:/i.test(body)) return "error";
+  if (/\bwarn|drop|duplicate|ceiling|exhausted|\bcap\b/i.test(body)) return "warn";
+  return "info";
+}
+
+// ---------------------------------------------------------------------------
+// Timestamps
+// ---------------------------------------------------------------------------
+
+/** `docker logs -t`'s prefix: RFC3339Nano, ending `Z` or a numeric offset. */
+const DOCKER_TS_RE =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))\s(.*)$/;
+
+const DOCKER_TS_PARTS_RE =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Go's std `log` package default flags (`Ldate|Ltime`) stamp a second
+ * precision, process-local date/time ahead of every relay line - stripped
+ * here for TEMPLATE MATCHING ONLY. It is never used as a clock: docker's own
+ * `-t` wrapper is the one authoritative source per this file's contract, so
+ * a relay line with no docker timestamp falls all the way through to
+ * relative anchoring rather than using this coarser embedded one.
+ */
+const GO_LOG_PREFIX_RE = /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2} /;
+
+function parseDockerTimestamp(iso: string): number | null {
+  const m = iso.match(DOCKER_TS_PARTS_RE);
+  if (!m) return null;
+  // JS `Date` only resolves millisecond precision; docker emits nanoseconds.
+  const millis = m[2] ? `.${m[2].slice(1, 4).padEnd(3, "0")}` : "";
+  const t = Date.parse(`${m[1]}${millis}${m[3]}`);
+  return Number.isFinite(t) ? t : null;
+}
+
+function stripPrefixes(line: string): { ts: number | null; body: string } {
+  const dockerMatch = line.match(DOCKER_TS_RE);
+  const ts = dockerMatch ? parseDockerTimestamp(dockerMatch[1]) : null;
+  const rest = dockerMatch ? dockerMatch[2] : line;
+  return { ts, body: rest.replace(GO_LOG_PREFIX_RE, "") };
+}
+
+// ---------------------------------------------------------------------------
+// The templated-line engine, shared by parseSfuLog / parseRelayLog / parseConsoleLog
+// ---------------------------------------------------------------------------
+
+interface TemplateResult {
+  peer?: string | null;
+  d?: Record<string, string | number | boolean | null>;
+}
+
+interface LineTemplate {
+  re: RegExp;
+  kind: DiagKind;
+  sev: DiagSeverity;
+  build?: (m: RegExpMatchArray) => TemplateResult;
+}
+
+function rawEvent(
+  seq: number,
+  at: number,
+  source: string,
+  observer: string,
+  body: string
+): MergedEvent {
+  return {
+    seq,
+    t: at,
+    kind: RAW_LOG_KIND,
+    sev: inferSeverity(body),
+    peer: null,
+    room: null,
+    d: { raw: truncate(body) },
+    at,
+    vantage: "log",
+    source,
+    observer,
+  };
+}
+
+/**
+ * Shared per-line engine for the three text-template parsers. Every non-empty
+ * line becomes exactly one event: a templated one when a template matches,
+ * else a `rawEvent` - so a mis-parse is visible in the Logs view rather than
+ * silently missing.
+ *
+ * @param skip lines this parser does not own (e.g. a `[sfu-telemetry]` line
+ *   inside `parseSfuLog`) - skipped entirely: no event, no `unmatched` count.
+ */
+function parseTemplatedLog(
+  text: string,
+  source: string,
+  observer: string,
+  templates: readonly LineTemplate[],
+  skip?: (body: string) => boolean
+): ParsedLog {
+  const warnings: string[] = [];
+  const events: MergedEvent[] = [];
+  const stripped = text
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .map(stripPrefixes);
+
+  const hasAnyTs = stripped.some((line) => line.ts !== null);
+  if (!hasAnyTs && stripped.length > 0) {
+    warnings.push(
+      `${source}: no "docker logs -t" timestamps found; times are relative to line order.`
+    );
+  }
+
+  let seq = 0;
+  let unmatched = 0;
+  let lastTs: number | null = null;
+  let relCounter = 0;
+
+  for (const { ts, body } of stripped) {
+    if (skip?.(body)) continue;
+    seq++;
+
+    let at: number;
+    if (ts !== null) {
+      at = ts;
+      lastTs = ts;
+    } else if (lastTs !== null) {
+      at = lastTs;
+    } else {
+      at = relCounter++;
+    }
+
+    let matched = false;
+    for (const tpl of templates) {
+      const m = body.match(tpl.re);
+      if (!m) continue;
+      matched = true;
+      const extra = tpl.build?.(m) ?? {};
+      events.push({
+        seq,
+        t: at,
+        kind: tpl.kind,
+        sev: tpl.sev,
+        peer: extra.peer ?? null,
+        room: null,
+        d: extra.d,
+        at,
+        vantage: "log",
+        source,
+        observer,
+      });
+      break;
+    }
+    if (!matched) {
+      unmatched++;
+      events.push(rawEvent(seq, at, source, observer, body));
+    }
+  }
+
+  return { events, warnings, unmatched };
+}
+
+// ---------------------------------------------------------------------------
+// parseSfuTelemetry - the structured `[sfu-telemetry] {json}` sweep line
+// ---------------------------------------------------------------------------
+
+const SFU_TELEMETRY_TAG_RE = /^\[sfu-telemetry\]/;
+const SFU_TELEMETRY_LINE_RE = /^\[sfu-telemetry\]\s+(\{.*\})\s*$/;
+
+interface SfuTelemetryPeer {
+  peerId: string;
+  producers: Array<{ id: string; source: string; kind: string; consumers: number }>;
+}
+
+function isSfuTelemetryPeer(v: unknown): v is SfuTelemetryPeer {
+  if (typeof v !== "object" || v === null) return false;
+  const p = v as Record<string, unknown>;
+  return typeof p.peerId === "string" && Array.isArray(p.producers);
+}
+
+interface SfuTelemetryLine {
+  v: number;
+  t: number;
+  room: string;
+  peers: SfuTelemetryPeer[];
+}
+
+function isSfuTelemetryLine(v: unknown): v is SfuTelemetryLine {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    o.v === 1 &&
+    typeof o.t === "number" &&
+    Number.isFinite(o.t) &&
+    typeof o.room === "string" &&
+    Array.isArray(o.peers) &&
+    o.peers.every(isSfuTelemetryPeer)
+  );
+}
+
+/**
+ * `[sfu-telemetry] {"v":1,"t":<unix ms>,"room":"<roomCode>","peers":[...]}` -
+ * one line per room per heartbeat sweep, emitted only when `SFU_TELEMETRY=1`
+ * (see `sfu/index.ts`'s `emitSfuTelemetrySweep`). Already structured and
+ * self-timestamped (the `t` field is real unix ms from the SFU's own clock),
+ * so no template matching and no docker `-t` dependency - the highest
+ * fidelity of the three SFU-adjacent sources.
+ *
+ * Produces one `sfu.diag` event per line: a room-level summary, not a
+ * per-peer one, so `peer` is always `null`; the room code goes into
+ * `d.roomRaw` only (see the module doc comment).
+ */
+export function parseSfuTelemetry(text: string, source: string): ParsedLog {
+  const warnings: string[] = [];
+  const events: MergedEvent[] = [];
+  let seq = 0;
+  let unmatched = 0;
+
+  for (const raw of text.split(/\r?\n/)) {
+    if (raw.length === 0) continue;
+    const { body } = stripPrefixes(raw);
+    if (!SFU_TELEMETRY_TAG_RE.test(body)) continue; // not our line - parseSfuLog's job
+    seq++;
+
+    const lineMatch = body.match(SFU_TELEMETRY_LINE_RE);
+    let parsed: unknown;
+    try {
+      parsed = lineMatch ? JSON.parse(lineMatch[1]) : undefined;
+    } catch {
+      parsed = undefined;
+    }
+
+    if (!isSfuTelemetryLine(parsed)) {
+      unmatched++;
+      events.push(rawEvent(seq, seq, source, "sfu", body));
+      continue;
+    }
+
+    let producers = 0;
+    let consumers = 0;
+    for (const peer of parsed.peers) {
+      producers += peer.producers.length;
+      for (const p of peer.producers) consumers += p.consumers;
+    }
+
+    events.push({
+      seq,
+      t: parsed.t,
+      kind: "sfu.diag",
+      sev: "debug",
+      peer: null,
+      room: null,
+      d: {
+        roomRaw: truncate(parsed.room),
+        roomPeers: parsed.peers.length,
+        producers,
+        consumers,
+      },
+      at: parsed.t,
+      vantage: "log",
+      source,
+      observer: "sfu",
+    });
+  }
+
+  return { events, warnings, unmatched };
+}
+
+// ---------------------------------------------------------------------------
+// parseSfuLog - the free-form `[sfu]` / `[router]` lines
+// ---------------------------------------------------------------------------
+
+const SFU_LOG_TEMPLATES: readonly LineTemplate[] = [
+  {
+    re: /^\[sfu\] join with invalid roomCode or peerId, closing$/,
+    kind: "sfu.join",
+    sev: "warn",
+    build: () => ({ d: { reason: "invalid-ids" } }),
+  },
+  {
+    re: /^\[sfu\] room ceiling reached \((\d+)\); refusing new room (\S+)$/,
+    kind: "sfu.join",
+    sev: "error",
+    build: (m) => ({ d: { reason: "server-full", maxRooms: Number(m[1]), roomRaw: truncate(m[2]) } }),
+  },
+  {
+    re: /^\[sfu\] room (\S+) is at the peer ceiling \((\d+)\); refusing peer (\S+)$/,
+    kind: "sfu.join",
+    sev: "error",
+    build: (m) => ({
+      peer: m[3],
+      d: { reason: "room-full", roomRaw: truncate(m[1]), maxPeers: Number(m[2]) },
+    }),
+  },
+  {
+    re: /^\[sfu\] duplicate peerId (\S+) in room (\S+) answered a liveness probe; refusing the new connection$/,
+    kind: "sfu.join",
+    sev: "warn",
+    build: (m) => ({
+      peer: m[1],
+      d: { reason: "peer-id-in-use", phase: "liveness-probe", roomRaw: truncate(m[2]) },
+    }),
+  },
+  {
+    re: /^\[sfu\] peerId (\S+) in room (\S+) was claimed while probing; refusing the new connection$/,
+    kind: "sfu.join",
+    sev: "warn",
+    build: (m) => ({
+      peer: m[1],
+      d: { reason: "peer-id-in-use", phase: "claimed-while-probing", roomRaw: truncate(m[2]) },
+    }),
+  },
+  {
+    re: /^\[sfu\] duplicate peerId (\S+) in room (\S+); the previous session is dead, replacing it$/,
+    kind: "sfu.join",
+    sev: "info",
+    build: (m) => ({ peer: m[1], d: { reason: "replaced-dead-session", roomRaw: truncate(m[2]) } }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) joined room (\S+)$/,
+    kind: "sfu.join",
+    sev: "info",
+    build: (m) => ({ peer: m[1], d: { roomRaw: truncate(m[2]) } }),
+  },
+  {
+    re: /^\[sfu\] create-transport: bad direction from peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "bad-direction", op: "create-transport" } }),
+  },
+  {
+    re: /^\[sfu\] create-transport: a (\S+) transport is already being created for peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[2], d: { reason: "duplicate-transport-creating", direction: m[1] } }),
+  },
+  {
+    re: /^\[sfu\] duplicate (\S+) transport for peer (\S+); closing the previous one$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[2], d: { reason: "duplicate-transport", direction: m[1] } }),
+  },
+  {
+    re: /^\[sfu\] connect-transport: bad direction from peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "bad-direction", op: "connect-transport" } }),
+  },
+  {
+    re: /^\[sfu\] connect-transport: (\S+) transport is already connected for peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[2], d: { reason: "already-connected", direction: m[1] } }),
+  },
+  {
+    re: /^\[sfu\] connect-transport: no (\S+) transport for peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({
+      peer: m[2],
+      d: { reason: "no-transport", op: "connect-transport", direction: m[1] },
+    }),
+  },
+  {
+    re: /^\[sfu\] produce: no send transport for peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "no-send-transport", op: "produce" } }),
+  },
+  {
+    // `reason: "invalid-produce"` matches the `ms:error` the SFU sends for
+    // this exact rejection (`send(peer.ws, { type: "ms:error", reason:
+    // "invalid-produce" })`), and the rule `sfu-session-latched` keys off
+    // that literal string - so this parser reuses it rather than inventing
+    // a differently-spelled reason for the same event.
+    re: /^\[sfu\] produce: invalid source from peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "invalid-produce", op: "produce" } }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) is at the producer ceiling \((\d+)\); refusing produce$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "producer-limit", ceiling: Number(m[2]) } }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) has exceeded cumulative produce limit \((\d+)\); refusing produce$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({
+      peer: m[1],
+      d: { reason: "producer-limit", cumulative: true, ceiling: Number(m[2]) },
+    }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) produced (\S+) \((\S+)\)$/,
+    kind: "sfu.produce",
+    sev: "info",
+    build: (m) => ({ peer: m[1], d: { producerId: m[2], source: m[3] } }),
+  },
+  {
+    re: /^\[sfu\] consume: no recv transport for peer (\S+)$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "no-recv-transport", op: "consume" } }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) already consuming producer (\S+); resending consumer options$/,
+    kind: "sfu.consume",
+    sev: "info",
+    build: (m) => ({ peer: m[1], d: { producerId: m[2], resent: true } }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) is at the consumer ceiling \((\d+)\); refusing consume$/,
+    kind: "sfu.error",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "consumer-limit", ceiling: Number(m[2]) } }),
+  },
+  {
+    re: /^\[sfu\] cannot consume producer (\S+) for peer (\S+)$/,
+    kind: "sfu.consume.failed",
+    sev: "error",
+    build: (m) => ({ peer: m[2], d: { producerId: m[1] } }),
+  },
+  {
+    re: /^\[sfu\] peer (\S+) consuming (\S+) \((\S+)\)$/,
+    kind: "sfu.consume",
+    sev: "info",
+    build: (m) => ({ peer: m[1], d: { producerId: m[2], source: m[3] } }),
+  },
+  {
+    re: /^\[sfu\] resume-consumer failed for peer (\S+):/,
+    kind: "sfu.consume.failed",
+    sev: "error",
+    build: (m) => ({ peer: m[1], d: { reason: "resume-failed" } }),
+  },
+  {
+    re: /^\[sfu\] oversized frame, closing$/,
+    kind: "sfu.ws.error",
+    sev: "error",
+    build: () => ({ d: { reason: "oversized-frame" } }),
+  },
+  {
+    re: /^\[sfu\] malformed frame from client$/,
+    kind: "sfu.ws.error",
+    sev: "error",
+    build: () => ({ d: { reason: "malformed-frame" } }),
+  },
+  {
+    re: /^\[sfu\] invalid JSON from client$/,
+    kind: "sfu.ws.error",
+    sev: "error",
+    build: () => ({ d: { reason: "invalid-json" } }),
+  },
+  {
+    re: /^\[sfu\] expected join as first message, got:/,
+    kind: "sfu.ws.error",
+    sev: "error",
+    build: () => ({ d: { reason: "expected-join-first" } }),
+  },
+  {
+    re: /^\[sfu\] unknown message type:/,
+    kind: "sfu.ws.error",
+    sev: "error",
+    build: () => ({ d: { reason: "unknown-type" } }),
+  },
+  {
+    re: /^\[sfu\] ws error:/,
+    kind: "sfu.ws.error",
+    sev: "error",
+    build: () => ({ d: { reason: "ws-error" } }),
+  },
+];
+
+/**
+ * The free-form `[sfu]` / `[router]` lines from `sfu/index.ts`. Skips a
+ * `[sfu-telemetry]` line entirely (no event, not counted in `unmatched`) -
+ * that structured line is `parseSfuTelemetry`'s job. Call both on the same
+ * text and concatenate their `events` for full coverage of one log file.
+ */
+export function parseSfuLog(text: string, source: string): ParsedLog {
+  return parseTemplatedLog(text, source, "sfu", SFU_LOG_TEMPLATES, (body) =>
+    SFU_TELEMETRY_TAG_RE.test(body)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// parseRelayLog - the `[rv]` / `[relay]` / `[http]` / `[peer]` lines
+// ---------------------------------------------------------------------------
+
+const RELAY_LOG_TEMPLATES: readonly LineTemplate[] = [
+  {
+    re: /^\[rv\] (\S+) left room \[(.*)\] \((\d+) peers\)$/,
+    kind: "rv.unregister",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1], roomRaw: truncate(m[2]), remaining: Number(m[3]) } }),
+  },
+  {
+    re: /^\[rv\] BUG: outbound (\S+) frame to (\S+) is (\d+) bytes \(> (\d+)\), dropping$/,
+    kind: "rv.send.fail",
+    sev: "error",
+    build: (m) => ({
+      d: {
+        peerSuffix: m[2],
+        reason: "oversize-outbound",
+        msgType: m[1],
+        bytes: Number(m[3]),
+        maxBytes: Number(m[4]),
+      },
+    }),
+  },
+  {
+    re: /^\[rv\] (\S+) is not reading its stream, dropping it$/,
+    kind: "rv.close",
+    sev: "warn",
+    build: (m) => ({ d: { peerSuffix: m[1], reason: "outbox-full" } }),
+  },
+  {
+    re: /^\[rv\] registry is at its (\d+)-registration ceiling, ignoring further REGISTERs$/,
+    kind: "rv.register",
+    sev: "warn",
+    build: (m) => ({ d: { refused: "capped", scope: "global", ceiling: Number(m[1]) } }),
+  },
+  {
+    re: /^\[rv\] (\S+) hit the (\d+)-room cap, ignoring further REGISTERs$/,
+    kind: "rv.register",
+    sev: "warn",
+    build: (m) => ({
+      d: { peerSuffix: m[1], refused: "capped", scope: "peer", ceiling: Number(m[2]) },
+    }),
+  },
+  {
+    re: /^\[rv\] (\S+) joined room \[(.*)\] \((\d+) peers\)$/,
+    kind: "rv.register",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1], roomRaw: truncate(m[2]), peers: Number(m[3]) } }),
+  },
+  {
+    re: /^\[rv\] (\S+) disconnected$/,
+    kind: "peer.disconnect",
+    sev: "warn",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[rv\] (\S+) opened rendezvous stream$/,
+    kind: "rv.open",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[rv\] (\S+) already holds (\d+) rendezvous streams, refusing another$/,
+    kind: "rv.open.fail",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1], reason: "stream-cap", maxStreams: Number(m[2]) } }),
+  },
+  {
+    // The relay's CURRENT text log has no failure reason on this line: an
+    // idle timeout, a liveness timeout and a graceful close all read
+    // identically (that ambiguity is exactly why the plan has
+    // `relay/telemetry.go` add a structured `rv.close` with a real
+    // `RelayCloseReason` - once that lands, prefer it over this parser for
+    // the same session). `reason: "unknown"` documents the gap rather than
+    // guessing "graceful" and hiding a wedge.
+    re: /^\[rv\] (\S+) stream closed \((\d+) still open\)$/,
+    kind: "rv.close",
+    sev: "warn",
+    build: (m) => ({ d: { peerSuffix: m[1], reason: "unknown", remainingStreams: Number(m[2]) } }),
+  },
+  {
+    re: /^\[rv\] message too large from (\S+): (\d+) bytes, closing stream$/,
+    kind: "rv.frame.oversize",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1], bytes: Number(m[2]) } }),
+  },
+  {
+    re: /^\[rv\] bad message from (\S+): /,
+    kind: "rv.send.fail",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1], reason: "bad-message", phase: "inbound" } }),
+  },
+  {
+    re: /^\[rv\] (\S+) sent an unusable room id \((\d+) bytes\), ignoring$/,
+    kind: "rv.send.fail",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1], reason: "invalid-room-id", bytes: Number(m[2]) } }),
+  },
+  {
+    re: /^\[rv\] unknown type from (\S+): (\S+)$/,
+    kind: "rv.send.fail",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1], reason: "unknown-type", msgType: m[2] } }),
+  },
+  {
+    re: /^\[rv\] (\S+) is changing rooms faster than (\d+)\/(\S+), ignoring$/,
+    kind: "rv.send.fail",
+    sev: "error",
+    build: (m) => ({
+      d: { peerSuffix: m[1], reason: "membership-rate-limited", limit: Number(m[2]), window: m[3] },
+    }),
+  },
+  {
+    re: /^\[rv\] (\S+) exhausted its empty-room register budget \((\d+)\/(\S+)\), ignoring$/,
+    kind: "rv.register",
+    sev: "warn",
+    build: (m) => ({
+      d: { peerSuffix: m[1], refused: "oracle", limit: Number(m[2]), window: m[3] },
+    }),
+  },
+  {
+    re: /^\[peer\] connect (\S+)$/,
+    kind: "peer.connect",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[peer\] disconnect (\S+)$/,
+    kind: "peer.disconnect",
+    sev: "warn",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+];
+
+/** The `[rv]` / `[relay]` / `[http]` / `[peer]` lines from `relay/main.go`. */
+export function parseRelayLog(text: string, source: string): ParsedLog {
+  return parseTemplatedLog(text, source, "relay", RELAY_LOG_TEMPLATES);
+}
+
+// ---------------------------------------------------------------------------
+// parseConsoleLog - pasted browser console output, house `[tag] message` shape
+// ---------------------------------------------------------------------------
+
+const CONSOLE_LOG_TEMPLATES: readonly LineTemplate[] = [
+  {
+    re: /^\[storage\] dropped (\d+) undecryptable row\(s\)$/,
+    kind: "storage.drop",
+    sev: "error",
+    build: (m) => ({ d: { count: Number(m[1]) } }),
+  },
+  {
+    re: /^\[storage\] dropped undecryptable (\S+) row:/,
+    kind: "storage.drop",
+    sev: "error",
+    build: (m) => ({ d: { store: m[1], count: 1 } }),
+  },
+  {
+    re: /^\[dm\] storage locked: offline queue not persisted$/,
+    kind: "storage.locked",
+    sev: "error",
+    build: () => ({ d: { what: "dm-queue" } }),
+  },
+  {
+    re: /^\[mailbox\] collected (\d+) offline DM\(s\)$/,
+    kind: "dm.mailbox.collect",
+    sev: "info",
+    build: (m) => ({ d: { count: Number(m[1]) } }),
+  },
+  { re: /^\[mailbox\] dropped blob:/, kind: "dm.mailbox.drop", sev: "error" },
+  {
+    re: /^\[mailbox\] delivery failed, keeping blob:/,
+    kind: "dm.mailbox.collect",
+    sev: "warn",
+    build: () => ({ d: { delivered: false } }),
+  },
+  {
+    re: /^\[Transport\] peer stopped answering: (\S+)$/,
+    kind: "peer.drop.liveness",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[Transport\] reconciled missed peer: (\S+)$/,
+    kind: "peer.connect",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[Transport\] upgraded to direct: (\S+)$/,
+    kind: "peer.upgrade.ok",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[Transport\] re-dialing peer: (\S+)$/,
+    kind: "peer.redial",
+    sev: "info",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  {
+    re: /^\[Transport\] stream never confirmed for (\S+)$/,
+    kind: "stream.confirm.fail",
+    sev: "error",
+    build: (m) => ({ d: { peerSuffix: m[1] } }),
+  },
+  { re: /^\[Transport\] relay connected$/, kind: "relay.dial.ok", sev: "info" },
+  { re: /^\[Transport\] relay dial failed:/, kind: "relay.dial.fail", sev: "error" },
+  {
+    re: /^\[Transport\] relay disconnected, scheduling reconnect$/,
+    kind: "relay.reconnect.schedule",
+    sev: "info",
+  },
+  { re: /^\[Rendezvous\] stream closed, reconnecting$/, kind: "rv.close", sev: "warn" },
+  { re: /^\[Rendezvous\] send failed:/, kind: "rv.send.fail", sev: "error" },
+  {
+    re: /^\[MediasoupVideo\] rejoin attempt (\d+) failed:/,
+    kind: "sfu.rejoin",
+    sev: "warn",
+    build: (m) => ({ d: { attempt: Number(m[1]) } }),
+  },
+];
+
+/**
+ * Pasted browser console output in the house `[tag] message` shape. The
+ * observer is unknown from text alone (unlike the relay/SFU logs, which are
+ * each exactly one server), so it is `""` - `mergeSources` treats a falsy
+ * observer as "do not touch a peer for this".
+ */
+export function parseConsoleLog(text: string, source: string): ParsedLog {
+  return parseTemplatedLog(text, source, "", CONSOLE_LOG_TEMPLATES);
+}
+
+// ---------------------------------------------------------------------------
+// resolveSuffix
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps an 8-character peerId suffix (the relay's `short()`, and some
+ * frontend console lines' `.slice(-8)`) to a full peerId, given the set of
+ * full ids already known for a capture (from its loaded client bundles).
+ *
+ * Two known ids sharing the same last 8 characters are indistinguishable
+ * from the suffix alone: returning a wrong attribution would be worse than
+ * returning none, so that case reports `ambiguous: true` and no `peerId`,
+ * for the caller to surface as a warning rather than a (possibly wrong)
+ * link in the topology.
+ */
+export function resolveSuffix(
+  suffix: string,
+  knownPeerIds: string[]
+): { peerId: string | null; ambiguous: boolean } {
+  if (suffix.length === 0) return { peerId: null, ambiguous: false };
+  const matches = knownPeerIds.filter((id) => id.endsWith(suffix));
+  if (matches.length === 0) return { peerId: null, ambiguous: false };
+  if (matches.length > 1) return { peerId: null, ambiguous: true };
+  return { peerId: matches[0], ambiguous: false };
+}

--- a/dashboard/src/lib/analysis/merge.test.ts
+++ b/dashboard/src/lib/analysis/merge.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_ACCEPTABLE_SKEW_MS,
+  mergeSources,
+  peerIdsOf,
+  skewSamples,
+  solveSkew,
+  vantagesOf,
+  type LoadedVantage,
+} from "./merge";
+import type { ClientBundle, DiagEvent, RelayVantage } from "../schema";
+
+let seq = 0;
+
+function event(
+  kind: DiagEvent["kind"],
+  t: number,
+  extra: Partial<DiagEvent> = {}
+): DiagEvent {
+  return {
+    seq: ++seq,
+    t,
+    kind,
+    sev: "info",
+    peer: null,
+    room: null,
+    ...extra,
+  };
+}
+
+function bundleOf(
+  peerId: string,
+  startedAt: number,
+  events: DiagEvent[],
+  overrides: Partial<ClientBundle> = {}
+): ClientBundle {
+  return {
+    schemaVersion: 1,
+    bundleId: `bundle-${peerId}`,
+    sessionId: `sess-${peerId}`,
+    createdAt: startedAt + 60_000,
+    startedAt,
+    vantage: "client",
+    app: { version: "1.0.0", commit: "abc" },
+    env: { ua: "test" },
+    config: {
+      apiHost: "relay.example.org",
+      relayPeerId: "12D3KooWRELAY",
+      sfuHosts: ["sfu.example.org"],
+      configured: true,
+    },
+    self: { peerId },
+    rooms: [],
+    peers: [],
+    counters: {},
+    events,
+    sfuSnapshots: [],
+    meta: {
+      ringCapacity: 4096,
+      dropped: 0,
+      suppressed: {},
+      faultsActive: false,
+      truncated: false,
+    },
+    ...overrides,
+  };
+}
+
+function relayView(observedPeerId: string, events: DiagEvent[]): RelayVantage {
+  return {
+    vantage: "relay",
+    relayPeerId: "12D3KooWRELAY",
+    observedPeerId,
+    registry: { totalRegistrations: 1, streamsForPeer: 1, atTotalCap: false },
+    rooms: [{ ref: "h:abc", size: 2, members: [observedPeerId] }],
+    streams: [],
+    events,
+  };
+}
+
+describe("vantagesOf", () => {
+  it("splits a stapled relay view into a second vantage", () => {
+    const bundle = bundleOf("pA", 1000, [event("session.start", 0)], {
+      relayView: relayView("pA", [event("rv.open", 1500)]),
+    });
+    const vantages = vantagesOf(bundle, "a.json");
+    expect(vantages.map((v) => v.kind)).toEqual(["client", "relay"]);
+    expect(vantages[1].source).toBe("a.json#relay");
+    expect(vantages[1].observer).toBe("12D3KooWRELAY");
+  });
+
+  it("gives a client vantage an epoch and a relay vantage none", () => {
+    // A relay event's `t` is already unix ms: the relay has no session start.
+    const bundle = bundleOf("pA", 5000, [event("session.start", 0)], {
+      relayView: relayView("pA", [event("rv.open", 7000)]),
+    });
+    const [client, relay] = vantagesOf(bundle, "a.json");
+    expect(client.epoch).toBe(5000);
+    expect(relay.epoch).toBe(0);
+  });
+});
+
+describe("peerIdsOf", () => {
+  it("names the observer, every peer ref, every event peer and every relay member", () => {
+    const bundle = bundleOf("pA", 1000, [event("peer.connect", 5, { peer: "pB" })], {
+      peers: [
+        { peerId: "pC", identityRef: null, firstSeen: 0, lastSeen: 1 },
+      ],
+      relayView: relayView("pA", []),
+    });
+    const [client, relay] = vantagesOf(bundle, "a.json");
+    expect([...peerIdsOf(client)].sort()).toEqual(["pA", "pB", "pC"]);
+    expect([...peerIdsOf(relay)]).toContain("pA");
+  });
+});
+
+describe("skewSamples", () => {
+  it("computes the NTP offset from the four timestamps", () => {
+    // A remote clock 1000 ms ahead, with a 20 ms symmetric path.
+    const bundle = bundleOf("pA", 0, [
+      event("peer.clock", 100, {
+        peer: "pB",
+        d: { t0: 1000, t1: 2010, t2: 2010, t3: 1020 },
+      }),
+    ]);
+    const [client] = vantagesOf(bundle, "a.json");
+    expect(skewSamples(client)).toEqual([
+      { from: "a.json", peer: "pB", offsetMs: 1000 },
+    ]);
+  });
+
+  it("ignores a clock event with a missing timestamp", () => {
+    const bundle = bundleOf("pA", 0, [
+      event("peer.clock", 100, { peer: "pB", d: { t0: 1, t1: 2 } }),
+    ]);
+    expect(skewSamples(vantagesOf(bundle, "a.json")[0])).toEqual([]);
+  });
+
+  it("ignores a clock event with no peer", () => {
+    const bundle = bundleOf("pA", 0, [
+      event("peer.clock", 100, { d: { t0: 1, t1: 2, t2: 3, t3: 4 } }),
+    ]);
+    expect(skewSamples(vantagesOf(bundle, "a.json")[0])).toEqual([]);
+  });
+});
+
+describe("solveSkew", () => {
+  function clockEvent(peer: string, offset: number, t: number): DiagEvent {
+    return event("peer.clock", t, {
+      peer,
+      d: { t0: 1000, t1: 1000 + offset, t2: 1000 + offset, t3: 1000 },
+    });
+  }
+
+  it("anchors on the vantage with the most samples and solves the rest", () => {
+    const a = bundleOf("pA", 0, [
+      clockEvent("pB", 1000, 10),
+      clockEvent("pB", 1000, 20),
+    ]);
+    const b = bundleOf("pB", 0, [clockEvent("pA", -1000, 15)]);
+    const vantages = [
+      ...vantagesOf(a, "a.json"),
+      ...vantagesOf(b, "b.json"),
+    ];
+    const solved = solveSkew(vantages);
+    expect(solved.offsets.get("a.json")).toBe(0);
+    expect(solved.offsets.get("b.json")).toBeCloseTo(1000, 0);
+    expect(solved.maxResidualMs).toBeLessThan(1);
+  });
+
+  it("reports a residual when two vantages disagree", () => {
+    // A and B measure each other and their answers do not agree, which is what
+    // an asymmetric path does. The residual is what makes every cross-vantage
+    // finding suspect.
+    const a = bundleOf("pA", 0, [clockEvent("pB", 5000, 10)]);
+    const b = bundleOf("pB", 0, [clockEvent("pA", 5000, 15)]);
+    const solved = solveSkew([
+      ...vantagesOf(a, "a.json"),
+      ...vantagesOf(b, "b.json"),
+    ]);
+    expect(solved.maxResidualMs).toBeGreaterThan(MAX_ACCEPTABLE_SKEW_MS);
+  });
+
+  it("warns when two client vantages carry no clock sample at all", () => {
+    const a = bundleOf("pA", 0, [event("peer.connect", 1, { peer: "pB" })]);
+    const b = bundleOf("pB", 0, [event("peer.connect", 1, { peer: "pA" })]);
+    const solved = solveSkew([
+      ...vantagesOf(a, "a.json"),
+      ...vantagesOf(b, "b.json"),
+    ]);
+    expect(solved.warnings).toHaveLength(1);
+    expect(solved.warnings[0]).toContain("No peer.clock samples");
+    expect(solved.offsets.get("b.json")).toBe(0);
+  });
+
+  it("does not warn for a single client vantage, which needs no correction", () => {
+    const a = bundleOf("pA", 0, [event("peer.connect", 1, { peer: "pB" })]);
+    expect(solveSkew(vantagesOf(a, "a.json")).warnings).toEqual([]);
+  });
+
+  it("leaves a relay vantage at zero, since it is its own reference", () => {
+    const a = bundleOf("pA", 0, [clockEvent("pB", 1000, 10)], {
+      relayView: relayView("pA", [event("rv.open", 7000)]),
+    });
+    const b = bundleOf("pB", 0, [clockEvent("pA", -1000, 15)]);
+    const solved = solveSkew([
+      ...vantagesOf(a, "a.json"),
+      ...vantagesOf(b, "b.json"),
+    ]);
+    expect(solved.offsets.get("a.json#relay")).toBe(0);
+  });
+
+  it("ignores a sample about a peer that uploaded nothing", () => {
+    const a = bundleOf("pA", 0, [clockEvent("pGhost", 9000, 10)]);
+    const solved = solveSkew(vantagesOf(a, "a.json"));
+    expect(solved.maxResidualMs).toBe(0);
+    expect(solved.offsets.get("a.json")).toBe(0);
+  });
+});
+
+describe("mergeSources", () => {
+  it("groups vantages that overlap and share a peer into one capture", () => {
+    const a = bundleOf("pA", 1000, [event("peer.connect", 100, { peer: "pB" })]);
+    const b = bundleOf("pB", 1200, [event("peer.connect", 100, { peer: "pA" })]);
+    const ws = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: b, source: "b.json" },
+    ]);
+    expect(ws.captures).toHaveLength(1);
+    expect(ws.captures[0].vantages).toHaveLength(2);
+  });
+
+  it("keeps two unrelated sessions apart", () => {
+    const a = bundleOf("pA", 1000, [event("peer.connect", 10, { peer: "pB" })]);
+    const far = bundleOf("pZ", 900_000_000, [
+      event("peer.connect", 10, { peer: "pY" }),
+    ]);
+    const ws = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: far, source: "z.json" },
+    ]);
+    expect(ws.captures).toHaveLength(2);
+  });
+
+  it("keeps overlapping vantages apart when they share no peer", () => {
+    // Two unrelated incidents at the same moment are not one incident.
+    const a = bundleOf("pA", 1000, [event("peer.connect", 10, { peer: "pB" })]);
+    const c = bundleOf("pC", 1000, [event("peer.connect", 10, { peer: "pD" })]);
+    const ws = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: c, source: "c.json" },
+    ]);
+    expect(ws.captures).toHaveLength(2);
+  });
+
+  it("refuses a bundle from an unknown schema version, loudly", () => {
+    const a = bundleOf("pA", 1000, []);
+    const ws = mergeSources([
+      {
+        bundle: { ...a, schemaVersion: 99 } as unknown as ClientBundle,
+        source: "future.json",
+      },
+    ]);
+    expect(ws.captures).toEqual([]);
+    expect(ws.warnings[0]).toContain("future.json");
+  });
+
+  it("makes every timeline entry absolute and sorted", () => {
+    const a = bundleOf("pA", 10_000, [
+      event("session.start", 0),
+      event("peer.connect", 500, { peer: "pB" }),
+    ]);
+    const [capture] = mergeSources([{ bundle: a, source: "a.json" }]).captures;
+    expect(capture.timeline.map((e) => e.at)).toEqual([10_000, 10_500]);
+    expect(capture.timeline[0].vantage).toBe("client");
+    expect(capture.timeline[0].observer).toBe("pA");
+    expect(capture.timeline[0].source).toBe("a.json");
+  });
+
+  it("interleaves a relay vantage by absolute time", () => {
+    const a = bundleOf(
+      "pA",
+      10_000,
+      [event("session.start", 0), event("peer.connect", 500, { peer: "pB" })],
+      { relayView: relayView("pA", [event("rv.open", 10_200)]) }
+    );
+    const [capture] = mergeSources([{ bundle: a, source: "a.json" }]).captures;
+    expect(capture.timeline.map((e) => e.kind)).toEqual([
+      "session.start",
+      "rv.open",
+      "peer.connect",
+    ]);
+  });
+
+  it("summarises peers, and marks the ones that uploaded a vantage", () => {
+    const a = bundleOf("pA", 1000, [event("peer.connect", 10, { peer: "pB" })]);
+    const b = bundleOf("pB", 1000, [event("peer.connect", 10, { peer: "pA" })]);
+    const [capture] = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: b, source: "b.json" },
+    ]).captures;
+    expect(capture.peers.get("pA")?.hasVantage).toBe(true);
+    expect(capture.peers.get("pB")?.hasVantage).toBe(true);
+    expect(capture.peers.get("pA")?.observers.sort()).toEqual(["pA", "pB"]);
+  });
+
+  it("scopes a room ref to its bundle, since r1 in two bundles is two rooms", () => {
+    // A room code is the room's only membership secret, so there is no way to
+    // join two bundles' refs, and pretending otherwise would invent a room.
+    const a = bundleOf("pA", 1000, [
+      event("app.join", 10, { peer: "pB", room: "r1" }),
+    ]);
+    const b = bundleOf("pB", 1000, [
+      event("app.join", 10, { peer: "pA", room: "r1" }),
+    ]);
+    const [capture] = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: b, source: "b.json" },
+    ]).captures;
+    expect([...capture.rooms.keys()].sort()).toEqual(["a.json:r1", "b.json:r1"]);
+  });
+
+  it("shares a relay room ref, which is an HMAC under one boot secret", () => {
+    const a = bundleOf("pA", 1000, [event("session.start", 0)], {
+      relayView: relayView("pA", [event("rv.register", 1100, { room: "h:abc" })]),
+    });
+    const b = bundleOf("pB", 1000, [event("session.start", 0)], {
+      relayView: relayView("pB", [event("rv.register", 1100, { room: "h:abc" })]),
+    });
+    const [capture] = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: b, source: "b.json" },
+    ]).captures;
+    expect([...capture.rooms.keys()]).toContain("relay:h:abc");
+  });
+
+  it("puts a log source in its own vantage so a mis-parse is attributable", () => {
+    const a = bundleOf("pA", 1000, [event("peer.connect", 10, { peer: "pB" })]);
+    const ws = mergeSources(
+      [{ bundle: a, source: "a.json" }],
+      [
+        {
+          ...event("rv.open", 0),
+          at: 1200,
+          vantage: "log",
+          source: "relay.log",
+          observer: "pA",
+        },
+      ]
+    );
+    expect(ws.captures).toHaveLength(1);
+    const kinds = ws.captures[0].vantages.map((v) => v.kind);
+    expect(kinds).toContain("log");
+    expect(ws.captures[0].timeline.map((e) => e.at)).toEqual([1010, 1200]);
+  });
+
+  it("orders captures newest first", () => {
+    const older = bundleOf("pA", 1000, [event("peer.connect", 1, { peer: "pB" })]);
+    const newer = bundleOf("pZ", 900_000_000, [
+      event("peer.connect", 1, { peer: "pY" }),
+    ]);
+    const ws = mergeSources([
+      { bundle: older, source: "a.json" },
+      { bundle: newer, source: "z.json" },
+    ]);
+    expect(ws.captures[0].window.from).toBeGreaterThan(
+      ws.captures[1].window.from
+    );
+  });
+
+  it("carries the skew warning into the capture", () => {
+    const a = bundleOf("pA", 0, [event("peer.connect", 1, { peer: "pB" })]);
+    const b = bundleOf("pB", 0, [event("peer.connect", 1, { peer: "pA" })]);
+    const [capture] = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: b, source: "b.json" },
+    ]).captures;
+    expect(capture.warnings.join(" ")).toContain("No peer.clock samples");
+  });
+
+  it("returns an empty workspace for no input", () => {
+    expect(mergeSources([])).toEqual({ captures: [], warnings: [] });
+  });
+
+  it("applies the solved offset to a vantage's own times", () => {
+    const a = bundleOf("pA", 0, [
+      event("peer.clock", 10, {
+        peer: "pB",
+        d: { t0: 1000, t1: 2000, t2: 2000, t3: 1000 },
+      }),
+    ]);
+    const b = bundleOf("pB", 0, [
+      event("peer.connect", 10, { peer: "pA" }),
+      event("peer.clock", 20, {
+        peer: "pA",
+        d: { t0: 1000, t1: 0, t2: 0, t3: 1000 },
+      }),
+    ]);
+    const [capture] = mergeSources([
+      { bundle: a, source: "a.json" },
+      { bundle: b, source: "b.json" },
+    ]).captures;
+    const bVantage = capture.vantages.find(
+      (v: LoadedVantage) => v.source === "b.json"
+    );
+    expect(bVantage?.offset).toBeCloseTo(1000, 0);
+    const bEvent = capture.timeline.find((e) => e.source === "b.json");
+    expect(bEvent?.at).toBeCloseTo(1010, 0);
+  });
+});

--- a/dashboard/src/lib/analysis/merge.ts
+++ b/dashboard/src/lib/analysis/merge.ts
@@ -1,0 +1,611 @@
+/**
+ * The workspace model: many loaded vantages become a small number of captures,
+ * each with one absolute-time timeline.
+ *
+ * Two problems make this more than a concatenation.
+ *
+ * 1. GROUPING. Nothing in a bundle names the incident it belongs to. Two
+ *    vantages belong to the same capture when their wall-clock windows overlap
+ *    AND they share at least one peerId. No shared secret and no new wire
+ *    message is needed: a peerId is the join key, and both servers already
+ *    know it.
+ * 2. CLOCK SKEW. Two browsers disagree about `Date.now()` by seconds. Without
+ *    a correction, "A saw B connect before B saw A" is noise, and every
+ *    cross-vantage finding is worthless. `peer.clock` events carry the four
+ *    NTP-style timestamps, which give one offset measurement per peer pair.
+ */
+
+import type {
+  ClientBundle,
+  DiagBundle,
+  DiagEvent,
+  DiagKind,
+  DiagPeerRef,
+  RelayVantage,
+} from "../schema";
+
+/** Beyond this the correction failed and every cross-vantage finding is suspect. */
+export const MAX_ACCEPTABLE_SKEW_MS = 2000;
+
+/** Jacobi iterations for the offset solve. The system is tiny and converges fast. */
+const SOLVE_ITERATIONS = 200;
+
+export type VantageKind = "client" | "relay" | "sfu" | "log";
+
+export interface LoadedVantage {
+  /** The file, or the relay bundle id, this came from. */
+  source: string;
+  kind: VantageKind;
+  /**
+   * Vantages that came out of ONE loaded file. They are the same session by
+   * construction, so they are grouped together even when clock skew pushed a
+   * window out of overlap.
+   */
+  bundleKey: string;
+  /** peerId of the observer, so "who saw this" is never ambiguous. */
+  observer: string;
+  /** Wall clock ms of the observer's `t = 0`. Zero for an already-absolute vantage. */
+  epoch: number;
+  /** Applied skew correction, added to every absolute time. */
+  offset: number;
+  events: VantageEvent[];
+  window: { from: number; to: number };
+  /** Present for a client vantage. */
+  bundle?: ClientBundle;
+  /** Present for a relay vantage. */
+  relay?: RelayVantage;
+}
+
+/**
+ * A log line that no template matched.
+ *
+ * NOT a wire kind: it never appears in a bundle, so it is deliberately absent
+ * from `DiagKind`. It exists so a parser can keep an unrecognised line rather
+ * than drop it silently, and so a reader can see that it was not understood.
+ */
+export const LOG_RAW_KIND = "log.raw";
+
+/** A wire kind, or the dashboard's own "not understood" marker. */
+export type MergedKind = DiagKind | typeof LOG_RAW_KIND;
+
+/**
+ * An event as held by a vantage: a wire event from a bundle, or a line a log
+ * parser recognised - or did not.
+ */
+export type VantageEvent = Omit<DiagEvent, "kind"> & { kind: MergedKind };
+
+export interface MergedEvent extends Omit<DiagEvent, "kind"> {
+  kind: MergedKind;
+  /** Absolute wall-clock ms after skew correction. */
+  at: number;
+  vantage: VantageKind;
+  /** Which loaded file this came from. */
+  source: string;
+  /** peerId of the observer. */
+  observer: string;
+}
+
+export interface PeerSummary {
+  peerId: string;
+  /** Identity ordinals are bundle-local, so this is a set of `source:ref`. */
+  identityRefs: string[];
+  /** Observers that named this peer. */
+  observers: string[];
+  firstSeen: number;
+  lastSeen: number;
+  /** True when this peer uploaded a vantage of its own. */
+  hasVantage: boolean;
+}
+
+export interface RoomSummary {
+  /**
+   * `source:ref` for a client vantage, `relay:ref` for a relay vantage.
+   *
+   * A client room ref is bundle-local: "r1" in two bundles is two different
+   * rooms, and there is deliberately no way to join them - the room code is
+   * the room's only membership secret. A relay ref is an HMAC under one boot
+   * secret, so relay refs from ONE relay lifetime do join.
+   */
+  key: string;
+  ref: string;
+  kind: "text" | "dm" | "sync" | "unknown";
+  observers: string[];
+  eventCount: number;
+}
+
+export interface Capture {
+  /** Derived and stable: the earliest observer plus the window start. */
+  id: string;
+  window: { from: number; to: number };
+  vantages: LoadedVantage[];
+  /** Every event from every vantage, skew-corrected, sorted by absolute time. */
+  timeline: MergedEvent[];
+  peers: Map<string, PeerSummary>;
+  rooms: Map<string, RoomSummary>;
+  /** Worst residual left by the offset solve, in ms. */
+  maxSkewResidualMs: number;
+  warnings: string[];
+}
+
+export interface Workspace {
+  captures: Capture[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Vantage extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a loaded bundle into its vantages. A stapled relay view is a SECOND
+ * vantage on the same session, not part of the client's.
+ */
+export function vantagesOf(bundle: DiagBundle, source: string): LoadedVantage[] {
+  const out: LoadedVantage[] = [];
+  const clientTimes = bundle.events.map((e) => bundle.startedAt + e.t);
+  out.push({
+    source,
+    kind: "client",
+    bundleKey: source,
+    observer: bundle.self.peerId,
+    epoch: bundle.startedAt,
+    offset: 0,
+    events: bundle.events,
+    window: {
+      from: bundle.startedAt,
+      to: Math.max(bundle.createdAt, ...clientTimes, bundle.startedAt),
+    },
+    bundle,
+  });
+
+  const view = bundle.relayView;
+  if (view) {
+    // A relay event's `t` is already unix ms: the relay has no session start.
+    const times = view.events.map((e) => e.t);
+    out.push({
+      source: `${source}#relay`,
+      kind: "relay",
+      bundleKey: source,
+      observer: view.relayPeerId,
+      epoch: 0,
+      offset: 0,
+      events: view.events,
+      window: {
+        from: times.length > 0 ? Math.min(...times) : bundle.startedAt,
+        to: times.length > 0 ? Math.max(...times) : bundle.createdAt,
+      },
+      relay: view,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+
+/** Every peerId a vantage names: its observer, and every peer it mentions. */
+export function peerIdsOf(v: LoadedVantage): Set<string> {
+  const ids = new Set<string>();
+  if (v.observer) ids.add(v.observer);
+  for (const p of v.bundle?.peers ?? []) ids.add(p.peerId);
+  for (const e of v.events) {
+    if (e.peer) ids.add(e.peer);
+  }
+  for (const room of v.relay?.rooms ?? []) {
+    for (const m of room.members) ids.add(m);
+  }
+  if (v.relay) ids.add(v.relay.observedPeerId);
+  return ids;
+}
+
+function overlaps(a: LoadedVantage, b: LoadedVantage): boolean {
+  return a.window.from <= b.window.to && b.window.from <= a.window.to;
+}
+
+function sharesPeer(a: Set<string>, b: Set<string>): boolean {
+  for (const id of a) {
+    if (b.has(id)) return true;
+  }
+  return false;
+}
+
+/** Union-find over the "same capture" relation. */
+function group(vantages: LoadedVantage[]): LoadedVantage[][] {
+  const parent = vantages.map((_, i) => i);
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]];
+      i = parent[i];
+    }
+    return i;
+  };
+  const ids = vantages.map(peerIdsOf);
+  for (let i = 0; i < vantages.length; i++) {
+    for (let j = i + 1; j < vantages.length; j++) {
+      const sameFile = vantages[i].bundleKey === vantages[j].bundleKey;
+      if (!sameFile) {
+        if (!overlaps(vantages[i], vantages[j])) continue;
+        if (!sharesPeer(ids[i], ids[j])) continue;
+      }
+      parent[find(i)] = find(j);
+    }
+  }
+  const byRoot = new Map<number, LoadedVantage[]>();
+  for (let i = 0; i < vantages.length; i++) {
+    const root = find(i);
+    const list = byRoot.get(root);
+    if (list) list.push(vantages[i]);
+    else byRoot.set(root, [vantages[i]]);
+  }
+  return [...byRoot.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Clock skew
+// ---------------------------------------------------------------------------
+
+export interface SkewSample {
+  /** The observer's vantage source. */
+  from: string;
+  /** The observed peer. */
+  peer: string;
+  /** `remote clock - local clock`, in ms. */
+  offsetMs: number;
+}
+
+/**
+ * One offset measurement per `peer.clock` event.
+ *
+ * `offset = ((t1 - t0) + (t2 - t3)) / 2` is the standard NTP estimator: it
+ * cancels a symmetric path delay, so an asymmetric path is the only thing that
+ * biases it.
+ */
+export function skewSamples(v: LoadedVantage): SkewSample[] {
+  const out: SkewSample[] = [];
+  for (const e of v.events) {
+    if (e.kind !== "peer.clock" || !e.peer || !e.d) continue;
+    const { t0, t1, t2, t3 } = e.d;
+    if (
+      typeof t0 !== "number" ||
+      typeof t1 !== "number" ||
+      typeof t2 !== "number" ||
+      typeof t3 !== "number"
+    ) {
+      continue;
+    }
+    out.push({
+      from: v.source,
+      peer: e.peer,
+      offsetMs: (t1 - t0 + (t2 - t3)) / 2,
+    });
+  }
+  return out;
+}
+
+export interface SkewSolution {
+  /** Offset per vantage source, to be ADDED to that vantage's times. */
+  offsets: Map<string, number>;
+  maxResidualMs: number;
+  warnings: string[];
+}
+
+/**
+ * Solve for a per-vantage offset.
+ *
+ * A sample says `clock(peer) - clock(observer) = offsetMs`. With one unknown
+ * per vantage that is a linear system whose least-squares solution is the
+ * minimiser of the sum of squared residuals. Jacobi iteration on the graph
+ * Laplacian reaches it; the anchor is pinned at zero, so the solution is a
+ * common time base rather than a true wall clock.
+ *
+ * The anchor is the vantage with the most samples, because it is the one whose
+ * measurements the rest are corrected against.
+ */
+export function solveSkew(vantages: LoadedVantage[]): SkewSolution {
+  const warnings: string[] = [];
+  const bySource = new Map<string, LoadedVantage>();
+  for (const v of vantages) bySource.set(v.source, v);
+
+  // A sample names a PEER, not a vantage. Only a peer that uploaded a vantage
+  // of its own can be corrected; the rest are measurements of an unknown clock.
+  const vantageOfPeer = new Map<string, string>();
+  for (const v of vantages) {
+    if (v.kind === "client" && v.observer) vantageOfPeer.set(v.observer, v.source);
+  }
+
+  const edges: Array<{ a: string; b: string; delta: number }> = [];
+  const sampleCount = new Map<string, number>();
+  for (const v of vantages) {
+    for (const s of skewSamples(v)) {
+      const b = vantageOfPeer.get(s.peer);
+      if (!b || b === s.from) continue;
+      edges.push({ a: s.from, b, delta: s.offsetMs });
+      sampleCount.set(s.from, (sampleCount.get(s.from) ?? 0) + 1);
+      sampleCount.set(b, (sampleCount.get(b) ?? 0) + 1);
+    }
+  }
+
+  const offsets = new Map<string, number>();
+  for (const v of vantages) offsets.set(v.source, 0);
+
+  if (edges.length === 0) {
+    if (vantages.filter((v) => v.kind === "client").length > 1) {
+      warnings.push(
+        "No peer.clock samples: vantage offsets are 0 and every cross-vantage finding is suspect."
+      );
+    }
+    return { offsets, maxResidualMs: 0, warnings };
+  }
+
+  let anchor = vantages[0].source;
+  let best = -1;
+  for (const [source, n] of sampleCount) {
+    if (n > best) {
+      best = n;
+      anchor = source;
+    }
+  }
+
+  // Average duplicate measurements of one edge first, so a chatty pair does
+  // not outvote a quiet one.
+  const merged = new Map<string, { a: string; b: string; delta: number; n: number }>();
+  for (const e of edges) {
+    const key = `${e.a}|${e.b}`;
+    const hit = merged.get(key);
+    if (hit) {
+      hit.delta += e.delta;
+      hit.n++;
+    } else merged.set(key, { ...e, n: 1 });
+  }
+  const averaged = [...merged.values()].map((e) => ({
+    a: e.a,
+    b: e.b,
+    delta: e.delta / e.n,
+  }));
+
+  for (let iter = 0; iter < SOLVE_ITERATIONS; iter++) {
+    const sums = new Map<string, { total: number; n: number }>();
+    for (const e of averaged) {
+      // b = a + delta, and a = b - delta.
+      add(sums, e.b, (offsets.get(e.a) ?? 0) + e.delta);
+      add(sums, e.a, (offsets.get(e.b) ?? 0) - e.delta);
+    }
+    for (const [source, { total, n }] of sums) {
+      if (source === anchor) continue;
+      offsets.set(source, total / n);
+    }
+    offsets.set(anchor, 0);
+  }
+
+  let maxResidualMs = 0;
+  for (const e of averaged) {
+    const predicted = (offsets.get(e.b) ?? 0) - (offsets.get(e.a) ?? 0);
+    maxResidualMs = Math.max(maxResidualMs, Math.abs(predicted - e.delta));
+  }
+
+  for (const v of vantages) {
+    if (v.kind !== "client") continue;
+    if (sampleCount.has(v.source)) continue;
+    warnings.push(
+      `${v.source}: no peer.clock sample, so its offset is 0 and its times may be wrong.`
+    );
+  }
+
+  // A relay vantage's times come from ONE machine's clock, and it is the only
+  // clock the relay ever reports, so it is the reference for itself.
+  for (const v of vantages) {
+    if (v.kind === "relay") offsets.set(v.source, 0);
+  }
+
+  return { offsets, maxResidualMs, warnings };
+}
+
+function add(
+  sums: Map<string, { total: number; n: number }>,
+  key: string,
+  value: number
+): void {
+  const hit = sums.get(key);
+  if (hit) {
+    hit.total += value;
+    hit.n++;
+  } else sums.set(key, { total: value, n: 1 });
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+function roomKey(v: LoadedVantage, ref: string): string {
+  return v.kind === "relay" ? `relay:${ref}` : `${v.source}:${ref}`;
+}
+
+function buildCapture(vantages: LoadedVantage[]): Capture {
+  const skew = solveSkew(vantages);
+  const timeline: MergedEvent[] = [];
+
+  for (const v of vantages) {
+    v.offset = skew.offsets.get(v.source) ?? 0;
+    for (const e of v.events) {
+      timeline.push({
+        ...e,
+        at: v.epoch + e.t + v.offset,
+        vantage: v.kind,
+        source: v.source,
+        observer: v.observer,
+      });
+    }
+  }
+  // Stable: a tie keeps the order the vantages were loaded in, then `seq`.
+  timeline.sort((a, b) => a.at - b.at || a.seq - b.seq);
+
+  const peers = new Map<string, PeerSummary>();
+  const touch = (peerId: string, at: number, observer: string): void => {
+    const hit = peers.get(peerId);
+    if (hit) {
+      hit.firstSeen = Math.min(hit.firstSeen, at);
+      hit.lastSeen = Math.max(hit.lastSeen, at);
+      if (!hit.observers.includes(observer)) hit.observers.push(observer);
+      return;
+    }
+    peers.set(peerId, {
+      peerId,
+      identityRefs: [],
+      observers: [observer],
+      firstSeen: at,
+      lastSeen: at,
+      hasVantage: false,
+    });
+  };
+
+  for (const v of vantages) {
+    if (v.observer) touch(v.observer, v.window.from, v.observer);
+    for (const ref of v.bundle?.peers ?? []) {
+      touch(ref.peerId, v.epoch + ref.firstSeen + v.offset, v.observer);
+      touch(ref.peerId, v.epoch + ref.lastSeen + v.offset, v.observer);
+      recordIdentity(peers, v, ref);
+    }
+  }
+  for (const e of timeline) {
+    if (e.peer) touch(e.peer, e.at, e.observer);
+  }
+  for (const v of vantages) {
+    const hit = peers.get(v.observer);
+    if (hit) hit.hasVantage = true;
+  }
+
+  const rooms = new Map<string, RoomSummary>();
+  for (const v of vantages) {
+    for (const r of v.bundle?.rooms ?? []) {
+      rooms.set(roomKey(v, r.ref), {
+        key: roomKey(v, r.ref),
+        ref: r.ref,
+        kind: r.kind,
+        observers: [v.observer],
+        eventCount: 0,
+      });
+    }
+    for (const r of v.relay?.rooms ?? []) {
+      const key = roomKey(v, r.ref);
+      if (!rooms.has(key)) {
+        rooms.set(key, {
+          key,
+          ref: r.ref,
+          kind: "unknown",
+          observers: [v.observer],
+          eventCount: 0,
+        });
+      }
+    }
+  }
+  for (const e of timeline) {
+    if (!e.room) continue;
+    const v = vantages.find((x) => x.source === e.source);
+    if (!v) continue;
+    const key = roomKey(v, e.room);
+    const hit = rooms.get(key);
+    if (hit) {
+      hit.eventCount++;
+      if (!hit.observers.includes(e.observer)) hit.observers.push(e.observer);
+    } else {
+      rooms.set(key, {
+        key,
+        ref: e.room,
+        kind: "unknown",
+        observers: [e.observer],
+        eventCount: 1,
+      });
+    }
+  }
+
+  const from = Math.min(...vantages.map((v) => v.window.from + v.offset));
+  const to = Math.max(...vantages.map((v) => v.window.to + v.offset));
+  const anchor = [...vantages].sort((a, b) => a.source.localeCompare(b.source))[0];
+
+  const warnings = [...skew.warnings];
+  if (skew.maxResidualMs > MAX_ACCEPTABLE_SKEW_MS) {
+    warnings.push(
+      `Clock offsets did not converge: worst residual ${Math.round(skew.maxResidualMs)} ms.`
+    );
+  }
+
+  return {
+    id: `${anchor.source}@${from}`,
+    window: { from, to },
+    vantages,
+    timeline,
+    peers,
+    rooms,
+    maxSkewResidualMs: skew.maxResidualMs,
+    warnings,
+  };
+}
+
+function recordIdentity(
+  peers: Map<string, PeerSummary>,
+  v: LoadedVantage,
+  ref: DiagPeerRef
+): void {
+  if (!ref.identityRef) return;
+  const hit = peers.get(ref.peerId);
+  if (!hit) return;
+  const scoped = `${v.source}:${ref.identityRef}`;
+  if (!hit.identityRefs.includes(scoped)) hit.identityRefs.push(scoped);
+}
+
+/**
+ * Build the workspace.
+ *
+ * @param bundles loaded client bundles, each possibly with a stapled relay view
+ * @param logEvents events parsed from raw server or console logs, already
+ *   absolute-timed by `logs.ts`
+ */
+export function mergeSources(
+  bundles: Array<{ bundle: DiagBundle; source: string }>,
+  logEvents: MergedEvent[] = []
+): Workspace {
+  const warnings: string[] = [];
+  const vantages: LoadedVantage[] = [];
+
+  for (const { bundle, source } of bundles) {
+    if (bundle.schemaVersion !== 1) {
+      warnings.push(
+        `${source}: schema version ${bundle.schemaVersion} is not understood, so it was refused.`
+      );
+      continue;
+    }
+    vantages.push(...vantagesOf(bundle, source));
+  }
+
+  // A log vantage per source, so a mis-parse is attributable to one file.
+  const bySource = new Map<string, MergedEvent[]>();
+  for (const e of logEvents) {
+    const list = bySource.get(e.source);
+    if (list) list.push(e);
+    else bySource.set(e.source, [e]);
+  }
+  for (const [source, events] of bySource) {
+    const times = events.map((e) => e.at);
+    vantages.push({
+      source,
+      kind: "log",
+      bundleKey: source,
+      observer: events[0]?.observer ?? "",
+      epoch: 0,
+      offset: 0,
+      // A log event is already absolute, so `t` carries the absolute time too.
+      events: events.map((e) => ({ ...e, t: e.at })),
+      window: {
+        from: times.length > 0 ? Math.min(...times) : 0,
+        to: times.length > 0 ? Math.max(...times) : 0,
+      },
+    });
+  }
+
+  const captures = group(vantages)
+    .map(buildCapture)
+    .sort((a, b) => b.window.from - a.window.from);
+
+  return { captures, warnings };
+}

--- a/dashboard/src/lib/analysis/prompt.test.ts
+++ b/dashboard/src/lib/analysis/prompt.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { buildPromptPack } from "./prompt";
+import type { Capture, LoadedVantage, MergedEvent, PeerSummary } from "./merge";
+import type { Finding } from "./findings";
+import type { DiagKind, DiagSeverity } from "../schema";
+
+const SELF = "12D3KooWSelfPeerAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1";
+const OTHER = "12D3KooWOtherPeerBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB2";
+/** A real 16-hex room code, exactly the format `roomKind` classifies. */
+const ROOM_CODE = "a1b2c3d4e5f60718";
+const DID = "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG";
+
+function mkEvent(overrides: {
+  at: number;
+  kind: DiagKind;
+  sev?: DiagSeverity;
+  peer?: string | null;
+  d?: Record<string, string | number | boolean | null>;
+}): MergedEvent {
+  return {
+    seq: overrides.at,
+    t: overrides.at,
+    kind: overrides.kind,
+    sev: overrides.sev ?? "info",
+    peer: overrides.peer ?? null,
+    room: null,
+    d: overrides.d,
+    at: overrides.at,
+    vantage: "client",
+    source: "fixture.json",
+    observer: SELF,
+  };
+}
+
+function makeCapture(timeline: MergedEvent[]): Capture {
+  const from = timeline[0]?.at ?? 0;
+  const to = timeline[timeline.length - 1]?.at ?? 0;
+  const vantage: LoadedVantage = {
+    source: "fixture.json",
+    kind: "client",
+    bundleKey: "fixture.json",
+    observer: SELF,
+    epoch: 0,
+    offset: 0,
+    events: timeline,
+    window: { from, to },
+  };
+  const otherSummary: PeerSummary = {
+    peerId: OTHER,
+    identityRefs: [],
+    observers: [SELF],
+    firstSeen: from,
+    lastSeen: to,
+    hasVantage: false,
+  };
+  return {
+    id: "fixture",
+    window: { from, to },
+    vantages: [vantage],
+    timeline,
+    peers: new Map([[OTHER, otherSummary]]),
+    rooms: new Map(),
+    maxSkewResidualMs: 0,
+    warnings: [],
+  };
+}
+
+function blockingFinding(evidenceIndex: number): Finding {
+  return {
+    id: "connected-not-proven",
+    severity: "block",
+    subject: { peer: OTHER },
+    evidence: [evidenceIndex],
+    detail: { note: "unproven" },
+  };
+}
+
+const SECTION_HEADINGS = [
+  "## 1. What awful.chat is",
+  "## 2. Event schema and kinds present",
+  "## 3. Findings",
+  "## 4. Topology",
+  "## 5. Event window",
+  "## 6. Question",
+];
+
+describe("buildPromptPack", () => {
+  it("never leaks a room code or a did:key, even from a d bag a log parser filled in", () => {
+    const timeline = [
+      mkEvent({ at: 0, kind: "session.start" }),
+      mkEvent({ at: 1000, kind: "rv.register", peer: OTHER, d: { roomRaw: ROOM_CODE } }),
+      mkEvent({
+        at: 2000,
+        kind: "app.profile.reject",
+        peer: OTHER,
+        sev: "warn",
+        d: { reason: DID },
+      }),
+      mkEvent({ at: 3000, kind: "peer.connect", peer: OTHER }),
+      mkEvent({ at: 4000, kind: "peer.upgrade.fail", peer: OTHER, sev: "error" }),
+    ];
+    const c = makeCapture(timeline);
+    const findings = [blockingFinding(4)];
+
+    const { markdown } = buildPromptPack(c, findings);
+
+    expect(markdown).not.toContain(ROOM_CODE);
+    expect(markdown.toLowerCase()).not.toContain("did:key:");
+    expect(markdown).toContain("[redacted-room]");
+    expect(markdown).toContain("[redacted-did]");
+  });
+
+  it("renders the six sections in order", () => {
+    const timeline = [
+      mkEvent({ at: 0, kind: "session.start" }),
+      mkEvent({ at: 1000, kind: "peer.connect", peer: OTHER }),
+    ];
+    const c = makeCapture(timeline);
+
+    const { markdown } = buildPromptPack(c, []);
+
+    let lastIndex = -1;
+    for (const heading of SECTION_HEADINGS) {
+      const index = markdown.indexOf(heading);
+      expect(index).toBeGreaterThan(lastIndex);
+      lastIndex = index;
+    }
+  });
+
+  it("produces a usable pack for a capture with no findings", () => {
+    const timeline = [mkEvent({ at: 0, kind: "session.start" })];
+    const c = makeCapture(timeline);
+
+    const { markdown, tokensEstimate } = buildPromptPack(c, []);
+
+    expect(markdown).toContain("No findings fired for this capture.");
+    expect(markdown).toContain("(no blocking finding in this capture)");
+    for (const heading of SECTION_HEADINGS) expect(markdown).toContain(heading);
+    expect(tokensEstimate).toBeGreaterThan(0);
+  });
+
+  it("honours maxEvents, taking the last N events when there is no blocking finding", () => {
+    const timeline = Array.from({ length: 20 }, (_, i) =>
+      mkEvent({ at: i * 1000, kind: "peer.rtt", peer: OTHER, d: { idx: i } }),
+    );
+    const c = makeCapture(timeline);
+
+    const { markdown } = buildPromptPack(c, [], { maxEvents: 7 });
+
+    const idxs = [...markdown.matchAll(/"idx":(\d+)/g)].map((m) => Number(m[1]));
+    expect(idxs).toEqual([13, 14, 15, 16, 17, 18, 19]);
+  });
+
+  it("centres the event window on the first blocking finding's evidence", () => {
+    const timeline = Array.from({ length: 20 }, (_, i) =>
+      mkEvent({ at: i * 1000, kind: "peer.rtt", peer: OTHER, d: { idx: i } }),
+    );
+    const c = makeCapture(timeline);
+    const findings = [blockingFinding(15)];
+
+    const { markdown } = buildPromptPack(c, findings, { maxEvents: 6 });
+
+    const idxs = [...markdown.matchAll(/"idx":(\d+)/g)].map((m) => Number(m[1]));
+    // radius = floor(6/2) = 3; start = 15-3 = 12, end = 12+6 = 18 -> indices 12..17,
+    // which straddles the anchor at 15 rather than trailing behind it.
+    expect(idxs).toEqual([12, 13, 14, 15, 16, 17]);
+    expect(idxs).toContain(15);
+  });
+});

--- a/dashboard/src/lib/analysis/prompt.ts
+++ b/dashboard/src/lib/analysis/prompt.ts
@@ -1,0 +1,306 @@
+/**
+ * The AI prompt pack: everything a model needs to explain WHY a capture
+ * failed, in the order it needs it — the schema and vocabulary before the
+ * data, the deterministic findings before the raw evidence, and the raw
+ * evidence last so the model's own reasoning is grounded in it.
+ *
+ * PRIVACY. This is the dashboard's own output, so it is bound by the same
+ * rule as a client bundle: no room code, no `did:key:`. A bundle never
+ * carries either, but `logs.ts` parses raw SFU/relay logs that DO contain
+ * room codes and peer ids in clear, and a log-derived `MergedEvent` can end
+ * up with a room code sitting in its `d` bag (e.g. `d.roomRaw`) before this
+ * module ever sees it. Every string that reaches the rendered markdown -
+ * every `d`/`detail` value, every rule sentence - is passed through
+ * `sanitizeString`, which strips a `did:key:...` token and any bare run of
+ * 16+ hex characters (the room code format; see `redact.ts` in the
+ * frontend's telemetry module). This is defense in depth: it is not this
+ * module's job to know which upstream parser might slip, only to guarantee
+ * its own output never contains the two forbidden shapes.
+ */
+
+import type { Capture, MergedEvent } from "./merge";
+import type { Finding } from "./findings";
+import { RULES } from "./rules";
+import { foldTopology, type Topology } from "./topology";
+
+export interface PromptPack {
+  markdown: string;
+  tokensEstimate: number;
+}
+
+/** Rendered sections, in the order a model needs them. */
+const SECTION_INTRO = "## 1. What awful.chat is";
+const SECTION_SCHEMA = "## 2. Event schema and kinds present";
+const SECTION_FINDINGS = "## 3. Findings";
+const SECTION_TOPOLOGY = "## 4. Topology";
+const SECTION_EVENTS = "## 5. Event window";
+const SECTION_QUESTION = "## 6. Question";
+
+export function buildPromptPack(
+  c: Capture,
+  findings: Finding[],
+  opts?: { maxEvents?: number },
+): PromptPack {
+  const maxEvents = opts?.maxEvents ?? 400;
+  const blocking = firstBlockingFinding(findings, c);
+  const markdown = [
+    sectionIntro(),
+    sectionSchema(c),
+    sectionFindings(findings),
+    sectionTopology(c, blocking),
+    sectionEventWindow(c, blocking, maxEvents),
+    sectionQuestion(),
+  ].join("\n\n");
+  // Documented approximation: ~4 characters per token, the common rule of
+  // thumb for English/markdown text. This is a token-budget estimate for the
+  // UI, not a tokenizer, so it never counts model-specific tokens exactly.
+  const tokensEstimate = Math.ceil(markdown.length / 4);
+  return { markdown, tokensEstimate };
+}
+
+// ---------------------------------------------------------------------------
+// Redaction - see the module comment. Applied to every string this module
+// emits that did not come from a literal written in this file.
+// ---------------------------------------------------------------------------
+
+const DID_RE = /did:key:[A-Za-z0-9]+/gi;
+/** 16 hex chars is the room code's own format (8 random bytes, hex-encoded). */
+const HEX_ROOM_CODE_RE = /\b[0-9a-fA-F]{16,}\b/g;
+
+function sanitizeString(s: string): string {
+  return s.replace(DID_RE, "[redacted-did]").replace(HEX_ROOM_CODE_RE, "[redacted-room]");
+}
+
+function formatDetail(d?: Record<string, string | number | boolean | null> | null): string {
+  if (!d || Object.keys(d).length === 0) return "{}";
+  const sanitized: Record<string, string | number | boolean | null> = {};
+  for (const [k, v] of Object.entries(d)) {
+    sanitized[sanitizeString(k)] = typeof v === "string" ? sanitizeString(v) : v;
+  }
+  return JSON.stringify(sanitized);
+}
+
+/** Last 8 characters, for a compact human-readable line. Never the join key. */
+function shortId(id: string): string {
+  return id.length > 8 ? id.slice(-8) : id;
+}
+
+// ---------------------------------------------------------------------------
+// Section 1 - what awful.chat is
+// ---------------------------------------------------------------------------
+
+function sectionIntro(): string {
+  return [
+    SECTION_INTRO,
+    "",
+    "awful.chat is a peer-to-peer chat app. Messages, files and voice calls",
+    "go directly between peers over libp2p. No server can read their",
+    "content. A libp2p relay does two jobs: rendezvous, so peers in one room",
+    "can find each other, and circuit relaying, so a peer behind a hard NAT",
+    "can still reach another peer. A separate SFU (selective forwarding",
+    "unit) routes video and screen-share streams only. Voice never touches",
+    "it.",
+    "",
+    "This pack merges up to three vantage points on one session:",
+    "- **client** - what one peer's own browser saw.",
+    "- **relay** - what the libp2p relay saw for that peer.",
+    "- **sfu** - what the SFU saw for that peer's media session.",
+    "",
+    "The three vantages can disagree with each other. A finding below can",
+    "name a peer, a pair of peers, a room or a vantage. Use the topology",
+    "tables and the event window in this pack to see the disagreement.",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section 2 - schema + kinds present
+// ---------------------------------------------------------------------------
+
+function kindsPresent(c: Capture): Array<[string, number]> {
+  const counts = new Map<string, number>();
+  for (const e of c.timeline) counts.set(e.kind, (counts.get(e.kind) ?? 0) + 1);
+  return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+function sectionSchema(c: Capture): string {
+  const counts = kindsPresent(c);
+  return [
+    SECTION_SCHEMA,
+    "",
+    "Every event on the wire has this shape:",
+    "```ts",
+    "interface DiagEvent {",
+    "  seq: number;   // 1-based, per session; a gap means events were dropped",
+    "  t: number;     // ms since the session start",
+    "  kind: DiagKind; // one literal from a closed vocabulary of event names",
+    '  sev: "debug" | "info" | "warn" | "error";',
+    "  peer: string | null;  // full peerId this event is about, or null",
+    '  room: string | null;  // bundle-local ordinal ("r1"); never a room code',
+    "  d?: Record<string, string | number | boolean | null>; // flat detail bag",
+    "}",
+    "```",
+    "",
+    `Kinds present in this capture (${c.timeline.length} event(s) total):`,
+    "```txt",
+    ...(counts.length > 0 ? counts.map(([kind, n]) => `${kind}: ${n}`) : ["(no events)"]),
+    "```",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section 3 - findings
+// ---------------------------------------------------------------------------
+
+function formatSubject(subject: Finding["subject"]): string {
+  const parts: string[] = [];
+  if (subject.peer) parts.push(`peer=${shortId(subject.peer)}`);
+  if (subject.pair) parts.push(`pair=${subject.pair.map(shortId).join(",")}`);
+  if (subject.room) parts.push(`room=${sanitizeString(subject.room)}`);
+  if (subject.vantage) parts.push(`vantage=${subject.vantage}`);
+  return parts.length > 0 ? parts.join(" ") : "(none)";
+}
+
+function sectionFindings(findings: Finding[]): string {
+  if (findings.length === 0) {
+    return [SECTION_FINDINGS, "", "No findings fired for this capture."].join("\n");
+  }
+  const lines = [SECTION_FINDINGS];
+  for (const f of findings) {
+    const rule = RULES[f.id];
+    lines.push(
+      "",
+      `### ${rule.title} (\`${f.id}\`, ${f.severity})`,
+      `- meaning: ${sanitizeString(rule.meaning)}`,
+      `- remedy: ${sanitizeString(rule.remedy)}`,
+      `- aiHint: ${sanitizeString(rule.aiHint)}`,
+      `- subject: ${formatSubject(f.subject)}`,
+      `- evidence: ${f.evidence.length} event(s), timeline indices [${f.evidence.join(", ")}]`,
+      `- detail: ${formatDetail(f.detail)}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section 4 - topology at the first blocking finding, and at the end
+// ---------------------------------------------------------------------------
+
+function firstBlockingFinding(findings: Finding[], c: Capture): Finding | undefined {
+  return findings.find(
+    (f) => f.severity === "block" && f.evidence.length > 0 && f.evidence[0] < c.timeline.length,
+  );
+}
+
+function renderTopologyTable(topo: Topology): string {
+  const lines: string[] = [];
+  lines.push(`self: ${shortId(topo.self)}`);
+  lines.push(
+    topo.relay
+      ? `relay: ${shortId(topo.relay.peerId)} connected=${topo.relay.connected} reserved=${topo.relay.reserved}`
+      : "relay: (none)",
+  );
+  lines.push(
+    topo.sfu
+      ? `sfu: ${topo.sfu.host} connected=${topo.sfu.connected} roomPeerCount=${topo.sfu.roomPeerCount ?? "?"}`
+      : "sfu: (none)",
+  );
+  lines.push("");
+  const ids = topo.nodes.map((n) => n.peerId);
+  if (ids.length === 0) {
+    lines.push("(no peers)");
+    return lines.join("\n");
+  }
+  lines.push(["from \\ to", ...ids.map(shortId)].join(" | "));
+  for (const from of ids) {
+    const row = [shortId(from)];
+    for (const to of ids) {
+      if (from === to) {
+        row.push("-");
+        continue;
+      }
+      const link = topo.links.find((l) => l.from === from && l.to === to);
+      row.push(link ? link.state : "none");
+    }
+    lines.push(row.join(" | "));
+  }
+  return lines.join("\n");
+}
+
+function sectionTopology(c: Capture, blocking: Finding | undefined): string {
+  const lines = [
+    SECTION_TOPOLOGY,
+    "",
+    "Peer, relay and observer ids below are shortened to their last 8",
+    "characters for a readable table; they are not ambiguous within one",
+    "capture.",
+    "",
+    "### At the first blocking finding",
+  ];
+  if (blocking) {
+    const at = c.timeline[blocking.evidence[0]].at;
+    lines.push("```txt", renderTopologyTable(foldTopology(c, at)), "```");
+  } else {
+    lines.push("(no blocking finding in this capture)");
+  }
+  lines.push("", "### At the end of the capture", "```txt", renderTopologyTable(foldTopology(c, c.window.to)), "```");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section 5 - the event window
+// ---------------------------------------------------------------------------
+
+function formatEventLine(e: MergedEvent): string {
+  const iso = new Date(e.at).toISOString();
+  const peer = e.peer ? shortId(e.peer) : "-";
+  return `${iso} observer=${shortId(e.observer)} kind=${e.kind} sev=${e.sev} peer=${peer} d=${formatDetail(e.d)}`;
+}
+
+/** [start, end) of `timeline` to render, centred on `blocking`'s evidence when present. */
+function eventWindowBounds(
+  timelineLength: number,
+  blocking: Finding | undefined,
+  maxEvents: number,
+): { start: number; end: number } {
+  if (!blocking) {
+    const end = timelineLength;
+    return { start: Math.max(0, end - maxEvents), end };
+  }
+  const anchor = blocking.evidence[0];
+  const radius = Math.floor(maxEvents / 2);
+  let start = Math.max(0, anchor - radius);
+  let end = Math.min(timelineLength, start + maxEvents);
+  start = Math.max(0, end - maxEvents);
+  return { start, end };
+}
+
+function sectionEventWindow(
+  c: Capture,
+  blocking: Finding | undefined,
+  maxEvents: number,
+): string {
+  const { start, end } = eventWindowBounds(c.timeline.length, blocking, maxEvents);
+  const slice = c.timeline.slice(start, end);
+  return [
+    SECTION_EVENTS,
+    "",
+    `${slice.length} of ${c.timeline.length} event(s), oldest first. Observer and peer`,
+    "ids are shortened to their last 8 characters.",
+    "```txt",
+    ...(slice.length > 0 ? slice.map(formatEventLine) : ["(no events)"]),
+    "```",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Section 6 - the question
+// ---------------------------------------------------------------------------
+
+function sectionQuestion(): string {
+  return [
+    SECTION_QUESTION,
+    "",
+    "Explain the causal chain, name the single root cause, and say what",
+    "evidence would confirm or refute it.",
+  ].join("\n");
+}

--- a/dashboard/src/lib/analysis/rules.ts
+++ b/dashboard/src/lib/analysis/rules.ts
@@ -43,7 +43,8 @@ export type FindingId =
   | "capture-incomplete"
   | "relay-close-unclean"
   | "peerconnection-leak"
-  | "uncaught-error";
+  | "uncaught-error"
+  | "producer-never-consumed";
 
 export interface Rule {
   id: FindingId;
@@ -289,6 +290,17 @@ export const RULES: Readonly<Record<FindingId, Rule>> = {
     meaning: "Some events were dropped or throttled before capture. Findings before the first surviving event can be wrong.",
     remedy: "Raise the ring capacity or the throttle budget for the noisy kind.",
     aiHint: "Check the suppressed kind counts to find which signal was lost.",
+  },
+  "producer-never-consumed": {
+    id: "producer-never-consumed",
+    title: "Producer never consumed",
+    severity: "block",
+    meaning:
+      "The SFU announced a camera producer to this peer. No consumer was ever built for it, so the tile stayed empty while everything reported connected.",
+    remedy:
+      "Check whether the receive transport still accepts a consume. One rejected consume can leave it unable to accept any later one.",
+    aiHint:
+      "Find the sfu.consume announced event, then read every sfu.consume.failed and sfu.transport.state for the same vantage after it.",
   },
   "peerconnection-leak": {
     id: "peerconnection-leak",

--- a/dashboard/src/lib/analysis/rules.ts
+++ b/dashboard/src/lib/analysis/rules.ts
@@ -1,0 +1,299 @@
+/**
+ * The deterministic rule table: metadata only, no detection logic.
+ *
+ * Every id here is grounded in a real failure mode of this codebase and is
+ * derivable from the events the flight recorder emits (see
+ * `frontend/src/lib/telemetry/`). `findings.ts` is the only module that reads
+ * `capture.timeline` and decides when a rule fires; this file just names what
+ * each rule means, once, so the Findings view and the AI prompt pack can
+ * quote the same sentence.
+ *
+ * Prose here follows ASD-STE100: short sentences, active voice, no `-ing`
+ * verb forms, and only `can` / `will` / `must` as modals.
+ */
+
+export type FindingId =
+  | "relay-reservation-never-completed"
+  | "relay-unreachable"
+  | "relay-flapping"
+  | "rendezvous-wedged"
+  | "turn-missing-and-needed"
+  | "connected-not-proven"
+  | "asymmetric-link"
+  | "upgrade-starved"
+  | "liveness-flap"
+  | "stream-confirm-starved"
+  | "room-view-split"
+  | "message-rejected"
+  | "sync-stalled"
+  | "voice-never-connected"
+  | "voice-media-stalled"
+  | "voice-relayed-only"
+  | "voice-restart-loop"
+  | "sfu-session-latched"
+  | "sfu-transport-timeout"
+  | "sfu-rejoin-loop"
+  | "sfu-consumer-stalled"
+  | "sfu-room-split"
+  | "sfu-placement-disagreement"
+  | "clock-skew"
+  | "fault-injection-active"
+  | "unconfigured-instance"
+  | "storage-locked-writes"
+  | "capture-incomplete"
+  | "relay-close-unclean";
+
+export interface Rule {
+  id: FindingId;
+  title: string;
+  severity: "block" | "warn" | "info";
+  /** One sentence: what it means. */
+  meaning: string;
+  /** One sentence: what to change. */
+  remedy: string;
+  /** What the AI should look for to explain WHY, in one sentence. */
+  aiHint: string;
+}
+
+export const RULES: Readonly<Record<FindingId, Rule>> = {
+  "relay-reservation-never-completed": {
+    id: "relay-reservation-never-completed",
+    title: "Relay reservation never completed",
+    severity: "block",
+    meaning:
+      "The relay never confirmed this reservation. No peer can dial in through this relay circuit.",
+    remedy: "Check the relay's health and the network path between the client and the relay.",
+    aiHint: "Find nearby relay.dial events and check if the relay connection dropped first.",
+  },
+  "relay-unreachable": {
+    id: "relay-unreachable",
+    title: "Relay unreachable",
+    severity: "block",
+    meaning: "The client failed four relay dials in a row. The relay is unreachable from here.",
+    remedy: "Check the relay address, DNS, and firewall rules on the client's network.",
+    aiHint: "Read the fail reason in each relay.dial.fail event and compare it across attempts.",
+  },
+  "relay-flapping": {
+    id: "relay-flapping",
+    title: "Relay flapping",
+    severity: "warn",
+    meaning: "The relay connection dropped three times in five minutes. The link is unstable.",
+    remedy: "Check the relay's load and the client's network stability.",
+    aiHint: "Look at the relay.dial.attempt gaps around each disconnect for a pattern.",
+  },
+  "rendezvous-wedged": {
+    id: "rendezvous-wedged",
+    title: "Rendezvous wedged",
+    severity: "block",
+    meaning:
+      "The rendezvous stream registered but never listed room peers, or the relay killed it on a liveness timeout.",
+    remedy: "Restart the rendezvous stream and check the relay's liveness timer.",
+    aiHint: "Compare this observer's rv.register time with the relay's rv.close reason.",
+  },
+  "turn-missing-and-needed": {
+    id: "turn-missing-and-needed",
+    title: "TURN missing and needed",
+    severity: "block",
+    meaning:
+      "TURN is unavailable and a relayed peer never proved a direct stream. The call has no confirmed path.",
+    remedy: "Configure a working TURN server and confirm its credentials.",
+    aiHint: "Check the ice.turn.fail reason and the peer's ICE candidate types.",
+  },
+  "connected-not-proven": {
+    id: "connected-not-proven",
+    title: "Connected but not proven",
+    severity: "block",
+    meaning: "The peer connected but never proved a working stream in time. Writes to it will vanish.",
+    remedy: "Check the stream confirm handshake and the peer's write path.",
+    aiHint: "Look for stream.confirm.fail or stream.write.fail events for this peer right after connect.",
+  },
+  "asymmetric-link": {
+    id: "asymmetric-link",
+    title: "Asymmetric link",
+    severity: "block",
+    meaning:
+      "One peer saw the other connect, but the reverse view is missing. The two sides disagree about this link.",
+    remedy: "Check both peers' dial logs for the same time window.",
+    aiHint: "Compare peer.dial and peer.connect events from both vantages for this pair.",
+  },
+  "upgrade-starved": {
+    id: "upgrade-starved",
+    title: "Upgrade starved",
+    severity: "warn",
+    meaning: "This peer failed three direct-upgrade attempts. The link stays relayed instead of direct.",
+    remedy: "Check the NAT type and ICE candidate set for this peer.",
+    aiHint: "Read each peer.upgrade.fail detail for a repeated failure reason.",
+  },
+  "liveness-flap": {
+    id: "liveness-flap",
+    title: "Liveness flap",
+    severity: "warn",
+    meaning: "This peer dropped on liveness three times in five minutes. The connection is unstable.",
+    remedy: "Check the peer's network path and the liveness timer settings.",
+    aiHint: "Look at peer.rtt values around each drop for a pattern.",
+  },
+  "stream-confirm-starved": {
+    id: "stream-confirm-starved",
+    title: "Stream confirm starved",
+    severity: "block",
+    meaning: "The stream confirm handshake failed twice for this peer. The stream cannot be trusted yet.",
+    remedy: "Check the peer's stream open and confirm code path.",
+    aiHint: "Read the confirm attempt count in each stream.confirm.fail event.",
+  },
+  "room-view-split": {
+    id: "room-view-split",
+    title: "Room view split",
+    severity: "warn",
+    meaning:
+      "The rendezvous peer count and the gossiped room count disagree for over 30 seconds. Membership views split.",
+    remedy: "Check the room sync path between rendezvous and the gossip layer.",
+    aiHint: "Compare rv.peers and app.roomusers counts from the same observer at the same time.",
+  },
+  "message-rejected": {
+    id: "message-rejected",
+    title: "Message rejected",
+    severity: "block",
+    meaning: "A message failed verification and was rejected. Content did not reach the app.",
+    remedy: "Check the sender's signing key and the message format for this reason.",
+    aiHint: "Group rejections by reason and check which peer sent each one.",
+  },
+  "sync-stalled": {
+    id: "sync-stalled",
+    title: "Sync stalled",
+    severity: "warn",
+    meaning:
+      "A digest went out but got no reply for over 60 seconds, while a peer was proven. Sync can be stuck.",
+    remedy: "Check the peer's digest handler and its inbound stream.",
+    aiHint: "Check if the peer sent app.digest.in at all, or only late.",
+  },
+  "voice-never-connected": {
+    id: "voice-never-connected",
+    title: "Voice never connected",
+    severity: "block",
+    meaning: "A voice peer connection never reached ICE connected in time. The call never started for this peer.",
+    remedy: "Check ICE candidates, TURN, and the signaling path for this peer.",
+    aiHint: "Look at voice.ice.state and voice.signal.invalid events for this peer.",
+  },
+  "voice-media-stalled": {
+    id: "voice-media-stalled",
+    title: "Voice media stalled",
+    severity: "block",
+    meaning: "Voice media stalled and never resumed. Audio stopped flowing to this peer.",
+    remedy: "Check the peer's network path and the media pipeline for a stuck track.",
+    aiHint: "Check the silent duration in the voice.media.stall detail.",
+  },
+  "voice-relayed-only": {
+    id: "voice-relayed-only",
+    title: "Voice relayed only",
+    severity: "warn",
+    meaning: "Every voice connection in this capture used a relay path. No direct voice path ever formed.",
+    remedy: "Check TURN reachability and the NAT type for the peers in this call.",
+    aiHint: "Check ice.turn.ok and the ICE candidate types across the capture.",
+  },
+  "voice-restart-loop": {
+    id: "voice-restart-loop",
+    title: "Voice restart loop",
+    severity: "warn",
+    meaning: "This voice peer restarted three or more times. The connection cannot hold steady.",
+    remedy: "Check network stability and the ICE restart trigger for this peer.",
+    aiHint: "Read the gap between each voice.restart to find the restart trigger.",
+  },
+  "sfu-session-latched": {
+    id: "sfu-session-latched",
+    title: "SFU session latched",
+    severity: "block",
+    meaning:
+      "An operation ceiling killed the whole SFU session instead of just that operation. The client has no branch for this reason.",
+    remedy: "Add a specific handler for this SFU error reason on the client.",
+    aiHint: "Check the producer and consumer counts at the time of this error.",
+  },
+  "sfu-transport-timeout": {
+    id: "sfu-transport-timeout",
+    title: "SFU transport timeout",
+    severity: "warn",
+    meaning: "An SFU transport timed out in one direction. That send or receive path did not connect in time.",
+    remedy: "Check the SFU host reachability and the ICE state for this direction.",
+    aiHint: "Check sfu.transport.state events for this direction right before the timeout.",
+  },
+  "sfu-rejoin-loop": {
+    id: "sfu-rejoin-loop",
+    title: "SFU rejoin loop",
+    severity: "block",
+    meaning: "The client rejoined the SFU three or more times. The rejoin ladder has no attempt cap.",
+    remedy: "Add a rejoin attempt limit and surface a hard failure after it.",
+    aiHint: "Read the delay between each sfu.rejoin to find the retry pattern.",
+  },
+  "sfu-consumer-stalled": {
+    id: "sfu-consumer-stalled",
+    title: "SFU consumer stalled",
+    severity: "warn",
+    meaning: "A track stalled twice or more for one producer. The viewer is not getting media.",
+    remedy: "Check the producer's bitrate and the consumer's network path.",
+    aiHint: "Check sfu.transport.state around each stall for a shared cause.",
+  },
+  "sfu-room-split": {
+    id: "sfu-room-split",
+    title: "SFU room split",
+    severity: "block",
+    meaning:
+      "The SFU room peer count and the voice call roster disagree for over 30 seconds. The two systems see different rooms.",
+    remedy: "Check that every call participant joined both the voice mesh and the SFU room.",
+    aiHint: "Compare sfu.diag roomPeers with voice.join and voice.leave counts for this observer.",
+  },
+  "sfu-placement-disagreement": {
+    id: "sfu-placement-disagreement",
+    title: "SFU placement disagreement",
+    severity: "block",
+    meaning: "Two client vantages picked different SFU hosts for this capture. Peers can end up in different video rooms.",
+    remedy: "Check the SFU host selection logic and the pool configuration.",
+    aiHint: "Compare each sfu.pick host against the configured SFU host pool.",
+  },
+  "clock-skew": {
+    id: "clock-skew",
+    title: "Clock skew",
+    severity: "warn",
+    meaning: "The clock offset solve left a residual over the acceptable limit. Cross-vantage timing here is not reliable.",
+    remedy: "Check for missing or noisy peer.clock samples across vantages.",
+    aiHint: "Check which vantage has the fewest peer.clock samples.",
+  },
+  "fault-injection-active": {
+    id: "fault-injection-active",
+    title: "Fault injection active",
+    severity: "warn",
+    meaning: "A fault was active during this capture. Every other finding here can be a fault artifact, not a real bug.",
+    remedy: "Re-run the capture with faults off to confirm the finding still holds.",
+    aiHint: "Check which fault flags were set and match them to the failing behavior.",
+  },
+  "unconfigured-instance": {
+    id: "unconfigured-instance",
+    title: "Unconfigured instance",
+    severity: "block",
+    meaning: "This build was never configured with a relay or SFU host. Nothing in this session could work.",
+    remedy: "Set the runtime configuration before this instance connects.",
+    aiHint: "Check the config detail for a missing apiHost, relayPeerId, or sfuHosts.",
+  },
+  "storage-locked-writes": {
+    id: "storage-locked-writes",
+    title: "Storage locked writes",
+    severity: "warn",
+    meaning: "Storage was locked when a write was due. The offline DM queue did not persist that write.",
+    remedy: "Check when the vault unlocks relative to this write attempt.",
+    aiHint: "Check the time gap between session.unlock and this storage.locked event.",
+  },
+  "capture-incomplete": {
+    id: "capture-incomplete",
+    title: "Capture incomplete",
+    severity: "info",
+    meaning: "Some events were dropped or throttled before capture. Findings before the first surviving event can be wrong.",
+    remedy: "Raise the ring capacity or the throttle budget for the noisy kind.",
+    aiHint: "Check the suppressed kind counts to find which signal was lost.",
+  },
+  "relay-close-unclean": {
+    id: "relay-close-unclean",
+    title: "Relay close unclean",
+    severity: "warn",
+    meaning: "The relay closed this stream for a reason other than a graceful close.",
+    remedy: "Check the named close reason against the relay's timeout and cap settings.",
+    aiHint: "Match the close reason to the relay's idle, liveness, or cap constants.",
+  },
+} as const satisfies Record<FindingId, Rule>;

--- a/dashboard/src/lib/analysis/rules.ts
+++ b/dashboard/src/lib/analysis/rules.ts
@@ -41,7 +41,9 @@ export type FindingId =
   | "unconfigured-instance"
   | "storage-locked-writes"
   | "capture-incomplete"
-  | "relay-close-unclean";
+  | "relay-close-unclean"
+  | "peerconnection-leak"
+  | "uncaught-error";
 
 export interface Rule {
   id: FindingId;
@@ -287,6 +289,26 @@ export const RULES: Readonly<Record<FindingId, Rule>> = {
     meaning: "Some events were dropped or throttled before capture. Findings before the first surviving event can be wrong.",
     remedy: "Raise the ring capacity or the throttle budget for the noisy kind.",
     aiHint: "Check the suppressed kind counts to find which signal was lost.",
+  },
+  "peerconnection-leak": {
+    id: "peerconnection-leak",
+    title: "PeerConnection leak",
+    severity: "block",
+    meaning:
+      "This tab held too many RTCPeerConnections at once. The browser refuses new connections at 500, and then voice, the SFU and libp2p all fail together.",
+    remedy:
+      "Find the loop that builds connections and does not close them. Compare pcCreated against pcLive over time.",
+    aiHint:
+      "Read pcLive across the runtime.resources samples. A count that only climbs is a leak. A pcCreated that climbs while pcLive holds is a rebuild loop.",
+  },
+  "uncaught-error": {
+    id: "uncaught-error",
+    title: "Uncaught error",
+    severity: "warn",
+    meaning: "An exception reached the window. No code in the app caught it.",
+    remedy: "Add a handler at the throw site, or fix the condition that throws.",
+    aiHint:
+      "Read the err text and the events immediately before it in the same vantage.",
   },
   "relay-close-unclean": {
     id: "relay-close-unclean",

--- a/dashboard/src/lib/analysis/rules.ts
+++ b/dashboard/src/lib/analysis/rules.ts
@@ -44,7 +44,8 @@ export type FindingId =
   | "relay-close-unclean"
   | "peerconnection-leak"
   | "uncaught-error"
-  | "producer-never-consumed";
+  | "producer-never-consumed"
+  | "turn-unreachable";
 
 export interface Rule {
   id: FindingId;
@@ -290,6 +291,17 @@ export const RULES: Readonly<Record<FindingId, Rule>> = {
     meaning: "Some events were dropped or throttled before capture. Findings before the first surviving event can be wrong.",
     remedy: "Raise the ring capacity or the throttle budget for the noisy kind.",
     aiHint: "Check the suppressed kind counts to find which signal was lost.",
+  },
+  "turn-unreachable": {
+    id: "turn-unreachable",
+    title: "TURN unreachable from this network",
+    severity: "block",
+    meaning:
+      "The client held valid TURN credentials and the server still gave it no allocation. This peer has no relayed path, and the cause is outside the app.",
+    remedy:
+      "Check that the TURN host is reachable on its UDP and TCP ports from this network, and that coturn is running.",
+    aiHint:
+      "Compare this against the app's own ICE results. A failed probe explains a failed connection. A probe that passed next to a connection that failed points at the app instead.",
   },
   "producer-never-consumed": {
     id: "producer-never-consumed",

--- a/dashboard/src/lib/analysis/topology.test.ts
+++ b/dashboard/src/lib/analysis/topology.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from "vitest";
+import { mergeSources, type Capture } from "./merge";
+import {
+  PEER_PROOF_GRACE_MS,
+  foldTopology,
+  primaryObserver,
+  topologyKeyframes,
+  vantageKinds,
+} from "./topology";
+import type { ClientBundle, DiagEvent, RelayVantage } from "../schema";
+
+let seq = 0;
+
+function event(
+  kind: DiagEvent["kind"],
+  t: number,
+  extra: Partial<DiagEvent> = {}
+): DiagEvent {
+  return { seq: ++seq, t, kind, sev: "info", peer: null, room: null, ...extra };
+}
+
+function bundleOf(
+  peerId: string,
+  startedAt: number,
+  events: DiagEvent[],
+  overrides: Partial<ClientBundle> = {}
+): ClientBundle {
+  return {
+    schemaVersion: 1,
+    bundleId: `bundle-${peerId}`,
+    sessionId: `sess-${peerId}`,
+    createdAt: startedAt + 120_000,
+    startedAt,
+    vantage: "client",
+    app: { version: "1.0.0", commit: "abc" },
+    env: { ua: "test" },
+    config: {
+      apiHost: "relay.example.org",
+      relayPeerId: "12D3KooWRELAY",
+      sfuHosts: ["sfu.example.org"],
+      configured: true,
+    },
+    self: { peerId },
+    rooms: [],
+    peers: [],
+    counters: {},
+    events,
+    sfuSnapshots: [],
+    meta: {
+      ringCapacity: 4096,
+      dropped: 0,
+      suppressed: {},
+      faultsActive: false,
+      truncated: false,
+    },
+    ...overrides,
+  };
+}
+
+function relayView(observedPeerId: string, events: DiagEvent[]): RelayVantage {
+  return {
+    vantage: "relay",
+    relayPeerId: "12D3KooWRELAY",
+    observedPeerId,
+    registry: { totalRegistrations: 1, streamsForPeer: 1, atTotalCap: false },
+    rooms: [],
+    streams: [],
+    events,
+  };
+}
+
+function captureOf(...bundles: Array<[string, ClientBundle]>): Capture {
+  const ws = mergeSources(
+    bundles.map(([source, bundle]) => ({ bundle, source }))
+  );
+  expect(ws.captures).toHaveLength(1);
+  return ws.captures[0];
+}
+
+const T0 = 100_000;
+
+describe("primaryObserver", () => {
+  it("picks the client vantage with the most events", () => {
+    const a = bundleOf("pA", T0, [
+      event("session.start", 0),
+      event("peer.connect", 10, { peer: "pB" }),
+      event("stream.proven", 20, { peer: "pB" }),
+    ]);
+    const b = bundleOf("pB", T0, [event("peer.connect", 10, { peer: "pA" })]);
+    expect(primaryObserver(captureOf(["a.json", a], ["b.json", b]))).toBe("pA");
+  });
+});
+
+describe("foldTopology", () => {
+  it("reports the relay as connected and reserved", () => {
+    const a = bundleOf("pA", T0, [
+      event("relay.dial.ok", 10),
+      event("relay.reservation.ok", 20),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(top.relay).toEqual({
+      peerId: "12D3KooWRELAY",
+      connected: true,
+      reserved: true,
+    });
+  });
+
+  it("clears the reservation when the relay goes away", () => {
+    const a = bundleOf("pA", T0, [
+      event("relay.dial.ok", 10),
+      event("relay.reservation.ok", 20),
+      event("relay.disconnect", 30),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(top.relay).toMatchObject({ connected: false, reserved: false });
+  });
+
+  it("ignores events after the folded instant", () => {
+    const a = bundleOf("pA", T0, [
+      event("relay.dial.ok", 10),
+      event("relay.disconnect", 5000),
+    ]);
+    const capture = captureOf(["a.json", a]);
+    expect(foldTopology(capture, T0 + 100).relay?.connected).toBe(true);
+    expect(foldTopology(capture, T0 + 6000).relay?.connected).toBe(false);
+  });
+
+  it("keeps a link directed, so one side's view cannot imply the other's", () => {
+    // THE point of three vantages: A saw B, B never saw A.
+    const a = bundleOf("pA", T0, [
+      event("peer.connect", 10, { peer: "pB" }),
+      event("stream.proven", 20, { peer: "pB" }),
+    ]);
+    const b = bundleOf("pB", T0, [event("session.start", 0)]);
+    const top = foldTopology(captureOf(["a.json", a], ["b.json", b]), T0 + 100);
+    const forward = top.links.find((l) => l.from === "pA" && l.to === "pB");
+    const back = top.links.find((l) => l.from === "pB" && l.to === "pA");
+    expect(forward?.state).toBe("proven");
+    expect(back).toBeUndefined();
+  });
+
+  it("promotes a connected link to proven and demotes it on loss", () => {
+    const a = bundleOf("pA", T0, [
+      event("peer.connect", 10, { peer: "pB" }),
+      event("stream.proven", 20, { peer: "pB" }),
+      event("stream.lost", 30, { peer: "pB" }),
+    ]);
+    const capture = captureOf(["a.json", a]);
+    expect(link(foldTopology(capture, T0 + 15), "pA", "pB")?.state).toBe(
+      "relayed"
+    );
+    expect(link(foldTopology(capture, T0 + 25), "pA", "pB")?.state).toBe(
+      "proven"
+    );
+    expect(link(foldTopology(capture, T0 + 35), "pA", "pB")?.state).toBe("lost");
+  });
+
+  it("keeps a proven link proven when it upgrades to direct", () => {
+    const a = bundleOf("pA", T0, [
+      event("peer.connect", 10, { peer: "pB" }),
+      event("stream.proven", 20, { peer: "pB" }),
+      event("peer.direct", 30, { peer: "pB" }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(link(top, "pA", "pB")?.state).toBe("proven");
+  });
+
+  it("names a liveness drop distinctly from an ordinary disconnect", () => {
+    const a = bundleOf("pA", T0, [
+      event("peer.connect", 10, { peer: "pB" }),
+      event("peer.drop.liveness", 20, { peer: "pB" }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(link(top, "pA", "pB")?.state).toBe("dropped");
+  });
+
+  it("reports a connected but unproven peer as online inside the grace window", () => {
+    // Reproducing `peer-online-status.ts`: reporting online from peer.connect
+    // alone is the bug that module exists to fix, and reporting "connecting"
+    // during the ordinary handshake is the flicker it also fixes.
+    const a = bundleOf("pA", T0, [event("peer.connect", 0, { peer: "pB" })]);
+    const capture = captureOf(["a.json", a]);
+    const early = foldTopology(capture, T0 + PEER_PROOF_GRACE_MS - 1);
+    expect(node(early, "pB")).toMatchObject({ online: true, connecting: false });
+  });
+
+  it("downgrades to connecting once the grace window elapses with no proof", () => {
+    const a = bundleOf("pA", T0, [event("peer.connect", 0, { peer: "pB" })]);
+    const late = foldTopology(
+      captureOf(["a.json", a]),
+      T0 + PEER_PROOF_GRACE_MS + 1
+    );
+    expect(node(late, "pB")).toMatchObject({ online: false, connecting: true });
+  });
+
+  it("reports a proven peer as online however long it has been up", () => {
+    const a = bundleOf("pA", T0, [
+      event("peer.connect", 0, { peer: "pB" }),
+      event("stream.proven", 10, { peer: "pB" }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 600_000);
+    expect(node(top, "pB")).toMatchObject({ online: true, connecting: false });
+  });
+
+  it("reports a peer nobody connected to as offline, not connecting", () => {
+    const a = bundleOf("pA", T0, [
+      event("peer.dial.fail", 10, { peer: "pB" }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(node(top, "pB")).toMatchObject({ online: false, connecting: false });
+    expect(link(top, "pA", "pB")?.state).toBe("dial-failed");
+  });
+
+  it("tracks the voice link separately from the data link", () => {
+    const a = bundleOf("pA", T0, [
+      event("peer.connect", 10, { peer: "pB" }),
+      event("voice.pc.new", 20, { peer: "pB" }),
+      event("voice.ice.connected", 30, { peer: "pB", d: { relayed: true } }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(link(top, "pA", "pB")).toMatchObject({
+      state: "relayed",
+      voice: "relayed",
+    });
+  });
+
+  it("distinguishes a direct voice path from a TURN-relayed one", () => {
+    const a = bundleOf("pA", T0, [
+      event("voice.ice.connected", 30, { peer: "pB", d: { relayed: false } }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(link(top, "pA", "pB")?.voice).toBe("connected");
+  });
+
+  it("marks a stalled voice link in both the voice and media dimensions", () => {
+    const a = bundleOf("pA", T0, [
+      event("voice.ice.connected", 10, { peer: "pB", d: { relayed: false } }),
+      event("voice.media.stall", 20, { peer: "pB", d: { silentMs: 4000 } }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(link(top, "pA", "pB")).toMatchObject({
+      voice: "stalled",
+      media: "stalled",
+    });
+  });
+
+  it("tracks the SFU host, its socket and its room count", () => {
+    const a = bundleOf("pA", T0, [
+      event("sfu.pick", 10, { d: { host: "sfu.example.org", poolSize: 2 } }),
+      event("sfu.ws.open", 20),
+      event("sfu.diag", 30, { d: { roomPeers: 3 } }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(top.sfu).toEqual({
+      host: "sfu.example.org",
+      connected: true,
+      roomPeerCount: 3,
+    });
+  });
+
+  it("forgets the SFU room count when the socket closes", () => {
+    const a = bundleOf("pA", T0, [
+      event("sfu.ws.open", 10),
+      event("sfu.diag", 20, { d: { roomPeers: 3 } }),
+      event("sfu.ws.close", 30, { d: { code: 1006 } }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(top.sfu).toMatchObject({ connected: false, roomPeerCount: null });
+  });
+
+  it("attributes a room ref to its own source", () => {
+    const a = bundleOf("pA", T0, [
+      event("app.join", 10, { peer: "pB", room: "r1" }),
+    ]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(node(top, "pB")?.rooms).toEqual(["a.json:r1"]);
+  });
+
+  it("keeps a relay vantage's own link view separate from the client's", () => {
+    const a = bundleOf("pA", T0, [event("peer.connect", 10, { peer: "pB" })], {
+      relayView: relayView("pA", [
+        event("peer.disconnect", T0 + 20, { peer: "pA" }),
+      ]),
+    });
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(link(top, "pA", "pB")?.state).toBe("relayed");
+    expect(link(top, "12D3KooWRELAY", "pA")?.state).toBe("lost");
+  });
+
+  it("excludes the primary observer from the node list", () => {
+    const a = bundleOf("pA", T0, [event("peer.connect", 10, { peer: "pB" })]);
+    const top = foldTopology(captureOf(["a.json", a]), T0 + 100);
+    expect(top.self).toBe("pA");
+    expect(top.nodes.map((n) => n.peerId)).toEqual(["pB", "12D3KooWRELAY"].filter(
+      (id) => top.nodes.some((n) => n.peerId === id)
+    ));
+    expect(top.nodes.some((n) => n.peerId === "pA")).toBe(false);
+  });
+});
+
+describe("topologyKeyframes", () => {
+  it("returns only the times where the graph changed", () => {
+    const a = bundleOf("pA", T0, [
+      event("session.start", 0), // no topology
+      event("relay.dial.ok", 10), // change
+      event("relay.dial.ok", 20), // no change: already connected
+      event("peer.connect", 30, { peer: "pB" }), // change
+      event("peer.rtt", 40, { peer: "pB", d: { ms: 30 } }), // no topology
+    ]);
+    const capture = captureOf(["a.json", a]);
+    expect(topologyKeyframes(capture)).toEqual([
+      capture.window.from,
+      T0 + 10,
+      T0 + 30,
+      capture.window.to,
+    ]);
+  });
+
+  it("always brackets the capture window", () => {
+    const a = bundleOf("pA", T0, [event("session.start", 0)]);
+    const capture = captureOf(["a.json", a]);
+    expect(topologyKeyframes(capture)).toEqual([
+      capture.window.from,
+      capture.window.to,
+    ]);
+  });
+});
+
+describe("vantageKinds", () => {
+  it("lists each kind once", () => {
+    const a = bundleOf("pA", T0, [event("session.start", 0)], {
+      relayView: relayView("pA", [event("rv.open", T0 + 10)]),
+    });
+    const b = bundleOf("pB", T0, [event("peer.connect", 10, { peer: "pA" })]);
+    expect(vantageKinds(captureOf(["a.json", a], ["b.json", b])).sort()).toEqual([
+      "client",
+      "relay",
+    ]);
+  });
+});
+
+function link(
+  top: ReturnType<typeof foldTopology>,
+  from: string,
+  to: string
+): ReturnType<typeof foldTopology>["links"][number] | undefined {
+  return top.links.find((l) => l.from === from && l.to === to);
+}
+
+function node(
+  top: ReturnType<typeof foldTopology>,
+  peerId: string
+): ReturnType<typeof foldTopology>["nodes"][number] | undefined {
+  return top.nodes.find((n) => n.peerId === peerId);
+}

--- a/dashboard/src/lib/analysis/topology.ts
+++ b/dashboard/src/lib/analysis/topology.ts
@@ -1,0 +1,568 @@
+/**
+ * The topology graph, folded from the merged timeline.
+ *
+ * Every link is DIRECTED on purpose. The whole reason three vantages exist is
+ * that A's view and B's view disagree: "A sees B, B never saw A" is a real
+ * failure this codebase produces, and an undirected edge hides it.
+ *
+ * `applyEvent` is an EXHAUSTIVE switch over `DiagKind`. A kind added to the
+ * schema without a decision here is a compile error, which is the only way to
+ * keep the fold honest as the vocabulary grows.
+ */
+
+import {
+  LOG_RAW_KIND,
+  type Capture,
+  type MergedEvent,
+  type MergedKind,
+  type VantageKind,
+} from "./merge";
+
+/**
+ * Copied, not imported, from `frontend/src/lib/peer-online-status.ts`. That
+ * module exists because the transport's connected set says nothing about
+ * whether a frame can reach the peer, and reporting "online" from
+ * `peer.connect` alone reproduces the exact bug it was written to fix.
+ */
+export const PEER_PROOF_GRACE_MS = 3000;
+
+export type LinkState =
+  | "none"
+  | "dialing"
+  | "dial-failed"
+  | "relayed"
+  | "direct"
+  | "proven"
+  | "lost"
+  | "dropped";
+
+export type VoiceLinkState =
+  | "none"
+  | "new"
+  | "connected"
+  | "relayed"
+  | "degraded"
+  | "stalled"
+  | "failed"
+  | "torn-down";
+
+export type MediaLinkState = "none" | "flowing" | "stalled";
+
+export interface TopologyNode {
+  peerId: string;
+  identityRef: string | null;
+  /** Room refs, scoped `source:ref` - see `RoomSummary`. */
+  rooms: string[];
+  online: boolean;
+  connecting: boolean;
+}
+
+export interface TopologyLink {
+  from: string;
+  to: string;
+  state: LinkState;
+  voice: VoiceLinkState;
+  media: MediaLinkState;
+  /** When `state` last changed, so the grace window can be applied. */
+  changedAt: number;
+  /** When this observer first saw the peer connected, for the grace window. */
+  connectedSince: number | null;
+  proven: boolean;
+}
+
+export interface TopologyRelay {
+  peerId: string;
+  connected: boolean;
+  reserved: boolean;
+}
+
+export interface TopologySfu {
+  host: string;
+  connected: boolean;
+  roomPeerCount: number | null;
+}
+
+export interface Topology {
+  at: number;
+  /** The primary client vantage's peerId. */
+  self: string;
+  relay: TopologyRelay | null;
+  sfu: TopologySfu | null;
+  nodes: TopologyNode[];
+  /** Directed: what `from` believed about `to` at `at`. */
+  links: TopologyLink[];
+}
+
+interface LinkKey {
+  from: string;
+  to: string;
+}
+
+interface FoldState {
+  /** Per observer. */
+  relay: Map<string, TopologyRelay>;
+  sfu: Map<string, TopologySfu>;
+  /** Keyed `observer|peer`. */
+  links: Map<string, TopologyLink>;
+  /** Room refs per peer. */
+  rooms: Map<string, Set<string>>;
+  identity: Map<string, string | null>;
+}
+
+function emptyState(): FoldState {
+  return {
+    relay: new Map(),
+    sfu: new Map(),
+    links: new Map(),
+    rooms: new Map(),
+    identity: new Map(),
+  };
+}
+
+function linkOf(state: FoldState, key: LinkKey, at: number): TopologyLink {
+  const id = `${key.from}|${key.to}`;
+  const hit = state.links.get(id);
+  if (hit) return hit;
+  const fresh: TopologyLink = {
+    from: key.from,
+    to: key.to,
+    state: "none",
+    voice: "none",
+    media: "none",
+    changedAt: at,
+    connectedSince: null,
+    proven: false,
+  };
+  state.links.set(id, fresh);
+  return fresh;
+}
+
+function relayOf(state: FoldState, observer: string): TopologyRelay {
+  const hit = state.relay.get(observer);
+  if (hit) return hit;
+  const fresh: TopologyRelay = { peerId: "", connected: false, reserved: false };
+  state.relay.set(observer, fresh);
+  return fresh;
+}
+
+function sfuOf(state: FoldState, observer: string): TopologySfu {
+  const hit = state.sfu.get(observer);
+  if (hit) return hit;
+  const fresh: TopologySfu = { host: "", connected: false, roomPeerCount: null };
+  state.sfu.set(observer, fresh);
+  return fresh;
+}
+
+function setLinkState(link: TopologyLink, next: LinkState, at: number): boolean {
+  if (link.state === next) return false;
+  link.state = next;
+  link.changedAt = at;
+  return true;
+}
+
+function noteRoom(state: FoldState, peer: string, room: string): boolean {
+  let set = state.rooms.get(peer);
+  if (!set) {
+    set = new Set();
+    state.rooms.set(peer, set);
+  }
+  if (set.has(room)) return false;
+  set.add(room);
+  return true;
+}
+
+/**
+ * Apply one event. Returns true when it changed the graph, which is what makes
+ * `topologyKeyframes` cheap and exact.
+ */
+function applyEvent(state: FoldState, e: MergedEvent): boolean {
+  const observer = e.observer;
+  const peer = e.peer;
+  const kind: MergedKind = e.kind;
+
+  switch (kind) {
+    // ----- relay, per observer -----
+    case "relay.dial.ok": {
+      const relay = relayOf(state, observer);
+      const was = relay.connected;
+      relay.connected = true;
+      return !was;
+    }
+    case "relay.disconnect":
+    case "relay.dial.fail": {
+      const relay = relayOf(state, observer);
+      const was = relay.connected || relay.reserved;
+      relay.connected = false;
+      relay.reserved = false;
+      return was;
+    }
+    case "relay.reservation.ok": {
+      const relay = relayOf(state, observer);
+      const was = relay.reserved;
+      relay.reserved = true;
+      return !was;
+    }
+    case "relay.reservation.timeout": {
+      const relay = relayOf(state, observer);
+      const was = relay.reserved;
+      relay.reserved = false;
+      return was;
+    }
+
+    // ----- the direct peer link -----
+    case "peer.dial.start":
+      if (!peer) return false;
+      return setLinkState(linkOf(state, { from: observer, to: peer }, e.at), "dialing", e.at);
+    case "peer.dial.fail":
+    case "stream.open.fail":
+    case "stream.confirm.fail":
+      if (!peer) return false;
+      return setLinkState(linkOf(state, { from: observer, to: peer }, e.at), "dial-failed", e.at);
+    case "peer.dial.ok":
+    case "peer.redial":
+      if (!peer) return false;
+      return setLinkState(linkOf(state, { from: observer, to: peer }, e.at), "dialing", e.at);
+    case "peer.connect": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      const changed = setLinkState(link, link.proven ? "proven" : "relayed", e.at);
+      if (link.connectedSince === null) {
+        link.connectedSince = e.at;
+        return true;
+      }
+      return changed;
+    }
+    case "peer.disconnect": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      link.proven = false;
+      link.connectedSince = null;
+      return setLinkState(link, "lost", e.at);
+    }
+    case "peer.drop.liveness": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      link.proven = false;
+      link.connectedSince = null;
+      return setLinkState(link, "dropped", e.at);
+    }
+    case "peer.relayed":
+      if (!peer) return false;
+      return setLinkState(linkOf(state, { from: observer, to: peer }, e.at), "relayed", e.at);
+    case "peer.direct": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      return setLinkState(link, link.proven ? "proven" : "direct", e.at);
+    }
+    case "stream.proven": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      const was = link.proven;
+      link.proven = true;
+      if (link.connectedSince === null) link.connectedSince = e.at;
+      return setLinkState(link, "proven", e.at) || !was;
+    }
+    case "stream.lost": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      const was = link.proven;
+      link.proven = false;
+      return setLinkState(link, "lost", e.at) || was;
+    }
+
+    // ----- voice -----
+    case "voice.join":
+    case "voice.pc.new": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      const next: VoiceLinkState = e.sev === "error" ? "failed" : "new";
+      if (link.voice === next) return false;
+      link.voice = next;
+      return true;
+    }
+    case "voice.ice.connected": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      const next: VoiceLinkState = e.d?.relayed === true ? "relayed" : "connected";
+      if (link.voice === next) return false;
+      link.voice = next;
+      return true;
+    }
+    case "voice.degraded":
+      return setVoice(state, observer, peer, "degraded", e.at);
+    case "voice.failed":
+      return setVoice(state, observer, peer, "failed", e.at);
+    case "voice.leave":
+    case "voice.teardown":
+      return setVoice(state, observer, peer, "torn-down", e.at);
+    case "voice.restart":
+      return setVoice(state, observer, peer, "new", e.at);
+    case "voice.media.stall": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      if (link.media === "stalled" && link.voice === "stalled") return false;
+      link.media = "stalled";
+      link.voice = "stalled";
+      return true;
+    }
+    case "voice.media.resume": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      if (link.media === "flowing") return false;
+      link.media = "flowing";
+      return true;
+    }
+
+    // ----- sfu -----
+    case "sfu.pick": {
+      const sfu = sfuOf(state, observer);
+      const host = typeof e.d?.host === "string" ? e.d.host : "";
+      if (sfu.host === host) return false;
+      sfu.host = host;
+      return true;
+    }
+    case "sfu.ws.open": {
+      const sfu = sfuOf(state, observer);
+      if (sfu.connected) return false;
+      sfu.connected = true;
+      return true;
+    }
+    case "sfu.ws.close": {
+      const sfu = sfuOf(state, observer);
+      if (!sfu.connected) return false;
+      sfu.connected = false;
+      sfu.roomPeerCount = null;
+      return true;
+    }
+    case "sfu.diag": {
+      const sfu = sfuOf(state, observer);
+      const count = typeof e.d?.roomPeers === "number" ? e.d.roomPeers : null;
+      if (sfu.roomPeerCount === count) return false;
+      sfu.roomPeerCount = count;
+      return true;
+    }
+    case "sfu.track.added": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      if (link.media === "flowing") return false;
+      link.media = "flowing";
+      return true;
+    }
+    case "sfu.track.stalled": {
+      if (!peer) return false;
+      const link = linkOf(state, { from: observer, to: peer }, e.at);
+      if (link.media === "stalled") return false;
+      link.media = "stalled";
+      return true;
+    }
+
+    // ----- room membership -----
+    case "rv.peers":
+    case "app.join":
+    case "app.leave": {
+      if (!e.room) return false;
+      const subject = peer ?? observer;
+      return noteRoom(state, subject, `${e.source}:${e.room}`);
+    }
+
+    // ----- kinds that carry no topology, listed so the switch stays total -----
+    case "session.start":
+    case "session.config":
+    case "session.unlock":
+    case "session.visibility":
+    case "session.online":
+    case "session.end":
+    case "relay.dial.attempt":
+    case "relay.reservation.request":
+    case "relay.reconnect.schedule":
+    case "relay.reconnect.fail":
+    case "rv.open":
+    case "rv.open.fail":
+    case "rv.register":
+    case "rv.unregister":
+    case "rv.peer.joined":
+    case "rv.peer.left":
+    case "rv.send.fail":
+    case "rv.frame.oversize":
+    case "rv.close":
+    case "peer.upgrade.attempt":
+    case "peer.upgrade.ok":
+    case "peer.upgrade.fail":
+    case "peer.rtt":
+    case "peer.clock":
+    case "stream.open":
+    case "stream.reset":
+    case "stream.write.fail":
+    case "app.roomusers":
+    case "app.msg.in":
+    case "app.msg.out":
+    case "app.msg.reject":
+    case "app.profile.in":
+    case "app.profile.reject":
+    case "app.digest.out":
+    case "app.digest.in":
+    case "app.sync.drop":
+    case "dm.send":
+    case "dm.queue":
+    case "dm.flush":
+    case "dm.mailbox.deposit":
+    case "dm.mailbox.collect":
+    case "dm.mailbox.drop":
+    case "ice.turn.ok":
+    case "ice.turn.unavailable":
+    case "ice.turn.fail":
+    case "ice.servers.changed":
+    case "voice.offer.out":
+    case "voice.offer.in":
+    case "voice.answer.in":
+    case "voice.signal.invalid":
+    case "voice.ice.state":
+    case "voice.pc.state":
+    case "voice.redial.ask":
+    case "voice.redial.serve":
+    case "sfu.ws.error":
+    case "sfu.join":
+    case "sfu.caps":
+    case "sfu.transport.create":
+    case "sfu.transport.state":
+    case "sfu.transport.timeout":
+    case "sfu.produce":
+    case "sfu.consume":
+    case "sfu.consume.failed":
+    case "sfu.error":
+    case "sfu.rejoin":
+    case "file.announce":
+    case "file.request":
+    case "file.progress":
+    case "file.fail":
+    case "storage.locked":
+    case "storage.quota":
+    case "storage.drop":
+    case "counters":
+    case "fault.injected":
+    case "meta.suppressed":
+    // A log line that no template matched. It carries no structure to fold,
+    // but it is listed so the switch stays total over `MergedKind`.
+    case LOG_RAW_KIND:
+      return false;
+  }
+}
+
+function setVoice(
+  state: FoldState,
+  observer: string,
+  peer: string | null,
+  next: VoiceLinkState,
+  at: number
+): boolean {
+  if (!peer) return false;
+  const link = linkOf(state, { from: observer, to: peer }, at);
+  if (link.voice === next) return false;
+  link.voice = next;
+  return true;
+}
+
+/** The client vantage with the most events. It drives `self` and `online`. */
+export function primaryObserver(c: Capture): string {
+  const counts = new Map<string, number>();
+  for (const v of c.vantages) {
+    if (v.kind !== "client") continue;
+    counts.set(v.observer, (counts.get(v.observer) ?? 0) + v.events.length);
+  }
+  let best = "";
+  let most = -1;
+  for (const [observer, n] of counts) {
+    if (n > most) {
+      most = n;
+      best = observer;
+    }
+  }
+  return best;
+}
+
+/**
+ * Derive the display state of a peer from the primary observer's point of view.
+ *
+ * Connected AND proven is online. Connected without proof is online only inside
+ * the grace window, because the ordinary handshake is briefly unproven and a
+ * flicker to "connecting" on every normal join is worse than useless.
+ */
+function deriveOnline(
+  link: TopologyLink | undefined,
+  at: number
+): { online: boolean; connecting: boolean } {
+  if (!link) return { online: false, connecting: false };
+  const connected =
+    link.state === "relayed" ||
+    link.state === "direct" ||
+    link.state === "proven";
+  if (!connected) return { online: false, connecting: false };
+  if (link.proven) return { online: true, connecting: false };
+  const withinGrace =
+    link.connectedSince !== null && at - link.connectedSince < PEER_PROOF_GRACE_MS;
+  return { online: withinGrace, connecting: !withinGrace };
+}
+
+function buildTopology(c: Capture, state: FoldState, at: number): Topology {
+  const self = primaryObserver(c);
+  const links = [...state.links.values()].map((l) => ({ ...l }));
+  const selfLinks = new Map<string, TopologyLink>();
+  for (const l of links) {
+    if (l.from === self) selfLinks.set(l.to, l);
+  }
+
+  const nodes: TopologyNode[] = [];
+  for (const [peerId, summary] of c.peers) {
+    if (peerId === self) continue;
+    const { online, connecting } = deriveOnline(selfLinks.get(peerId), at);
+    nodes.push({
+      peerId,
+      identityRef: summary.identityRefs[0] ?? null,
+      rooms: [...(state.rooms.get(peerId) ?? [])],
+      online,
+      connecting,
+    });
+  }
+  nodes.sort((a, b) => a.peerId.localeCompare(b.peerId));
+
+  const relay = state.relay.get(self) ?? null;
+  if (relay) {
+    const named = c.vantages.find((v) => v.kind === "client" && v.observer === self);
+    relay.peerId = named?.bundle?.config.relayPeerId ?? relay.peerId;
+  }
+
+  return {
+    at,
+    self,
+    relay: relay ? { ...relay } : null,
+    sfu: state.sfu.get(self) ? { ...(state.sfu.get(self) as TopologySfu) } : null,
+    nodes,
+    links,
+  };
+}
+
+/** The graph as of `at`. Events later than `at` are ignored. */
+export function foldTopology(c: Capture, at: number): Topology {
+  const state = emptyState();
+  for (const e of c.timeline) {
+    if (e.at > at) break;
+    applyEvent(state, e);
+  }
+  return buildTopology(c, state, at);
+}
+
+/** Times where the graph actually changed. Always includes the window edges. */
+export function topologyKeyframes(c: Capture): number[] {
+  const state = emptyState();
+  const out: number[] = [c.window.from];
+  for (const e of c.timeline) {
+    if (applyEvent(state, e) && out[out.length - 1] !== e.at) out.push(e.at);
+  }
+  if (out[out.length - 1] !== c.window.to) out.push(c.window.to);
+  return out;
+}
+
+/** The vantage kinds present, for the Sessions view. */
+export function vantageKinds(c: Capture): VantageKind[] {
+  return [...new Set(c.vantages.map((v) => v.kind))];
+}

--- a/dashboard/src/lib/analysis/topology.ts
+++ b/dashboard/src/lib/analysis/topology.ts
@@ -441,8 +441,9 @@ function applyEvent(state: FoldState, e: MergedEvent): boolean {
     case "counters":
     case "fault.injected":
     case "meta.suppressed":
-    // Local to one tab: an uncaught throw and the connection gauge say
-    // nothing about who can reach whom.
+    // Local to one tab: an uncaught throw, the connection gauge and a media
+    // sample say nothing about who can reach whom.
+    case "voice.media.sample":
     case "runtime.error":
     case "runtime.resources":
     // A log line that no template matched. It carries no structure to fold,

--- a/dashboard/src/lib/analysis/topology.ts
+++ b/dashboard/src/lib/analysis/topology.ts
@@ -441,6 +441,10 @@ function applyEvent(state: FoldState, e: MergedEvent): boolean {
     case "counters":
     case "fault.injected":
     case "meta.suppressed":
+    // Local to one tab: an uncaught throw and the connection gauge say
+    // nothing about who can reach whom.
+    case "runtime.error":
+    case "runtime.resources":
     // A log line that no template matched. It carries no structure to fold,
     // but it is listed so the switch stays total over `MergedKind`.
     case LOG_RAW_KIND:

--- a/dashboard/src/lib/relay-client.ts
+++ b/dashboard/src/lib/relay-client.ts
@@ -1,0 +1,157 @@
+/**
+ * The relay's operator read endpoints.
+ *
+ * Both routes are absent unless the operator sets `TELEMETRY_ADMIN_TOKEN`, and
+ * the relay answers 404 in that case on purpose: it must not advertise a
+ * console that does not exist. A 404 is therefore a CONFIGURATION answer, not
+ * a missing bundle, and this module says so in the message it returns.
+ *
+ * The token is a parameter. It is never read from or written to storage here.
+ * See the note on `relay` in `sources.svelte.ts`.
+ *
+ * Nothing in this module throws. Every outcome is a discriminated result, so a
+ * view renders a reason instead of a stack trace.
+ */
+
+import type { ClientBundle } from "./schema";
+
+export interface RelayBundleRef {
+  /** `<peerId>/<file>`, the exact `id` the get route wants. */
+  id: string;
+  peerId: string;
+  size: number;
+  createdAt: number;
+}
+
+export type RelayFailure =
+  /** The operator did not set `TELEMETRY_ADMIN_TOKEN`, so there is no console. */
+  | "no-console"
+  /** The token was wrong. */
+  | "unauthorized"
+  | "rate-limited"
+  /** The relay refused, or answered a status this client does not expect. */
+  | "server"
+  /** The body was not the JSON this client expects. */
+  | "malformed"
+  /** DNS, TLS, CORS or an offline host. */
+  | "network"
+  /** The form was incomplete, so no request was made. */
+  | "input";
+
+export type RelayResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: RelayFailure; message: string };
+
+const MESSAGES: Readonly<Record<RelayFailure, string>> = {
+  "no-console":
+    "This relay has no telemetry console. The operator did not set TELEMETRY_ADMIN_TOKEN.",
+  unauthorized: "The relay refused the admin token.",
+  "rate-limited": "The relay rate-limited this client. Wait a minute.",
+  server: "The relay answered an unexpected status.",
+  malformed: "The relay answered a body this client does not understand.",
+  network:
+    "The relay is unreachable. Check the host, the scheme and the relay's CORS answer.",
+  input: "Give both a relay host and an admin token.",
+};
+
+function fail<T>(reason: RelayFailure, extra?: string): RelayResult<T> {
+  const base = MESSAGES[reason];
+  return { ok: false, reason, message: extra ? `${base} ${extra}` : base };
+}
+
+/**
+ * Accept `relay.example.com`, `https://relay.example.com` or a trailing slash.
+ * A bare host becomes https, because the relay's admin routes are TLS-only in
+ * every deployment that has a token at all.
+ */
+export function normalizeBase(input: string): string {
+  const raw = input.trim().replace(/\/+$/, "");
+  if (raw === "") return "";
+  if (/^https?:\/\//i.test(raw)) return raw;
+  return `https://${raw}`;
+}
+
+async function get(
+  base: string,
+  path: string,
+  token: string
+): Promise<RelayResult<unknown>> {
+  const apiBase = normalizeBase(base);
+  if (apiBase === "" || token.trim() === "") return fail("input");
+
+  let res: Response;
+  try {
+    res = await fetch(`${apiBase}${path}`, {
+      method: "GET",
+      headers: { authorization: `Bearer ${token.trim()}` },
+      // No cookies: a bearer token is the only credential this console has.
+      credentials: "omit",
+    });
+  } catch {
+    return fail("network");
+  }
+
+  if (res.status === 404) return fail("no-console");
+  if (res.status === 401 || res.status === 403) return fail("unauthorized");
+  if (res.status === 429) return fail("rate-limited");
+  if (!res.ok) return fail("server", `Status ${res.status}.`);
+
+  try {
+    return { ok: true, value: (await res.json()) as unknown };
+  } catch {
+    return fail("malformed");
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function refOf(v: unknown): RelayBundleRef | null {
+  if (!isRecord(v)) return null;
+  const { id, peerId, size, createdAt } = v;
+  if (typeof id !== "string" || typeof peerId !== "string") return null;
+  return {
+    id,
+    peerId,
+    size: typeof size === "number" ? size : 0,
+    createdAt: typeof createdAt === "number" ? createdAt : 0,
+  };
+}
+
+/** `GET /telemetry/list`. Newest first, as the relay returns them. */
+export async function listBundles(
+  apiBase: string,
+  token: string
+): Promise<RelayResult<RelayBundleRef[]>> {
+  const res = await get(apiBase, "/telemetry/list", token);
+  if (!res.ok) return res;
+  if (!isRecord(res.value) || !Array.isArray(res.value.bundles)) {
+    return fail("malformed");
+  }
+  const out: RelayBundleRef[] = [];
+  for (const entry of res.value.bundles) {
+    const ref = refOf(entry);
+    if (ref) out.push(ref);
+  }
+  return { ok: true, value: out };
+}
+
+/** `GET /telemetry/get?id=<peerId>/<file>`. */
+export async function getBundle(
+  apiBase: string,
+  token: string,
+  id: string
+): Promise<RelayResult<ClientBundle>> {
+  const res = await get(
+    apiBase,
+    `/telemetry/get?id=${encodeURIComponent(id)}`,
+    token
+  );
+  if (!res.ok) return res;
+  const b = res.value;
+  if (!isRecord(b) || b.vantage !== "client" || !Array.isArray(b.events)) {
+    return fail("malformed", "It is not a client bundle.");
+  }
+  return { ok: true, value: b as unknown as ClientBundle };
+}

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -1,0 +1,526 @@
+/**
+ * Diagnostic wire schema - the flight recorder's only contract.
+ *
+ * MIRRORED, byte-for-byte, FROM `frontend/src/lib/telemetry/schema.ts`, as the
+ * `ms:*` protocol is mirrored between `sfu/index.ts` and
+ * `frontend/src/lib/transport/mediasoup.ts`. The SFU-side view types below are
+ * mirrored a THIRD time, in `sfu/telemetry.ts`.
+ *
+ * A change here MUST be made in every copy, in the same commit. There is no
+ * negotiation step and no version handshake: a bundle carries
+ * `schemaVersion`, and a reader that sees an unknown version refuses the
+ * bundle rather than guessing.
+ *
+ * PRIVACY - this file defines what CAN be transmitted, so it is the first
+ * place a leak would appear. A room code, a `did:key:`, message content, file
+ * content, a nickname, an avatar and an ICE candidate ADDRESS have no field
+ * here and must never be given one. See `docs/spec.md` "Server Privacy".
+ */
+
+export const DIAG_SCHEMA_VERSION = 1;
+
+export type DiagSeverity = "debug" | "info" | "warn" | "error";
+
+export interface DiagEvent {
+  /** 1-based, per session. A gap means the ring or the throttle dropped events. */
+  seq: number;
+  /** Milliseconds since the session's `startedAt`, integer. */
+  t: number;
+  kind: DiagKind;
+  sev: DiagSeverity;
+  /** FULL peerId when the event is about a peer, else null. */
+  peer: string | null;
+  /** Bundle-local room ordinal ("r1"). NEVER a room code. */
+  room: string | null;
+  /** Flat detail bag: JSON primitives only, <=12 keys, strings <=200 chars. */
+  d?: Record<string, string | number | boolean | null>;
+}
+
+/**
+ * The exhaustive event vocabulary. Each literal is a wire contract: the
+ * dashboard's rule engine matches on these strings, so renaming one is a
+ * breaking change that needs a `DIAG_SCHEMA_VERSION` bump.
+ */
+export type DiagKind =
+  // session
+  | "session.start"
+  | "session.config"
+  | "session.unlock"
+  | "session.visibility"
+  | "session.online"
+  | "session.end"
+  // relay
+  | "relay.dial.attempt"
+  | "relay.dial.ok"
+  | "relay.dial.fail"
+  | "relay.reservation.request"
+  | "relay.reservation.ok"
+  | "relay.reservation.timeout"
+  | "relay.disconnect"
+  | "relay.reconnect.schedule"
+  | "relay.reconnect.fail"
+  // rendezvous
+  | "rv.open"
+  | "rv.open.fail"
+  | "rv.register"
+  | "rv.unregister"
+  | "rv.peers"
+  | "rv.peer.joined"
+  | "rv.peer.left"
+  | "rv.send.fail"
+  | "rv.frame.oversize"
+  | "rv.close"
+  // peer
+  | "peer.dial.start"
+  | "peer.dial.ok"
+  | "peer.dial.fail"
+  | "peer.connect"
+  | "peer.disconnect"
+  | "peer.relayed"
+  | "peer.direct"
+  | "peer.upgrade.attempt"
+  | "peer.upgrade.ok"
+  | "peer.upgrade.fail"
+  | "peer.drop.liveness"
+  | "peer.redial"
+  | "peer.rtt"
+  | "peer.clock"
+  // direct stream
+  | "stream.open"
+  | "stream.open.fail"
+  | "stream.proven"
+  | "stream.lost"
+  | "stream.confirm.fail"
+  | "stream.reset"
+  | "stream.write.fail"
+  // app layer
+  | "app.join"
+  | "app.leave"
+  | "app.roomusers"
+  | "app.msg.in"
+  | "app.msg.out"
+  | "app.msg.reject"
+  | "app.profile.in"
+  | "app.profile.reject"
+  | "app.digest.out"
+  | "app.digest.in"
+  | "app.sync.drop"
+  // dm + mailbox
+  | "dm.send"
+  | "dm.queue"
+  | "dm.flush"
+  | "dm.mailbox.deposit"
+  | "dm.mailbox.collect"
+  | "dm.mailbox.drop"
+  // ice / turn
+  | "ice.turn.ok"
+  | "ice.turn.unavailable"
+  | "ice.turn.fail"
+  | "ice.servers.changed"
+  // voice (p2p mesh)
+  | "voice.join"
+  | "voice.leave"
+  | "voice.pc.new"
+  | "voice.offer.out"
+  | "voice.offer.in"
+  | "voice.answer.in"
+  | "voice.signal.invalid"
+  | "voice.ice.state"
+  | "voice.pc.state"
+  | "voice.ice.connected"
+  | "voice.degraded"
+  | "voice.failed"
+  | "voice.restart"
+  | "voice.teardown"
+  | "voice.redial.ask"
+  | "voice.redial.serve"
+  | "voice.media.stall"
+  | "voice.media.resume"
+  // sfu
+  | "sfu.pick"
+  | "sfu.ws.open"
+  | "sfu.ws.close"
+  | "sfu.ws.error"
+  | "sfu.join"
+  | "sfu.caps"
+  | "sfu.transport.create"
+  | "sfu.transport.state"
+  | "sfu.transport.timeout"
+  | "sfu.produce"
+  | "sfu.consume"
+  | "sfu.consume.failed"
+  | "sfu.error"
+  | "sfu.rejoin"
+  | "sfu.track.added"
+  | "sfu.track.stalled"
+  | "sfu.diag"
+  // files
+  | "file.announce"
+  | "file.request"
+  | "file.progress"
+  | "file.fail"
+  // local infrastructure
+  | "storage.locked"
+  | "storage.quota"
+  | "storage.drop"
+  | "counters"
+  | "fault.injected"
+  | "meta.suppressed";
+
+/**
+ * The number of members of `DiagKind`. `KIND_SEV` is asserted against it at
+ * test time, so a kind added without a severity is a test failure rather than
+ * an `undefined` severity on the wire.
+ */
+export const DIAG_KIND_COUNT = 112;
+
+/**
+ * Default severity per kind. Classes, in the order they were decided:
+ *
+ * - "error": a named failure - `*.fail`, `*.failed`, `*.timeout`, `*.reject`,
+ *   `*.drop*`, `*.invalid`, `*.oversize`, plus `storage.locked` (an offline
+ *   queue write was silently lost), `sfu.error` and `sfu.ws.error` (both are
+ *   failures whose names predate this table), and `ice.turn.unavailable` (no
+ *   TURN is a hard failure for a peer behind a symmetric NAT).
+ * - "warn": a degradation that still works - `*.degraded`, `*.stall*`,
+ *   `*.retry`, `rv.close`, `peer.disconnect`, `storage.quota`.
+ * - "debug": high-rate sampling - `peer.rtt`, `peer.clock`, `counters`,
+ *   `sfu.diag`, `voice.ice.state`.
+ * - "info": everything else.
+ *
+ * `sev` decides the order `trimBundleForUpload` sacrifices events in, and it
+ * is what the dashboard's severity filter reads. It is deliberately NOT what
+ * the rule engine keys on - a finding's severity comes from `RULES`.
+ */
+export const KIND_SEV = {
+  // session
+  "session.start": "info",
+  "session.config": "info",
+  "session.unlock": "info",
+  "session.visibility": "info",
+  "session.online": "info",
+  "session.end": "info",
+  // relay
+  "relay.dial.attempt": "info",
+  "relay.dial.ok": "info",
+  "relay.dial.fail": "error",
+  "relay.reservation.request": "info",
+  "relay.reservation.ok": "info",
+  "relay.reservation.timeout": "error",
+  "relay.disconnect": "info",
+  "relay.reconnect.schedule": "info",
+  "relay.reconnect.fail": "error",
+  // rendezvous
+  "rv.open": "info",
+  "rv.open.fail": "error",
+  "rv.register": "info",
+  "rv.unregister": "info",
+  "rv.peers": "info",
+  "rv.peer.joined": "info",
+  "rv.peer.left": "info",
+  "rv.send.fail": "error",
+  "rv.frame.oversize": "error",
+  "rv.close": "warn",
+  // peer
+  "peer.dial.start": "info",
+  "peer.dial.ok": "info",
+  "peer.dial.fail": "error",
+  "peer.connect": "info",
+  "peer.disconnect": "warn",
+  "peer.relayed": "info",
+  "peer.direct": "info",
+  "peer.upgrade.attempt": "info",
+  "peer.upgrade.ok": "info",
+  "peer.upgrade.fail": "error",
+  "peer.drop.liveness": "error",
+  "peer.redial": "info",
+  "peer.rtt": "debug",
+  "peer.clock": "debug",
+  // direct stream
+  "stream.open": "info",
+  "stream.open.fail": "error",
+  "stream.proven": "info",
+  "stream.lost": "info",
+  "stream.confirm.fail": "error",
+  "stream.reset": "info",
+  "stream.write.fail": "error",
+  // app layer
+  "app.join": "info",
+  "app.leave": "info",
+  "app.roomusers": "info",
+  "app.msg.in": "info",
+  "app.msg.out": "info",
+  "app.msg.reject": "error",
+  "app.profile.in": "info",
+  "app.profile.reject": "error",
+  "app.digest.out": "info",
+  "app.digest.in": "info",
+  "app.sync.drop": "error",
+  // dm + mailbox
+  "dm.send": "info",
+  "dm.queue": "info",
+  "dm.flush": "info",
+  "dm.mailbox.deposit": "info",
+  "dm.mailbox.collect": "info",
+  "dm.mailbox.drop": "error",
+  // ice / turn
+  "ice.turn.ok": "info",
+  "ice.turn.unavailable": "error",
+  "ice.turn.fail": "error",
+  "ice.servers.changed": "info",
+  // voice
+  "voice.join": "info",
+  "voice.leave": "info",
+  "voice.pc.new": "info",
+  "voice.offer.out": "info",
+  "voice.offer.in": "info",
+  "voice.answer.in": "info",
+  "voice.signal.invalid": "error",
+  "voice.ice.state": "debug",
+  "voice.pc.state": "info",
+  "voice.ice.connected": "info",
+  "voice.degraded": "warn",
+  "voice.failed": "error",
+  "voice.restart": "info",
+  "voice.teardown": "info",
+  "voice.redial.ask": "info",
+  "voice.redial.serve": "info",
+  "voice.media.stall": "warn",
+  "voice.media.resume": "info",
+  // sfu
+  "sfu.pick": "info",
+  "sfu.ws.open": "info",
+  "sfu.ws.close": "info",
+  "sfu.ws.error": "error",
+  "sfu.join": "info",
+  "sfu.caps": "info",
+  "sfu.transport.create": "info",
+  "sfu.transport.state": "info",
+  "sfu.transport.timeout": "error",
+  "sfu.produce": "info",
+  "sfu.consume": "info",
+  "sfu.consume.failed": "error",
+  "sfu.error": "error",
+  "sfu.rejoin": "info",
+  "sfu.track.added": "info",
+  "sfu.track.stalled": "warn",
+  "sfu.diag": "debug",
+  // files
+  "file.announce": "info",
+  "file.request": "info",
+  "file.progress": "info",
+  "file.fail": "error",
+  // local infrastructure
+  "storage.locked": "error",
+  "storage.quota": "warn",
+  "storage.drop": "error",
+  counters: "debug",
+  "fault.injected": "info",
+  "meta.suppressed": "info",
+} as const satisfies Record<DiagKind, DiagSeverity>;
+
+/** Events per second, per kind, before the ring's throttle suppresses. */
+export const DEFAULT_BUDGET = 20;
+/** A failure is worth more than a sample, so it gets a bigger allowance. */
+export const ERROR_BUDGET = 60;
+
+/**
+ * Per-kind overrides for kinds that can arrive in a storm. Without these one
+ * hot kind evicts the whole ring, which is the failure mode the throttle
+ * exists to prevent.
+ */
+export const KIND_BUDGET: Readonly<Partial<Record<DiagKind, number>>> = {
+  "app.msg.in": 5,
+  "app.msg.out": 5,
+  "file.progress": 2,
+  "voice.ice.state": 5,
+  "peer.rtt": 2,
+};
+
+// ---------------------------------------------------------------------------
+// Bundle envelope
+// ---------------------------------------------------------------------------
+
+export interface DiagBundleHead {
+  schemaVersion: typeof DIAG_SCHEMA_VERSION;
+  /** 16 random bytes, hex, minted at export. */
+  bundleId: string;
+  /** 16 random bytes, hex, minted in `LibP2PTransport.connect()`. */
+  sessionId: string;
+  /** Wall clock ms at export. */
+  createdAt: number;
+  /** Wall clock ms of `session.start`. */
+  startedAt: number;
+}
+
+export interface DiagRoomRef {
+  /** Bundle-local ordinal, "r1". NEVER a room code. */
+  ref: string;
+  kind: "text" | "dm" | "sync";
+  joinedAt: number;
+}
+
+export interface DiagPeerRef {
+  /** FULL peerId. The relay and the SFU already have it. */
+  peerId: string;
+  /**
+   * Bundle-local ordinal shared by peerIds that PROVED the same DID. It
+   * preserves "these are one person's devices" without naming the person.
+   */
+  identityRef: string | null;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+/**
+ * What this build was configured to talk to. HOSTS only: a full URL can carry
+ * a path or a query, and `isConfigured()` is the flag that tells a reader the
+ * instance was never set up at all.
+ */
+export interface DiagRuntimeConfig {
+  apiHost: string;
+  relayPeerId: string;
+  sfuHosts: string[];
+  configured: boolean;
+}
+
+export interface ClientBundle extends DiagBundleHead {
+  vantage: "client";
+  app: { version: string; commit: string };
+  /** `ua` truncated to 200 chars. */
+  env: { ua: string };
+  config: DiagRuntimeConfig;
+  /** NO `did`, not even the uploader's own. */
+  self: { peerId: string };
+  rooms: DiagRoomRef[];
+  peers: DiagPeerRef[];
+  counters: Record<string, number>;
+  events: DiagEvent[];
+  /** The last 8 SFU snapshots, which are too large for a `d` bag. */
+  sfuSnapshots: SfuSnapshot[];
+  meta: {
+    ringCapacity: number;
+    /** Evicted by wraparound. */
+    dropped: number;
+    /** Per kind, by the throttle. */
+    suppressed: Record<string, number>;
+    faultsActive: boolean;
+    /** Trimmed to fit an upload. */
+    truncated: boolean;
+  };
+  /** Stapled by the relay at ingest; absent in a file export. */
+  relayView?: RelayVantage;
+}
+
+export interface RelayVantage {
+  vantage: "relay";
+  relayPeerId: string;
+  observedPeerId: string;
+  registry: {
+    totalRegistrations: number;
+    streamsForPeer: number;
+    atTotalCap: boolean;
+  };
+  rooms: Array<{ ref: string; size: number; members: string[] }>;
+  streams: Array<{
+    ref: string;
+    openedAt: number;
+    closedAt: number | null;
+    closeReason: RelayCloseReason | null;
+    rooms: number;
+    registers: number;
+    unregisters: number;
+    capped: number;
+    oracleSilenced: number;
+  }>;
+  events: DiagEvent[];
+}
+
+/**
+ * Why a rendezvous stream ended. Today the relay collapses all of these into
+ * one log line, which is the difference between "a peer left" and "a peer
+ * wedged". See `relay/telemetry.go`.
+ */
+export type RelayCloseReason =
+  | "graceful"
+  | "liveness-timeout"
+  | "idle-timeout"
+  | "read-error"
+  | "frame-oversize"
+  | "frame-invalid"
+  | "outbox-full"
+  | "stream-cap"
+  | "peer-disconnect"
+  | "evicted";
+
+/**
+ * Anything the dashboard can load from a file. Only a client bundle is ever
+ * exported; a relay vantage always arrives stapled inside one.
+ */
+export type DiagBundle = ClientBundle;
+
+// ---------------------------------------------------------------------------
+// SFU vantage - mirrored a third time in `sfu/telemetry.ts`
+// ---------------------------------------------------------------------------
+
+export interface DiagTransportView {
+  dir: "send" | "recv";
+  iceState: string;
+  dtlsState: string;
+  /** Protocol and LOCAL port only. NEVER a remote address. */
+  tuple: { protocol: string; localPort: number } | null;
+  bytesSent: number;
+  bytesReceived: number;
+  rtt: number | null;
+}
+
+export interface DiagProducerView {
+  id: string;
+  kind: string;
+  source: string;
+  score: number;
+  consumers: number;
+  bitrate: number;
+  packetsLost: number;
+}
+
+export interface DiagConsumerView {
+  id: string;
+  producerId: string;
+  kind: string;
+  score: number;
+  paused: boolean;
+  producerPaused: boolean;
+  bitrate: number;
+  packetsLost: number;
+}
+
+export interface SfuSnapshot {
+  schemaVersion: number;
+  takenAt: number;
+  roomPeerCount: number;
+  self: {
+    peerId: string;
+    transports: DiagTransportView[];
+    producers: DiagProducerView[];
+    consumers: DiagConsumerView[];
+    cumulativeProduces: number;
+    backpressured: boolean;
+  };
+  room: Array<{
+    peerId: string;
+    producers: Array<{
+      id: string;
+      source: string;
+      kind: string;
+      consumers: number;
+    }>;
+  }>;
+  ceilings: {
+    peersPerRoom: number;
+    producersPerPeer: number;
+    consumersPerPeer: number;
+    rooms: number;
+    maxRooms: number;
+  };
+}

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -163,6 +163,8 @@ export type DiagKind =
   | "storage.locked"
   | "storage.quota"
   | "storage.drop"
+  | "runtime.error"
+  | "runtime.resources"
   | "counters"
   | "fault.injected"
   | "meta.suppressed";
@@ -172,7 +174,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 112;
+export const DIAG_KIND_COUNT = 114;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:
@@ -181,11 +183,12 @@ export const DIAG_KIND_COUNT = 112;
  *   `*.drop*`, `*.invalid`, `*.oversize`, plus `storage.locked` (an offline
  *   queue write was silently lost), `sfu.error` and `sfu.ws.error` (both are
  *   failures whose names predate this table), and `ice.turn.unavailable` (no
- *   TURN is a hard failure for a peer behind a symmetric NAT).
+ *   TURN is a hard failure for a peer behind a symmetric NAT), and
+ *   `runtime.error` (an exception nothing in the app caught).
  * - "warn": a degradation that still works - `*.degraded`, `*.stall*`,
  *   `*.retry`, `rv.close`, `peer.disconnect`, `storage.quota`.
  * - "debug": high-rate sampling - `peer.rtt`, `peer.clock`, `counters`,
- *   `sfu.diag`, `voice.ice.state`.
+ *   `sfu.diag`, `voice.ice.state`, `runtime.resources`.
  * - "info": everything else.
  *
  * `sev` decides the order `trimBundleForUpload` sacrifices events in, and it
@@ -314,6 +317,8 @@ export const KIND_SEV = {
   "storage.locked": "error",
   "storage.quota": "warn",
   "storage.drop": "error",
+  "runtime.error": "error",
+  "runtime.resources": "debug",
   counters: "debug",
   "fault.injected": "info",
   "meta.suppressed": "info",
@@ -335,6 +340,11 @@ export const KIND_BUDGET: Readonly<Partial<Record<DiagKind, number>>> = {
   "file.progress": 2,
   "voice.ice.state": 5,
   "peer.rtt": 2,
+  // One broken frame can throw on every animation tick. A storm of the same
+  // error says nothing the first five did not, and it would evict the ring
+  // that explains WHY it started.
+  "runtime.error": 5,
+  "runtime.resources": 2,
 };
 
 // ---------------------------------------------------------------------------

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -134,6 +134,7 @@ export type DiagKind =
   | "voice.teardown"
   | "voice.redial.ask"
   | "voice.redial.serve"
+  | "voice.media.sample"
   | "voice.media.stall"
   | "voice.media.resume"
   // sfu
@@ -174,7 +175,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 114;
+export const DIAG_KIND_COUNT = 115;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:
@@ -188,7 +189,8 @@ export const DIAG_KIND_COUNT = 114;
  * - "warn": a degradation that still works - `*.degraded`, `*.stall*`,
  *   `*.retry`, `rv.close`, `peer.disconnect`, `storage.quota`.
  * - "debug": high-rate sampling - `peer.rtt`, `peer.clock`, `counters`,
- *   `sfu.diag`, `voice.ice.state`, `runtime.resources`.
+ *   `sfu.diag`, `voice.ice.state`, `runtime.resources`,
+ *   `voice.media.sample`.
  * - "info": everything else.
  *
  * `sev` decides the order `trimBundleForUpload` sacrifices events in, and it
@@ -288,6 +290,7 @@ export const KIND_SEV = {
   "voice.teardown": "info",
   "voice.redial.ask": "info",
   "voice.redial.serve": "info",
+  "voice.media.sample": "debug",
   "voice.media.stall": "warn",
   "voice.media.resume": "info",
   // sfu
@@ -343,6 +346,7 @@ export const KIND_BUDGET: Readonly<Partial<Record<DiagKind, number>>> = {
   // One broken frame can throw on every animation tick. A storm of the same
   // error says nothing the first five did not, and it would evict the ring
   // that explains WHY it started.
+  "voice.media.sample": 4,
   "runtime.error": 5,
   "runtime.resources": 2,
 };

--- a/dashboard/src/lib/sources.svelte.ts
+++ b/dashboard/src/lib/sources.svelte.ts
@@ -1,0 +1,1109 @@
+/**
+ * The console's only reactive state.
+ *
+ * The split this module enforces is the same one the chat app uses for call
+ * quality: `call-quality.ts` is pure, `call-peer-quality.svelte.ts` holds the
+ * runes, `CallStatus.svelte` renders. Here `analysis/*.ts` is pure, this file
+ * holds every rune, and a `.svelte` file renders and nothing else.
+ *
+ * Two rules keep it fast and honest.
+ *
+ * 1. HEAVY PAYLOADS STAY OUT OF `$state`. A bundle holds up to 4096 events. A
+ *    rune proxy over that array would proxy every event on every read, so the
+ *    payloads live in a plain `Map` and a `revision` counter marks them dirty.
+ *    Only the light per-file metadata is reactive, because that is what the
+ *    Sources view renders.
+ * 2. THE RELAY ADMIN TOKEN LIVES IN MEMORY ONLY. It is never written to
+ *    localStorage, never put in a URL and never logged. A reload loses it, and
+ *    that is the intended cost: this console reads a production relay.
+ *
+ * An SFU log carries room codes in clear (see `analysis/logs.ts`). Those stay
+ * in this process. Nothing here writes a room code into an export or a prompt.
+ */
+
+import { DIAG_SCHEMA_VERSION } from "./schema";
+import type { ClientBundle, DiagSeverity, SfuSnapshot } from "./schema";
+import { MAX_ACCEPTABLE_SKEW_MS, mergeSources } from "./analysis/merge";
+import type {
+  Capture,
+  MergedEvent,
+  PeerSummary,
+  VantageKind,
+} from "./analysis/merge";
+import {
+  foldTopology,
+  primaryObserver,
+  topologyKeyframes,
+  vantageKinds,
+} from "./analysis/topology";
+import type { LinkState, Topology, TopologyLink } from "./analysis/topology";
+import { runFindings } from "./analysis/findings";
+import type { Finding } from "./analysis/findings";
+import {
+  parseConsoleLog,
+  parseRelayLog,
+  parseSfuLog,
+  parseSfuTelemetry,
+  resolveSuffix,
+} from "./analysis/logs";
+import type { ParsedLog } from "./analysis/logs";
+import { buildPromptPack } from "./analysis/prompt";
+import type { PromptPack } from "./analysis/prompt";
+import { getBundle, listBundles, normalizeBase } from "./relay-client";
+import type { RelayBundleRef } from "./relay-client";
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+export type Tab =
+  | "sources"
+  | "sessions"
+  | "findings"
+  | "timeline"
+  | "topology"
+  | "matrix"
+  | "peers"
+  | "logs"
+  | "ai";
+
+/**
+ * The workflow order: load, pick a capture, read the verdict, then dig, then
+ * check the parse, then hand the pack to a model.
+ */
+export const TABS: ReadonlyArray<{ id: Tab; label: string }> = [
+  { id: "sources", label: "Sources" },
+  { id: "sessions", label: "Sessions" },
+  { id: "findings", label: "Findings" },
+  { id: "timeline", label: "Timeline" },
+  { id: "topology", label: "Topology" },
+  { id: "matrix", label: "Matrix" },
+  { id: "peers", label: "Peers" },
+  { id: "logs", label: "Logs" },
+  { id: "ai", label: "AI" },
+];
+
+export type LogParser = "sfu" | "relay" | "console";
+
+/**
+ * `sfu` runs BOTH SFU parsers over one text. A real `docker logs sfu` file
+ * carries the structured `[sfu-telemetry]` lines beside the free-form `[sfu]`
+ * lines, and `parseSfuLog` skips the structured ones, so the two parsers
+ * cover one file without a duplicate or a double-counted line.
+ */
+export const LOG_PARSERS: ReadonlyArray<{ id: LogParser; label: string }> = [
+  { id: "sfu", label: "sfu container log" },
+  { id: "relay", label: "relay container log" },
+  { id: "console", label: "browser console" },
+];
+
+export type FileRole = "bundle" | "log" | "rejected";
+
+/** The light half of a loaded file. This is what the Sources view renders. */
+export interface FileMeta {
+  id: string;
+  name: string;
+  /** Unique per workspace, so `MergedEvent.source` names exactly one file. */
+  source: string;
+  bytes: number;
+  role: FileRole;
+  /** The vantage a bundle carries, or "log". */
+  vantage: VantageKind | null;
+  /** The bundle's own peerId, or the first peerId a log resolved. */
+  observer: string;
+  eventCount: number;
+  /** Set for a log. */
+  parser: LogParser | null;
+  /** Log lines the parser did not recognise. They survive as `raw` events. */
+  unmatched: number;
+  warnings: string[];
+  /** Why the file is unusable. Reported, never dropped. */
+  error: string | null;
+  /** True when the relay's admin route supplied it. */
+  fromRelay: boolean;
+}
+
+export interface Filter {
+  /** The lowest severity a row must have. "debug" shows every row. */
+  minSev: DiagSeverity;
+  /** Matched against the start of `DiagEvent.kind`. */
+  kindPrefix: string;
+  /** A full peerId, matched against `peer` or `observer`. */
+  peer: string;
+  from: number | null;
+  to: number | null;
+}
+
+const DEFAULT_FILTER: Filter = {
+  minSev: "debug",
+  kindPrefix: "",
+  peer: "",
+  from: null,
+  to: null,
+};
+
+export interface TimelineRow {
+  /** Index into `capture.timeline`. A finding's evidence names this number. */
+  i: number;
+  e: MergedEvent;
+  lane: string;
+}
+
+export interface Lane {
+  key: string;
+  label: string;
+  kind: VantageKind;
+}
+
+export interface CaptureRow {
+  capture: Capture;
+  kinds: VantageKind[];
+  peerCount: number;
+  counts: FindingCounts;
+}
+
+export interface FindingCounts {
+  block: number;
+  warn: number;
+  info: number;
+}
+
+const SEV_RANK: Readonly<Record<DiagSeverity, number>> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// ---------------------------------------------------------------------------
+// Raw state
+// ---------------------------------------------------------------------------
+
+interface Payload {
+  bundle: ClientBundle | null;
+  parsed: ParsedLog | null;
+  /** The raw text, so the Logs view can show a mis-parse beside its source. */
+  text: string;
+}
+
+/** Deliberately not `$state`: see rule 1 at the top of this file. */
+const payloads = new Map<string, Payload>();
+
+const files = $state<FileMeta[]>([]);
+/** Bumped whenever `payloads` changes. `workspace` reads it to stay correct. */
+let revision = $state(0);
+
+let tab = $state<Tab>("sources");
+let selectedCaptureId = $state<string | null>(null);
+let selectedPeerId = $state<string | null>(null);
+/** Null means "the end of the capture window". */
+let scrubAt = $state<number | null>(null);
+/** Index into the filtered rows, not into the timeline. */
+let cursor = $state<number | null>(null);
+const filter = $state<Filter>({ ...DEFAULT_FILTER });
+
+const relay = $state({
+  apiBase: "",
+  /** Memory only. Never persisted, never in a URL. */
+  token: "",
+  busy: false,
+  /** The last outcome, in the operator's words. */
+  message: "",
+  ok: false,
+  bundles: [] as RelayBundleRef[],
+});
+
+const ai = $state({
+  /** Memory only, like the relay token. */
+  endpoint: "",
+  key: "",
+  model: "",
+  busy: false,
+  response: "",
+  error: "",
+  maxEvents: 400,
+});
+
+let nextId = 1;
+
+// ---------------------------------------------------------------------------
+// Derived
+// ---------------------------------------------------------------------------
+
+/**
+ * The loaded inputs, with every log peer suffix resolved.
+ *
+ * The relay's `short()` prints only the last 8 characters of a peerId, and a
+ * log parser gets no peer list, so it records `d.peerSuffix` and leaves `peer`
+ * null. This is the one place that knows both halves, so this is where the
+ * resolution belongs. It is additive: an ambiguous suffix stays unattributed
+ * and becomes a warning, because a wrong attribution is worse than a gap.
+ */
+const inputs = $derived.by(() => {
+  // Read the marker so a payload change invalidates this.
+  void revision;
+  const bundles: Array<{ bundle: ClientBundle; source: string }> = [];
+  const raw: MergedEvent[] = [];
+  for (const f of files) {
+    const p = payloads.get(f.id);
+    if (!p) continue;
+    if (f.role === "bundle" && p.bundle) {
+      bundles.push({ bundle: p.bundle, source: f.source });
+    }
+    if (f.role === "log" && p.parsed) raw.push(...p.parsed.events);
+  }
+
+  const known = new Set<string>();
+  for (const { bundle } of bundles) {
+    known.add(bundle.self.peerId);
+    for (const p of bundle.peers) known.add(p.peerId);
+    for (const e of bundle.events) {
+      if (e.peer) known.add(e.peer);
+    }
+    const view = bundle.relayView;
+    if (!view) continue;
+    known.add(view.relayPeerId);
+    known.add(view.observedPeerId);
+    for (const room of view.rooms) for (const m of room.members) known.add(m);
+  }
+  const ids = [...known];
+
+  const ambiguous = new Set<string>();
+  const unresolved = new Set<string>();
+  const events = raw.map((e) => {
+    const suffix = e.peer === null ? e.d?.peerSuffix : undefined;
+    if (typeof suffix !== "string" || suffix === "") return e;
+    const hit = resolveSuffix(suffix, ids);
+    if (hit.peerId !== null) return { ...e, peer: hit.peerId };
+    if (hit.ambiguous) ambiguous.add(suffix);
+    else unresolved.add(suffix);
+    return e;
+  });
+
+  const warnings: string[] = [];
+  for (const s of ambiguous) {
+    warnings.push(
+      `The log suffix …${s} matches more than one loaded peer, so it stays unattributed.`
+    );
+  }
+  if (unresolved.size > 0) {
+    warnings.push(
+      `${unresolved.size} log peer suffix(es) match no loaded bundle: …${[...unresolved].slice(0, 6).join(", …")}. Load that peer's bundle to attribute them.`
+    );
+  }
+  return { bundles, events, warnings };
+});
+
+const workspace = $derived.by(() => mergeSources(inputs.bundles, inputs.events));
+
+const captureRows = $derived.by<CaptureRow[]>(() =>
+  workspace.captures.map((capture) => {
+    const servers = serversOf(capture);
+    return {
+      capture,
+      kinds: vantageKinds(capture),
+      peerCount: [...capture.peers.keys()].filter((id) => !servers.has(id)).length,
+      counts: countFindings(runFindings(capture)),
+    };
+  })
+);
+
+const capture = $derived.by<Capture | null>(() => {
+  const list = workspace.captures;
+  if (list.length === 0) return null;
+  const hit = list.find((c) => c.id === selectedCaptureId);
+  return hit ?? list[0];
+});
+
+const findings = $derived.by<Finding[]>(() =>
+  capture ? runFindings(capture) : []
+);
+
+const findingCounts = $derived.by(() => countFindings(findings));
+
+const at = $derived.by(() => {
+  if (!capture) return 0;
+  if (scrubAt === null) return capture.window.to;
+  return Math.min(Math.max(scrubAt, capture.window.from), capture.window.to);
+});
+
+const lanes = $derived.by<Lane[]>(() => {
+  if (!capture) return [];
+  const out: Lane[] = [];
+  const seen = new Set<string>();
+  for (const v of capture.vantages) {
+    const key = laneKeyOfVantage(v.kind, v.observer, v.source);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ key, kind: v.kind, label: laneLabel(v.kind, v.observer, v.source) });
+  }
+  // Clients first, then the relay, then the SFU and other logs.
+  const rank: Record<VantageKind, number> = { client: 0, relay: 1, sfu: 2, log: 3 };
+  return out.sort((a, b) => rank[a.kind] - rank[b.kind] || a.label.localeCompare(b.label));
+});
+
+const rows = $derived.by<TimelineRow[]>(() => {
+  if (!capture) return [];
+  const min = SEV_RANK[filter.minSev];
+  const prefix = filter.kindPrefix.trim();
+  const peer = filter.peer.trim();
+  const out: TimelineRow[] = [];
+  const timeline = capture.timeline;
+  for (let i = 0; i < timeline.length; i++) {
+    const e = timeline[i];
+    if (SEV_RANK[e.sev] < min) continue;
+    if (prefix !== "" && !e.kind.startsWith(prefix)) continue;
+    if (peer !== "" && e.peer !== peer && e.observer !== peer) continue;
+    if (filter.from !== null && e.at < filter.from) continue;
+    if (filter.to !== null && e.at > filter.to) continue;
+    out.push({ i, e, lane: laneKeyOf(e) });
+  }
+  return out;
+});
+
+const topology = $derived.by<Topology | null>(() =>
+  capture ? foldTopology(capture, at) : null
+);
+
+const keyframes = $derived.by<number[]>(() =>
+  capture ? topologyKeyframes(capture) : []
+);
+
+const logFiles = $derived.by(() => files.filter((f) => f.role === "log"));
+
+const promptPack = $derived.by<PromptPack | null>(() =>
+  capture ? buildPromptPack(capture, findings, { maxEvents: ai.maxEvents }) : null
+);
+
+/** Empty rather than absent, so a view never needs a null check for a set. */
+const NO_SERVERS: ReadonlySet<string> = new Set<string>();
+
+const serverIds = $derived.by<ReadonlySet<string>>(() =>
+  capture ? serversOf(capture) : NO_SERVERS
+);
+
+const peerList = $derived.by<PeerSummary[]>(() => {
+  if (!capture) return [];
+  return [...capture.peers.values()]
+    .filter((p) => !serverIds.has(p.peerId))
+    .sort(
+      (a, b) =>
+        Number(b.hasVantage) - Number(a.hasVantage) ||
+        a.firstSeen - b.firstSeen ||
+        a.peerId.localeCompare(b.peerId)
+    );
+});
+
+const selectedPeer = $derived.by<PeerSummary | null>(() => {
+  const list = peerList;
+  if (list.length === 0) return null;
+  const hit = list.find((p) => p.peerId === selectedPeerId);
+  return hit ?? list[0];
+});
+
+// ---------------------------------------------------------------------------
+// The read surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Getters, because Svelte refuses a direct `export` of reassigned rune state.
+ * A template that reads `app.rows` still tracks every dependency behind it.
+ */
+export const app = {
+  get tab(): Tab {
+    return tab;
+  },
+  get files(): FileMeta[] {
+    return files;
+  },
+  get logFiles(): FileMeta[] {
+    return logFiles;
+  },
+  get warnings(): string[] {
+    return [...workspace.warnings, ...inputs.warnings];
+  },
+  get captures(): Capture[] {
+    return workspace.captures;
+  },
+  get captureRows(): CaptureRow[] {
+    return captureRows;
+  },
+  get capture(): Capture | null {
+    return capture;
+  },
+  get findings(): Finding[] {
+    return findings;
+  },
+  get findingCounts(): FindingCounts {
+    return findingCounts;
+  },
+  get at(): number {
+    return at;
+  },
+  get lanes(): Lane[] {
+    return lanes;
+  },
+  get rows(): TimelineRow[] {
+    return rows;
+  },
+  get cursor(): number | null {
+    return cursor;
+  },
+  get filter(): Filter {
+    return filter;
+  },
+  get topology(): Topology | null {
+    return topology;
+  },
+  get keyframes(): number[] {
+    return keyframes;
+  },
+  get peers(): PeerSummary[] {
+    return peerList;
+  },
+  /** Ids to exclude from any peer view: the relay, the SFU, a log's own name. */
+  get serverIds(): ReadonlySet<string> {
+    return serverIds;
+  },
+  get selectedPeer(): PeerSummary | null {
+    return selectedPeer;
+  },
+  get relay() {
+    return relay;
+  },
+  get ai() {
+    return ai;
+  },
+  get promptPack(): PromptPack | null {
+    return promptPack;
+  },
+  /** True when the offset solve left a residual big enough to distrust. */
+  get skewSuspect(): boolean {
+    return (capture?.maxSkewResidualMs ?? 0) > MAX_ACCEPTABLE_SKEW_MS;
+  },
+  get primaryObserver(): string {
+    return capture ? primaryObserver(capture) : "";
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mutators
+// ---------------------------------------------------------------------------
+
+export function goTo(next: Tab): void {
+  tab = next;
+}
+
+export function selectCapture(id: string): void {
+  selectedCaptureId = id;
+  scrubAt = null;
+  cursor = null;
+  selectedPeerId = null;
+}
+
+export function scrubTo(next: number): void {
+  scrubAt = next;
+}
+
+export function selectPeer(peerId: string): void {
+  selectedPeerId = peerId;
+}
+
+export function setFilter(patch: Partial<Filter>): void {
+  Object.assign(filter, patch);
+  cursor = null;
+}
+
+export function resetFilter(): void {
+  Object.assign(filter, DEFAULT_FILTER);
+}
+
+export function setParser(id: string, parser: LogParser): void {
+  const meta = files.find((f) => f.id === id);
+  const payload = payloads.get(id);
+  if (!meta || !payload || meta.role !== "log") return;
+  applyParser(meta, payload, parser);
+  revision++;
+}
+
+export function removeFile(id: string): void {
+  const at = files.findIndex((f) => f.id === id);
+  if (at < 0) return;
+  files.splice(at, 1);
+  payloads.delete(id);
+  revision++;
+}
+
+/** Drops every loaded file. The relay form survives, so a re-list is one click. */
+export function clearAll(): void {
+  files.length = 0;
+  payloads.clear();
+  relay.bundles = [];
+  relay.message = "";
+  relay.ok = false;
+  selectedCaptureId = null;
+  selectedPeerId = null;
+  scrubAt = null;
+  cursor = null;
+  Object.assign(filter, DEFAULT_FILTER);
+  revision++;
+}
+
+/**
+ * Read every file and classify it. A file that is not a usable bundle stays in
+ * the list with an `error`, because a silent drop hides the real problem.
+ */
+export async function loadFiles(list: File[]): Promise<void> {
+  for (const file of list) {
+    let text = "";
+    try {
+      text = await file.text();
+    } catch {
+      push(
+        meta(file.name, file.size, "rejected", {
+          error: "The browser could not read this file.",
+        }),
+        { bundle: null, parsed: null, text: "" }
+      );
+      continue;
+    }
+    ingest(file.name, file.size, text, false);
+  }
+  revision++;
+  autoSelect();
+}
+
+/** List the relay's stored bundles. The token stays in memory. */
+export async function loadFromRelay(): Promise<void> {
+  relay.busy = true;
+  relay.message = "";
+  const res = await listBundles(relay.apiBase, relay.token);
+  relay.busy = false;
+  relay.ok = res.ok;
+  if (!res.ok) {
+    relay.bundles = [];
+    relay.message = res.message;
+    return;
+  }
+  relay.bundles = res.value;
+  relay.apiBase = normalizeBase(relay.apiBase);
+  relay.message =
+    res.value.length === 0
+      ? "The relay has no stored bundles."
+      : `The relay holds ${res.value.length} bundle(s).`;
+}
+
+/** Fetch one listed bundle into the workspace. */
+export async function loadRelayBundle(ref: RelayBundleRef): Promise<void> {
+  relay.busy = true;
+  const res = await getBundle(relay.apiBase, relay.token, ref.id);
+  relay.busy = false;
+  if (!res.ok) {
+    relay.ok = false;
+    relay.message = `${ref.id}: ${res.message}`;
+    return;
+  }
+  const text = JSON.stringify(res.value);
+  ingest(`relay:${ref.id}`, text.length, text, true);
+  relay.message = `Loaded ${ref.id}.`;
+  revision++;
+  autoSelect();
+}
+
+// ---------------------------------------------------------------------------
+// Timeline navigation
+// ---------------------------------------------------------------------------
+
+/** `j` and `k`. The scrubber follows, so the Topology view tracks the cursor. */
+export function stepCursor(delta: number): void {
+  const list = rows;
+  if (list.length === 0) return;
+  const from = cursor === null ? (delta > 0 ? -1 : list.length) : cursor;
+  const next = Math.min(Math.max(from + delta, 0), list.length - 1);
+  setCursor(next);
+}
+
+export function setCursor(index: number): void {
+  const list = rows;
+  if (index < 0 || index >= list.length) return;
+  cursor = index;
+  scrubAt = list[index].e.at;
+}
+
+/**
+ * Jump to a timeline index a finding named. When the filter hides that event
+ * the filter is reset, because evidence must always be reachable.
+ */
+export function focusTimelineIndex(i: number): void {
+  let hit = rows.findIndex((r) => r.i === i);
+  if (hit < 0) {
+    resetFilter();
+    hit = rows.findIndex((r) => r.i === i);
+  }
+  if (hit < 0) return;
+  setCursor(hit);
+  tab = "timeline";
+}
+
+/** `f`. The next piece of evidence after the cursor, in timeline order. */
+export function nextEvidence(): void {
+  const marks = evidenceIndices();
+  if (marks.length === 0) return;
+  const here = cursor === null ? -1 : rows[cursor].i;
+  const next = marks.find((i) => i > here) ?? marks[0];
+  focusTimelineIndex(next);
+}
+
+/** Every timeline index any finding cites, ascending and without duplicates. */
+export function evidenceIndices(): number[] {
+  const set = new Set<number>();
+  for (const f of findings) for (const i of f.evidence) set.add(i);
+  return [...set].sort((a, b) => a - b);
+}
+
+// ---------------------------------------------------------------------------
+// Queries the views need
+// ---------------------------------------------------------------------------
+
+/**
+ * The raw text a log file carried, beside the events its parser produced. The
+ * Logs view shows both, so a mis-parse is visible instead of silent.
+ *
+ * An SFU log holds room codes in clear. This text stays in the process: the
+ * prompt pack and every export are built from the capture, never from here.
+ */
+export function logPayload(id: string): { text: string; parsed: ParsedLog } | null {
+  const p = payloads.get(id);
+  if (!p?.parsed) return null;
+  return { text: p.text, parsed: p.parsed };
+}
+
+/**
+ * The merged timeline index of a parsed event. The merge re-wraps every event,
+ * so identity is lost and `(source, seq, at)` is the key that survives.
+ */
+export function timelineIndexOf(source: string, seq: number, at: number): number {
+  if (!capture) return -1;
+  return capture.timeline.findIndex(
+    (e) => e.source === source && e.seq === seq && e.at === at
+  );
+}
+
+/** The link the observer `from` held toward `to` at the scrubbed instant. */
+export function linkAt(from: string, to: string): TopologyLink | null {
+  const t = topology;
+  if (!t) return null;
+  return t.links.find((l) => l.from === from && l.to === to) ?? null;
+}
+
+/** Observers with a vantage of their own. Only these can disagree. */
+export function observersWithVantage(): string[] {
+  if (!capture) return [];
+  return capture.vantages.filter((v) => v.kind === "client").map((v) => v.observer);
+}
+
+/** Every event about one peer, oldest first, with its timeline index. */
+export function eventsForPeer(peerId: string): TimelineRow[] {
+  if (!capture) return [];
+  const out: TimelineRow[] = [];
+  capture.timeline.forEach((e, i) => {
+    if (e.peer === peerId || e.observer === peerId) {
+      out.push({ i, e, lane: laneKeyOf(e) });
+    }
+  });
+  return out;
+}
+
+/** The `counters` series an observer emitted. Only an observer has counters. */
+export function counterSeries(peerId: string): Array<{ at: number; d: Record<string, string | number | boolean | null> }> {
+  if (!capture) return [];
+  const out: Array<{ at: number; d: Record<string, string | number | boolean | null> }> = [];
+  for (const e of capture.timeline) {
+    if (e.kind === "counters" && e.observer === peerId && e.d) {
+      out.push({ at: e.at, d: e.d });
+    }
+  }
+  return out;
+}
+
+/** The round-trip series toward one peer. A lost probe records `ms: null`. */
+export function rttSeries(peerId: string): Array<{ at: number; ms: number | null }> {
+  if (!capture) return [];
+  const out: Array<{ at: number; ms: number | null }> = [];
+  for (const e of capture.timeline) {
+    if (e.kind !== "peer.rtt" || e.peer !== peerId) continue;
+    const raw = e.d?.ms;
+    out.push({ at: e.at, ms: typeof raw === "number" ? raw : null });
+  }
+  return out;
+}
+
+/** The SFU snapshots a bundle carried, newest last. */
+export function sfuSnapshots(): SfuSnapshot[] {
+  if (!capture) return [];
+  const out: SfuSnapshot[] = [];
+  for (const v of capture.vantages) {
+    for (const s of v.bundle?.sfuSnapshots ?? []) out.push(s);
+  }
+  return out.sort((a, b) => a.takenAt - b.takenAt);
+}
+
+export async function sendPromptPack(): Promise<void> {
+  const pack = promptPack;
+  if (!pack || ai.endpoint.trim() === "") return;
+  ai.busy = true;
+  ai.error = "";
+  ai.response = "";
+  try {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (ai.key.trim() !== "") headers.authorization = `Bearer ${ai.key.trim()}`;
+    const res = await fetch(ai.endpoint.trim(), {
+      method: "POST",
+      headers,
+      credentials: "omit",
+      body: JSON.stringify({
+        model: ai.model.trim() === "" ? undefined : ai.model.trim(),
+        messages: [{ role: "user", content: pack.markdown }],
+      }),
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      ai.error = `The endpoint answered ${res.status}. ${text.slice(0, 400)}`;
+      return;
+    }
+    ai.response = extractReply(text);
+  } catch {
+    ai.error = "The request failed. Check the endpoint, the scheme and its CORS answer.";
+  } finally {
+    ai.busy = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function ingest(name: string, bytes: number, text: string, fromRelay: boolean): void {
+  if (text.trimStart().startsWith("{")) {
+    ingestBundle(name, bytes, text, fromRelay);
+    return;
+  }
+  const m = meta(name, bytes, "log", { fromRelay });
+  const payload: Payload = { bundle: null, parsed: null, text };
+  applyParser(m, payload, sniffParser(text));
+  push(m, payload);
+}
+
+function ingestBundle(name: string, bytes: number, text: string, fromRelay: boolean): void {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    push(
+      meta(name, bytes, "rejected", {
+        fromRelay,
+        error: `The file starts like JSON but does not parse: ${err instanceof Error ? err.message : String(err)}`,
+      }),
+      { bundle: null, parsed: null, text }
+    );
+    return;
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    push(
+      meta(name, bytes, "rejected", {
+        fromRelay,
+        error: "The JSON is not an object, so it is not a bundle.",
+      }),
+      { bundle: null, parsed: null, text }
+    );
+    return;
+  }
+  const b = raw as Partial<ClientBundle>;
+  if (b.vantage !== "client" || !Array.isArray(b.events) || !b.self?.peerId) {
+    push(
+      meta(name, bytes, "rejected", {
+        fromRelay,
+        error:
+          'The JSON is not a client bundle. A bundle has vantage: "client", an events array and self.peerId.',
+      }),
+      { bundle: null, parsed: null, text }
+    );
+    return;
+  }
+  if (b.schemaVersion !== DIAG_SCHEMA_VERSION) {
+    push(
+      meta(name, bytes, "rejected", {
+        fromRelay,
+        error: `Schema version ${String(b.schemaVersion)} is not understood. This console reads version ${DIAG_SCHEMA_VERSION}.`,
+      }),
+      { bundle: null, parsed: null, text }
+    );
+    return;
+  }
+  const bundle = raw as ClientBundle;
+  const warnings: string[] = [];
+  if (bundle.meta?.truncated) warnings.push("The bundle was trimmed for upload.");
+  if ((bundle.meta?.dropped ?? 0) > 0) {
+    warnings.push(`The ring dropped ${bundle.meta.dropped} event(s).`);
+  }
+  if (bundle.meta?.faultsActive) {
+    warnings.push("Fault injection was active, so every finding is suspect.");
+  }
+  push(
+    meta(name, bytes, "bundle", {
+      fromRelay,
+      vantage: "client",
+      observer: bundle.self.peerId,
+      eventCount: bundle.events.length + (bundle.relayView?.events.length ?? 0),
+      warnings,
+    }),
+    { bundle, parsed: null, text }
+  );
+}
+
+function applyParser(m: FileMeta, payload: Payload, parser: LogParser): void {
+  const runs: ParsedLog[] =
+    parser === "sfu"
+      ? [
+          parseSfuTelemetry(payload.text, m.source),
+          parseSfuLog(payload.text, m.source),
+        ]
+      : [
+          parser === "relay"
+            ? parseRelayLog(payload.text, m.source)
+            : parseConsoleLog(payload.text, m.source),
+        ];
+  const events = runs
+    .flatMap((r) => r.events)
+    .sort((a, b) => a.at - b.at || a.seq - b.seq);
+  const parsed: ParsedLog = {
+    events,
+    warnings: runs.flatMap((r) => r.warnings),
+    unmatched: runs.reduce((sum, r) => sum + r.unmatched, 0),
+  };
+  payload.parsed = parsed;
+  m.parser = parser;
+  m.vantage = "log";
+  m.eventCount = parsed.events.length;
+  m.unmatched = parsed.unmatched;
+  m.warnings = parsed.warnings;
+  m.observer = parsed.events.find((e) => e.observer !== "")?.observer ?? "";
+}
+
+function meta(
+  name: string,
+  bytes: number,
+  role: FileRole,
+  extra: Partial<FileMeta> = {}
+): FileMeta {
+  return {
+    id: `f${nextId++}`,
+    name,
+    source: uniqueSource(name),
+    bytes,
+    role,
+    vantage: null,
+    observer: "",
+    eventCount: 0,
+    parser: null,
+    unmatched: 0,
+    warnings: [],
+    error: null,
+    fromRelay: false,
+    ...extra,
+  };
+}
+
+function push(m: FileMeta, payload: Payload): void {
+  files.push(m);
+  payloads.set(m.id, payload);
+}
+
+function uniqueSource(name: string): string {
+  let candidate = name;
+  let n = 2;
+  while (files.some((f) => f.source === candidate)) candidate = `${name}#${n++}`;
+  return candidate;
+}
+
+/**
+ * Select the RICHEST capture, not the newest.
+ *
+ * A log-only capture often starts later than the bundles it belongs to, so
+ * "newest first" would open a one-vantage capture and hide the real incident.
+ * The most vantages wins, then the most events, then the newest.
+ */
+function autoSelect(): void {
+  if (selectedCaptureId !== null) return;
+  const best = [...workspace.captures].sort(
+    (a, b) =>
+      b.vantages.length - a.vantages.length ||
+      b.timeline.length - a.timeline.length ||
+      b.window.from - a.window.from
+  )[0];
+  if (best) selectedCaptureId = best.id;
+}
+
+/**
+ * Pick a parser by the tags a log carries. The choice is a guess, so the
+ * Sources view exposes it as a select and shows the unmatched count. A wrong
+ * guess is then visible and one click from fixed.
+ */
+export function sniffParser(text: string): LogParser {
+  const head = text.slice(0, 200_000);
+  if (head.includes("[sfu-telemetry]")) return "sfu";
+  const sfu = countMatches(head, /\[(?:sfu|router|worker)\]/g);
+  const rv = countMatches(head, /\[(?:rv|relay|http|turn|mailbox)\]/g);
+  if (sfu === 0 && rv === 0) return "console";
+  return sfu > rv ? "sfu" : "relay";
+}
+
+function countMatches(text: string, re: RegExp): number {
+  let n = 0;
+  for (const _ of text.matchAll(re)) n++;
+  return n;
+}
+
+/**
+ * Ids that name a SERVER, not a peer.
+ *
+ * `Capture.peers` holds every id any vantage mentioned, and that includes the
+ * relay's own peerId and a log vantage's observer name. Neither belongs in a
+ * peer graph, a peer matrix or a peer picker. The set is exact rather than a
+ * guess: it comes from each vantage's kind and from each bundle's own config.
+ */
+function serversOf(c: Capture): Set<string> {
+  const out = new Set<string>();
+  for (const v of c.vantages) {
+    if (v.kind !== "client" && v.observer !== "") out.add(v.observer);
+    const configured = v.bundle?.config.relayPeerId;
+    if (configured) out.add(configured);
+    if (v.relay) out.add(v.relay.relayPeerId);
+  }
+  return out;
+}
+
+function countFindings(list: Finding[]): FindingCounts {
+  const counts: FindingCounts = { block: 0, warn: 0, info: 0 };
+  for (const f of list) counts[f.severity]++;
+  return counts;
+}
+
+function laneKeyOfVantage(kind: VantageKind, observer: string, source: string): string {
+  if (kind === "client") return `client:${observer}`;
+  if (kind === "relay") return "relay";
+  if (kind === "sfu") return "sfu";
+  return `log:${source}`;
+}
+
+function laneLabel(kind: VantageKind, observer: string, source: string): string {
+  if (kind === "client") return shortPeer(observer);
+  if (kind === "relay") return "relay";
+  if (kind === "sfu") return "sfu";
+  return source;
+}
+
+export function laneKeyOf(e: MergedEvent): string {
+  return laneKeyOfVantage(e.vantage, e.observer, e.source);
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+}
+
+/** Accept an OpenAI-shaped reply, and fall back to the raw body. */
+function extractReply(body: string): string {
+  try {
+    const j = JSON.parse(body) as {
+      choices?: Array<{ message?: { content?: string } }>;
+      content?: Array<{ text?: string }>;
+    };
+    const openai = j.choices?.[0]?.message?.content;
+    if (typeof openai === "string") return openai;
+    const anthropic = j.content?.map((p) => p.text ?? "").join("");
+    if (anthropic) return anthropic;
+  } catch {
+    // Not JSON. The raw body is the most honest answer.
+  }
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+//
+// Presentation, not analysis. They live here because this is the console's one
+// shared module, and nine views must format a peerId the same way.
+// ---------------------------------------------------------------------------
+
+/** The last 8 characters, which is what the relay's own logs print. */
+export function shortPeer(peerId: string): string {
+  if (peerId === "") return "-";
+  return peerId.length <= 8 ? peerId : `…${peerId.slice(-8)}`;
+}
+
+export function fmtClock(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "--:--:--.---";
+  const d = new Date(ms);
+  const p = (n: number, w = 2): string => String(n).padStart(w, "0");
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
+}
+
+export function fmtDate(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "-";
+  return new Date(ms).toISOString().replace("T", " ").replace("Z", "");
+}
+
+export function fmtDur(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "-";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${Math.round(s % 60)}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
+export function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MiB`;
+}
+
+/** A token reference, never a literal colour. See `app.css`. */
+export function sevColor(sev: DiagSeverity): string {
+  return `var(--color-sev-${sev})`;
+}
+
+export function severityColor(sev: Finding["severity"]): string {
+  if (sev === "block") return "var(--color-sev-error)";
+  if (sev === "warn") return "var(--color-sev-warn)";
+  return "var(--color-sev-info)";
+}
+
+export function linkColor(state: LinkState): string {
+  return `var(--color-ls-${state})`;
+}
+
+/** A flat `d` bag as one line. Keys stay in insertion order. */
+export function fmtDetail(
+  d: Record<string, string | number | boolean | null> | undefined
+): string {
+  if (!d) return "";
+  return Object.entries(d)
+    .map(([k, v]) => `${k}=${v === null ? "null" : maskValue(k, v)}`)
+    .join(" ");
+}
+
+/**
+ * An SFU or relay log line carries a room code in CLEAR, and `logs.ts` keeps it
+ * as `d.roomRaw`. A room code is the room's only membership secret, so it must
+ * not appear in a view an operator screenshots or pastes into a ticket.
+ *
+ * This is the single render boundary for a `d` bag, so it is the right place to
+ * mask it. The Logs view's raw pane still shows the file verbatim, because that
+ * is the file the operator asked to read.
+ */
+function maskValue(key: string, value: string | number | boolean): string {
+  if (key === "roomRaw") return "«room code held back»";
+  return String(value);
+}

--- a/dashboard/src/lib/views/Ai.svelte
+++ b/dashboard/src/lib/views/Ai.svelte
@@ -1,0 +1,122 @@
+<!--
+  AI: the prompt pack.
+
+  A finding names what and where. A model is good at why, but only when it gets
+  the contract before the data, which is what `buildPromptPack` assembles. The
+  pack carries opaque room refs and no DID, so it is safe to paste anywhere.
+
+  The endpoint and the key stay in memory, exactly like the relay admin token.
+-->
+<script lang="ts">
+  import { app, goTo, sendPromptPack } from "$lib/sources.svelte";
+
+  let copied = $state(false);
+
+  const pack = $derived(app.promptPack);
+
+  async function copy(): Promise<void> {
+    if (!pack) return;
+    try {
+      await navigator.clipboard.writeText(pack.markdown);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      copied = false;
+    }
+  }
+
+  function download(): void {
+    if (!pack || !app.capture) return;
+    const blob = new Blob([pack.markdown], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    // A capture id embeds its source file name, which can hold a slash (a relay
+    // bundle id is `<peerId>/<file>`). A slash in `download` breaks the save.
+    a.download = `awful-capture-${app.capture.id.replace(/[^A-Za-z0-9._-]+/g, "-")}.md`;
+    // The anchor must be in the document, and the URL must outlive the click:
+    // an immediate revoke cancels the transfer before the browser reads it.
+    document.body.append(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
+  }
+</script>
+
+{#if !pack}
+  <p class="text-dim">
+    No capture selected. Pick one in
+    <button class="text-key underline" onclick={() => goTo("sessions")}>Sessions</button>.
+  </p>
+{:else}
+  <div class="flex flex-col gap-2">
+    <div class="flex flex-wrap items-center gap-2">
+      <button class="btn {copied ? 'btn-on' : ''}" onclick={() => void copy()}>
+        {copied ? "Copied" : "Copy"}
+      </button>
+      <button class="btn" onclick={download}>Download .md</button>
+      <span class="chip text-dim">≈{pack.tokensEstimate} tokens</span>
+      <label class="flex items-center gap-1">
+        <span class="font-mono text-[10px] tracking-wider text-faint uppercase">events</span>
+        <input
+          class="field w-20"
+          type="number"
+          min="50"
+          max="4000"
+          step="50"
+          bind:value={app.ai.maxEvents}
+        />
+      </label>
+      <span class="font-mono text-[10px] text-faint">
+        centred on the first blocking finding
+      </span>
+    </div>
+
+    <section class="panel">
+      <h2 class="panel-head">send it directly (optional)</h2>
+      <div class="grid gap-2 p-2 lg:grid-cols-[1fr_14rem_10rem_auto]">
+        <input
+          class="field"
+          placeholder="https://api.example.com/v1/chat/completions"
+          bind:value={app.ai.endpoint}
+        />
+        <input
+          class="field"
+          type="password"
+          autocomplete="off"
+          placeholder="api key"
+          bind:value={app.ai.key}
+        />
+        <input class="field" placeholder="model" bind:value={app.ai.model} />
+        <button
+          class="btn"
+          disabled={app.ai.busy || app.ai.endpoint.trim() === ""}
+          onclick={() => void sendPromptPack()}
+        >
+          {app.ai.busy ? "…" : "Send"}
+        </button>
+      </div>
+      <p class="px-2 pb-2 text-[11px] text-faint">
+        The body is an OpenAI-shaped chat request with the pack as one user
+        message. The endpoint and the key stay in memory. A reload loses both.
+      </p>
+      {#if app.ai.error}
+        <p class="px-2 pb-2 text-[11px]" style="color: var(--color-sev-error)">{app.ai.error}</p>
+      {/if}
+    </section>
+
+    {#if app.ai.response}
+      <section class="panel">
+        <h2 class="panel-head" style="color: var(--color-key)">answer</h2>
+        <pre class="max-h-96 overflow-auto p-2 text-[11px] whitespace-pre-wrap">{app.ai
+            .response}</pre>
+      </section>
+    {/if}
+
+    <section class="panel">
+      <h2 class="panel-head">prompt pack</h2>
+      <pre
+        class="max-h-[36rem] overflow-auto p-2 text-[11px] leading-snug whitespace-pre-wrap">{pack.markdown}</pre>
+    </section>
+  </div>
+{/if}

--- a/dashboard/src/lib/views/Findings.svelte
+++ b/dashboard/src/lib/views/Findings.svelte
@@ -1,0 +1,123 @@
+<!--
+  Findings: the deterministic engine's answer, grouped by severity.
+
+  A finding names WHAT and WHERE. It never guesses WHY: that is the AI tab's
+  job, which is why every row carries the rule's `aiHint` beside its remedy.
+  Every evidence chip jumps the Timeline to the exact event that justified it.
+-->
+<script lang="ts">
+  import { RULES } from "$lib/analysis/rules";
+  import type { Finding } from "$lib/analysis/findings";
+  import {
+    app,
+    fmtClock,
+    fmtDetail,
+    focusTimelineIndex,
+    goTo,
+    severityColor,
+    shortPeer,
+  } from "$lib/sources.svelte";
+
+  const GROUPS: ReadonlyArray<{ sev: Finding["severity"]; label: string; blurb: string }> = [
+    { sev: "block", label: "blocking", blurb: "The session cannot work until one of these is fixed." },
+    { sev: "warn", label: "warning", blurb: "The session works, but a failure mode is active." },
+    { sev: "info", label: "context", blurb: "Read these before you trust the rest." },
+  ];
+
+  function subject(f: Finding): string {
+    const s = f.subject;
+    if (s.pair) return `${shortPeer(s.pair[0])} → ${shortPeer(s.pair[1])}`;
+    if (s.peer) return shortPeer(s.peer);
+    if (s.room) return `room ${s.room}`;
+    if (s.vantage) return s.vantage;
+    return "capture";
+  }
+</script>
+
+{#if !app.capture}
+  <p class="text-dim">
+    No capture selected. Pick one in
+    <button class="text-key underline" onclick={() => goTo("sessions")}>Sessions</button>.
+  </p>
+{:else if app.findings.length === 0}
+  <div class="panel p-4">
+    <p style="color: var(--color-key)">No rule fired on this capture.</p>
+    <p class="mt-1 text-dim">
+      That is a real answer, not an empty state: the engine is deterministic. If
+      the bug is in this capture, either the recorder did not see it or a rule is
+      missing. Check <button class="text-key underline" onclick={() => goTo("timeline")}
+        >Timeline</button
+      > for error-severity events the rules do not cover.
+    </p>
+  </div>
+{:else}
+  <div class="flex flex-col gap-4">
+    {#each GROUPS as g (g.sev)}
+      {@const list = app.findings.filter((f) => f.severity === g.sev)}
+      {#if list.length > 0}
+        <section class="flex flex-col gap-2">
+          <h2 class="flex items-baseline gap-2">
+            <span class="font-mono text-[11px] tracking-widest uppercase" style="color: {severityColor(g.sev)}">
+              {g.label} · {list.length}
+            </span>
+            <span class="text-[11px] text-faint">{g.blurb}</span>
+          </h2>
+
+          {#each list as f, i (`${f.id}-${i}`)}
+            {@const rule = RULES[f.id]}
+            <article
+              class="panel border-l-2 p-2.5"
+              style="border-left-color: {severityColor(f.severity)}"
+            >
+              <header class="flex flex-wrap items-baseline gap-x-2">
+                <h3 class="font-mono text-[12px]" style="color: {severityColor(f.severity)}">
+                  {rule?.title ?? f.id}
+                </h3>
+                <code class="text-[10px] text-faint">{f.id}</code>
+                <span class="chip text-dim">{subject(f)}</span>
+              </header>
+
+              {#if rule}
+                <dl class="mt-1.5 grid gap-x-3 gap-y-0.5 sm:grid-cols-[5.5rem_1fr]">
+                  <dt class="font-mono text-[10px] tracking-wider text-faint uppercase">means</dt>
+                  <dd>{rule.meaning}</dd>
+                  <dt class="font-mono text-[10px] tracking-wider text-faint uppercase">fix</dt>
+                  <dd style="color: var(--color-key)">{rule.remedy}</dd>
+                  <dt class="font-mono text-[10px] tracking-wider text-faint uppercase">ask ai</dt>
+                  <dd class="text-dim">{rule.aiHint}</dd>
+                </dl>
+              {/if}
+
+              {#if Object.keys(f.detail).length > 0}
+                <p class="mt-1.5 font-mono text-[11px] text-dim">{fmtDetail(f.detail)}</p>
+              {/if}
+
+              {#if f.evidence.length > 0}
+                <div class="mt-1.5 flex flex-wrap items-center gap-1">
+                  <span class="font-mono text-[10px] tracking-wider text-faint uppercase">
+                    evidence
+                  </span>
+                  {#each f.evidence.slice(0, 24) as idx (idx)}
+                    {@const e = app.capture?.timeline[idx]}
+                    <button
+                      class="btn"
+                      title={e ? `${e.kind} ${fmtDetail(e.d)}` : `timeline index ${idx}`}
+                      onclick={() => focusTimelineIndex(idx)}
+                    >
+                      {e ? `${fmtClock(e.at)} ${e.kind}` : `#${idx}`}
+                    </button>
+                  {/each}
+                  {#if f.evidence.length > 24}
+                    <span class="text-[11px] text-faint">
+                      +{f.evidence.length - 24} more
+                    </span>
+                  {/if}
+                </div>
+              {/if}
+            </article>
+          {/each}
+        </section>
+      {/if}
+    {/each}
+  </div>
+{/if}

--- a/dashboard/src/lib/views/Logs.svelte
+++ b/dashboard/src/lib/views/Logs.svelte
@@ -1,0 +1,150 @@
+<!--
+  Logs: the raw text beside the events its parser produced.
+
+  A template table is a guess about a log line. This view exists so a wrong
+  guess is visible: the unmatched count is at the top, an unrecognised line
+  survives as a `raw` event, and the raw pane is right there to compare against.
+-->
+<script lang="ts">
+  import {
+    LOG_PARSERS,
+    app,
+    fmtBytes,
+    fmtClock,
+    fmtDetail,
+    focusTimelineIndex,
+    goTo,
+    logPayload,
+    sevColor,
+    setParser,
+    shortPeer,
+    timelineIndexOf,
+    type LogParser,
+  } from "$lib/sources.svelte";
+
+  let selected = $state<string | null>(null);
+  const current = $derived(
+    app.logFiles.find((f) => f.id === selected) ?? app.logFiles[0] ?? null
+  );
+  const payload = $derived(current ? logPayload(current.id) : null);
+
+  /** Enough to read, and small enough that the browser stays responsive. */
+  const MAX_LINES = 4000;
+  const lines = $derived(payload ? payload.text.split("\n").slice(0, MAX_LINES) : []);
+</script>
+
+{#if app.logFiles.length === 0}
+  <p class="text-dim">
+    No log loaded. Capture one with <code class="text-key">docker logs -t &lt;relay&gt;</code> and
+    drop it in <button class="text-key underline" onclick={() => goTo("sources")}>Sources</button>.
+    Without <code>-t</code> the parser anchors every line relative to the first
+    match and adds a warning.
+  </p>
+{:else}
+  <div class="flex flex-col gap-2">
+    <div class="flex flex-wrap items-center gap-2">
+      {#each app.logFiles as f (f.id)}
+        <button
+          class="btn {current?.id === f.id ? 'btn-on' : ''}"
+          onclick={() => (selected = f.id)}
+        >
+          {f.name}
+          <span class="text-faint">{f.eventCount}</span>
+        </button>
+      {/each}
+    </div>
+
+    {#if current && payload}
+      <div class="flex flex-wrap items-center gap-2">
+        <label class="flex items-center gap-1">
+          <span class="font-mono text-[10px] tracking-wider text-faint uppercase">parser</span>
+          <select
+            class="field"
+            value={current.parser}
+            onchange={(e) =>
+              setParser(current.id, (e.currentTarget as HTMLSelectElement).value as LogParser)}
+          >
+            {#each LOG_PARSERS as p (p.id)}
+              <option value={p.id}>{p.label}</option>
+            {/each}
+          </select>
+        </label>
+        <span class="chip text-dim">{payload.parsed.events.length} events</span>
+        <span
+          class="chip"
+          style="color: {current.unmatched > 0
+            ? 'var(--color-sev-warn)'
+            : 'var(--color-ls-proven)'}"
+        >
+          {current.unmatched} unmatched
+        </span>
+        <span class="font-mono text-[10px] text-faint">{fmtBytes(current.bytes)}</span>
+        {#if lines.length === MAX_LINES}
+          <span class="chip" style="color: var(--color-sev-warn)">
+            raw pane shows the first {MAX_LINES} lines
+          </span>
+        {/if}
+      </div>
+
+      {#each current.warnings as w, i (i)}
+        <p class="text-[11px]" style="color: var(--color-sev-warn)">{w}</p>
+      {/each}
+
+      <div class="grid min-h-0 gap-3 xl:grid-cols-2">
+        <section class="panel flex min-h-0 flex-col">
+          <h2 class="panel-head">raw</h2>
+          <pre
+            class="max-h-[32rem] overflow-auto p-2 text-[11px] leading-snug whitespace-pre">{#each lines as line, n (n)}<span
+                class="text-faint">{String(n + 1).padStart(5)} </span>{line}
+{/each}</pre>
+        </section>
+
+        <section class="panel flex min-h-0 flex-col">
+          <h2 class="panel-head">parsed</h2>
+          <div class="max-h-[32rem] overflow-auto">
+            <table class="tbl">
+              <thead>
+                <tr><th>time</th><th>kind</th><th>peer</th><th>detail</th></tr>
+              </thead>
+              <tbody>
+                {#each payload.parsed.events as e, n (n)}
+                  {@const raw = e.d?.raw !== undefined}
+                  <tr
+                    class="cursor-pointer"
+                    onclick={() => {
+                      const i = timelineIndexOf(e.source, e.seq, e.at);
+                      if (i >= 0) focusTimelineIndex(i);
+                    }}
+                    title={raw ? "This line matched no template. It survives as a raw event." : ""}
+                  >
+                    <td class="whitespace-nowrap">{fmtClock(e.at)}</td>
+                    <td style="color: {raw ? 'var(--color-sev-warn)' : sevColor(e.sev)}">
+                      {raw ? "unmatched" : e.kind}
+                    </td>
+                    <!--
+                      This pane shows the PARSER's own output, before the merge
+                      resolves a suffix to a full peerId, because a mis-parse is
+                      what the operator came here to check.
+                    -->
+                    <td
+                      class="text-dim"
+                      title={e.peer ??
+                        "The parser saw only a suffix. The merge resolves it against the loaded bundles."}
+                    >
+                      {e.peer
+                        ? shortPeer(e.peer)
+                        : typeof e.d?.peerSuffix === "string"
+                          ? `…${e.d.peerSuffix}?`
+                          : ""}
+                    </td>
+                    <td class="max-w-[26rem] break-all text-dim">{fmtDetail(e.d)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/dashboard/src/lib/views/Matrix.svelte
+++ b/dashboard/src/lib/views/Matrix.svelte
@@ -1,0 +1,246 @@
+<!--
+  Matrix: the N×N pairwise link grid at the scrubbed instant.
+
+  Every cell is ONE square split on its anti-diagonal:
+
+    upper-left triangle   what the ROW peer believed about the COLUMN peer
+    lower-right triangle  what the COLUMN peer believed about the ROW peer
+
+  When the two agree the square is one flat colour and the split is invisible.
+  When they disagree the square reads as two colours with a hard white seam.
+  "Works for A but not B" is therefore a shape, not a number to compare.
+
+  A half whose observer uploaded no vantage is not a disagreement, it is
+  ignorance. Those halves are drawn faint with a "?" so they never read as red.
+-->
+<script lang="ts">
+  import type { LinkState } from "$lib/analysis/topology";
+  import {
+    app,
+    fmtClock,
+    goTo,
+    linkAt,
+    linkColor,
+    observersWithVantage,
+    scrubTo,
+    selectPeer,
+    setFilter,
+    shortPeer,
+  } from "$lib/sources.svelte";
+
+  const CELL = 30;
+
+  const peers = $derived(app.peers);
+  const witnesses = $derived(new Set(observersWithVantage()));
+
+  interface Half {
+    state: LinkState;
+    known: boolean;
+  }
+
+  function half(from: string, to: string): Half {
+    if (!witnesses.has(from)) return { state: "none", known: false };
+    return { state: linkAt(from, to)?.state ?? "none", known: true };
+  }
+
+  function color(h: Half): string {
+    return h.known ? linkColor(h.state) : "var(--color-ink)";
+  }
+
+  /** Pairs where two witnesses actually disagree. This is the view's headline. */
+  const splits = $derived.by(() => {
+    const out: Array<{ a: string; b: string; ab: LinkState; ba: LinkState }> = [];
+    for (let i = 0; i < peers.length; i++) {
+      for (let j = i + 1; j < peers.length; j++) {
+        const a = peers[i].peerId;
+        const b = peers[j].peerId;
+        const ab = half(a, b);
+        const ba = half(b, a);
+        if (!ab.known || !ba.known) continue;
+        if (ab.state !== ba.state) out.push({ a, b, ab: ab.state, ba: ba.state });
+      }
+    }
+    return out;
+  });
+</script>
+
+{#if !app.capture}
+  <p class="text-dim">
+    No capture selected. Pick one in
+    <button class="text-key underline" onclick={() => goTo("sessions")}>Sessions</button>.
+  </p>
+{:else if peers.length === 0}
+  <p class="text-dim">This capture names no peer.</p>
+{:else}
+  <div class="flex flex-col gap-2">
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="font-mono text-[11px]" style="color: var(--color-key)">{fmtClock(app.at)}</span>
+      <input
+        type="range"
+        class="min-w-48 flex-1 accent-key"
+        aria-label="scrub time"
+        min={app.capture.window.from}
+        max={app.capture.window.to}
+        step="1"
+        value={app.at}
+        oninput={(e) => scrubTo(Number((e.currentTarget as HTMLInputElement).value))}
+      />
+      <span
+        class="chip"
+        style="color: {splits.length > 0 ? 'var(--color-sev-error)' : 'var(--color-ls-proven)'}"
+      >
+        {splits.length} asymmetric pair{splits.length === 1 ? "" : "s"}
+      </span>
+      <span class="font-mono text-[10px] text-faint">
+        {witnesses.size} of {peers.length} peers uploaded a vantage
+      </span>
+    </div>
+
+    <div class="panel overflow-auto p-2">
+      <table style="border-collapse: separate; border-spacing: 2px">
+        <thead>
+          <tr>
+            <th></th>
+            {#each peers as p, j (p.peerId)}
+              <th
+                class="font-mono text-[10px] font-normal"
+                style="width: {CELL}px; color: {witnesses.has(p.peerId)
+                  ? 'var(--color-dim)'
+                  : 'var(--color-faint)'}"
+                title={p.peerId}>{j + 1}</th
+              >
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each peers as row, i (row.peerId)}
+            <tr>
+              <th class="pr-2 text-right font-mono text-[10px] font-normal whitespace-nowrap">
+                <button
+                  class="hover:text-key"
+                  style="color: {witnesses.has(row.peerId)
+                    ? 'var(--color-text)'
+                    : 'var(--color-faint)'}"
+                  title="{row.peerId}{witnesses.has(row.peerId)
+                    ? ''
+                    : ' — no vantage, so this row is unknown, not broken'}"
+                  onclick={() => {
+                    selectPeer(row.peerId);
+                    goTo("peers");
+                  }}
+                >
+                  {i + 1}. {shortPeer(row.peerId)}
+                </button>
+              </th>
+
+              {#each peers as col, j (col.peerId)}
+                {#if i === j}
+                  <td
+                    style="width: {CELL}px; height: {CELL}px; background-color: var(--color-raise)"
+                  ></td>
+                {:else}
+                  {@const ab = half(row.peerId, col.peerId)}
+                  {@const ba = half(col.peerId, row.peerId)}
+                  {@const differs = ab.known && ba.known && ab.state !== ba.state}
+                  <td style="width: {CELL}px; height: {CELL}px; padding: 0">
+                    <button
+                      class="block"
+                      style="width: {CELL}px; height: {CELL}px"
+                      title="{shortPeer(row.peerId)} → {shortPeer(col.peerId)}: {ab.known
+                        ? ab.state
+                        : 'no vantage'} | {shortPeer(col.peerId)} → {shortPeer(
+                        row.peerId
+                      )}: {ba.known ? ba.state : 'no vantage'}"
+                      onclick={() => {
+                        setFilter({ peer: col.peerId });
+                        goTo("timeline");
+                      }}
+                    >
+                      <svg viewBox="0 0 30 30" class="block h-full w-full" aria-hidden="true">
+                        <polygon points="0,0 30,0 0,30" fill={color(ab)} />
+                        <polygon points="30,0 30,30 0,30" fill={color(ba)} />
+                        {#if differs}
+                          <line
+                            x1="30"
+                            y1="0"
+                            x2="0"
+                            y2="30"
+                            stroke="var(--color-text)"
+                            stroke-width="2"
+                          />
+                        {/if}
+                        {#if !ab.known}
+                          <text
+                            x="9"
+                            y="13"
+                            text-anchor="middle"
+                            class="text-[10px]"
+                            fill="var(--color-faint)">?</text
+                          >
+                        {/if}
+                        {#if !ba.known}
+                          <text
+                            x="21"
+                            y="26"
+                            text-anchor="middle"
+                            class="text-[10px]"
+                            fill="var(--color-faint)">?</text
+                          >
+                        {/if}
+                      </svg>
+                    </button>
+                  </td>
+                {/if}
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+
+      <p class="mt-2 text-[11px] text-faint">
+        A flat square means both peers agree. A seam means they do not. Click a
+        square to filter the Timeline to that peer; click a row label to open it
+        in Peers.
+      </p>
+    </div>
+
+    {#if splits.length > 0}
+      <section class="panel">
+        <h2 class="panel-head" style="color: var(--color-sev-error)">asymmetric pairs</h2>
+        <table class="tbl">
+          <thead>
+            <tr><th>a</th><th>a saw</th><th>b</th><th>b saw</th><th></th></tr>
+          </thead>
+          <tbody>
+            {#each splits as s (`${s.a}|${s.b}`)}
+              <tr>
+                <td title={s.a}>{shortPeer(s.a)}</td>
+                <td style="color: {linkColor(s.ab)}">{s.ab}</td>
+                <td title={s.b}>{shortPeer(s.b)}</td>
+                <td style="color: {linkColor(s.ba)}">{s.ba}</td>
+                <td>
+                  <button
+                    class="btn"
+                    onclick={() => {
+                      selectPeer(s.b);
+                      goTo("peers");
+                    }}>Inspect {shortPeer(s.b)}</button
+                  >
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </section>
+    {/if}
+
+    <div class="panel flex flex-wrap items-center gap-x-4 gap-y-1 p-2">
+      {#each ["none", "dialing", "dial-failed", "relayed", "direct", "proven", "lost", "dropped"] as LinkState[] as s (s)}
+        <span class="flex items-center gap-1 font-mono text-[10px] text-dim">
+          <span class="inline-block h-3 w-3" style="background-color: {linkColor(s)}"></span>
+          {s}
+        </span>
+      {/each}
+    </div>
+  </div>
+{/if}

--- a/dashboard/src/lib/views/PeerDetail.svelte
+++ b/dashboard/src/lib/views/PeerDetail.svelte
@@ -1,0 +1,411 @@
+<!--
+  PeerDetail: everything one peer did, from every vantage that saw it.
+
+  The panels answer the four questions a peer bug raises in order: what did each
+  observer believe about it, how did its transport behave, what did voice do,
+  and what did the SFU hold for it.
+-->
+<script lang="ts">
+  import {
+    app,
+    counterSeries,
+    eventsForPeer,
+    fmtClock,
+    fmtDate,
+    fmtDetail,
+    fmtDur,
+    goTo,
+    linkAt,
+    linkColor,
+    observersWithVantage,
+    rttSeries,
+    selectPeer,
+    sevColor,
+    sfuSnapshots,
+    shortPeer,
+  } from "$lib/sources.svelte";
+
+  /** Kinds that move a peer from one state to another, as opposed to sampling it. */
+  const TRANSITIONS: Readonly<Record<string, true>> = {
+    "peer.dial.start": true,
+    "peer.dial.ok": true,
+    "peer.dial.fail": true,
+    "peer.connect": true,
+    "peer.disconnect": true,
+    "peer.relayed": true,
+    "peer.direct": true,
+    "peer.upgrade.attempt": true,
+    "peer.upgrade.ok": true,
+    "peer.upgrade.fail": true,
+    "peer.drop.liveness": true,
+    "peer.redial": true,
+    "stream.open": true,
+    "stream.open.fail": true,
+    "stream.proven": true,
+    "stream.lost": true,
+    "stream.confirm.fail": true,
+    "stream.reset": true,
+  };
+
+  const peer = $derived(app.selectedPeer);
+  const rows = $derived(peer ? eventsForPeer(peer.peerId) : []);
+  const transitions = $derived(rows.filter((r) => TRANSITIONS[r.e.kind] === true));
+  const voiceHistory = $derived(
+    rows.filter((r) => r.e.kind === "voice.pc.state" || r.e.kind === "voice.ice.state")
+  );
+  const iceEvents = $derived(
+    rows.filter((r) => r.e.kind.startsWith("ice.") || r.e.kind === "voice.ice.connected")
+  );
+  const counters = $derived(peer ? counterSeries(peer.peerId) : []);
+  const rtt = $derived(peer ? rttSeries(peer.peerId) : []);
+
+  /** The unbroken runs of a measured round trip. A lost probe breaks the line. */
+  const rttPath = $derived.by(() => {
+    const pts = rtt.filter((s) => s.ms !== null);
+    if (pts.length < 2) return { path: "", max: 0, lost: rtt.filter((s) => s.ms === null).length };
+    const max = Math.max(...pts.map((s) => s.ms ?? 0), 1);
+    const t0 = pts[0].at;
+    const span = Math.max(1, pts[pts.length - 1].at - t0);
+    const segments: string[] = [];
+    let open = false;
+    for (const s of rtt) {
+      if (s.ms === null) {
+        open = false;
+        continue;
+      }
+      const x = ((s.at - t0) / span) * 300;
+      const y = 40 - (s.ms / max) * 36;
+      segments.push(`${open ? "L" : "M"}${x.toFixed(1)} ${y.toFixed(1)}`);
+      open = true;
+    }
+    return { path: segments.join(" "), max, lost: rtt.filter((s) => s.ms === null).length };
+  });
+
+  const snapshots = $derived(sfuSnapshots());
+  const ownSnapshot = $derived(
+    peer ? [...snapshots].reverse().find((s) => s.self.peerId === peer.peerId) : undefined
+  );
+  const siblingProducers = $derived.by(() => {
+    if (!peer) return [];
+    for (const s of [...snapshots].reverse()) {
+      const hit = s.room.find((r) => r.peerId === peer.peerId);
+      if (hit) return hit.producers;
+    }
+    return [];
+  });
+</script>
+
+{#if !app.capture}
+  <p class="text-dim">
+    No capture selected. Pick one in
+    <button class="text-key underline" onclick={() => goTo("sessions")}>Sessions</button>.
+  </p>
+{:else}
+  <div class="grid gap-3 lg:grid-cols-[13rem_1fr]">
+    <!-- Picker -->
+    <nav class="panel h-fit">
+      <h2 class="panel-head">peers {app.peers.length}</h2>
+      <ul>
+        {#each app.peers as p (p.peerId)}
+          <li>
+            <button
+              class="flex w-full items-baseline gap-1.5 px-2 py-0.5 text-left font-mono text-[11px]
+                     {peer?.peerId === p.peerId ? 'bg-raise' : 'hover:bg-raise'}"
+              onclick={() => selectPeer(p.peerId)}
+              title={p.peerId}
+            >
+              <span style="color: {peer?.peerId === p.peerId ? 'var(--color-key)' : ''}">
+                {shortPeer(p.peerId)}
+              </span>
+              {#if p.hasVantage}
+                <span class="text-[9px] text-faint">vantage</span>
+              {/if}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    </nav>
+
+    {#if !peer}
+      <p class="text-dim">This capture names no peer.</p>
+    {:else}
+      <div class="flex min-w-0 flex-col gap-3">
+        <!-- Identity -->
+        <section class="panel p-2.5">
+          <p class="font-mono text-[12px] break-all" style="color: var(--color-key)">
+            {peer.peerId}
+          </p>
+          <dl class="mt-1 grid gap-x-4 gap-y-0.5 font-mono text-[11px] sm:grid-cols-2">
+            <div><span class="text-faint">first seen </span>{fmtDate(peer.firstSeen)}</div>
+            <div><span class="text-faint">last seen </span>{fmtDate(peer.lastSeen)}</div>
+            <div>
+              <span class="text-faint">alive for </span>{fmtDur(peer.lastSeen - peer.firstSeen)}
+            </div>
+            <div>
+              <span class="text-faint">vantage </span>{peer.hasVantage ? "yes" : "no"}
+            </div>
+            <div class="sm:col-span-2">
+              <span class="text-faint">named by </span>{peer.observers
+                .map((o) => shortPeer(o))
+                .join(", ")}
+            </div>
+            <div class="sm:col-span-2">
+              <span class="text-faint">identity refs </span>{peer.identityRefs.length === 0
+                ? "none proven"
+                : peer.identityRefs.join(", ")}
+            </div>
+          </dl>
+          {#if peer.identityRefs.length > 1}
+            <p class="mt-1 text-[11px]" style="color: var(--color-sev-warn)">
+              Two bundles gave this peer different identity ordinals. An ordinal is
+              bundle-local, so that is expected and joins nothing.
+            </p>
+          {/if}
+        </section>
+
+        <!-- What each witness believes right now -->
+        <section class="panel">
+          <h2 class="panel-head">
+            link state at {fmtClock(app.at)}
+          </h2>
+          <table class="tbl">
+            <thead>
+              <tr><th>observer</th><th>state</th><th>voice</th><th>media</th><th>proven</th></tr>
+            </thead>
+            <tbody>
+              {#each observersWithVantage() as o (o)}
+                {#if o !== peer.peerId}
+                  {@const l = linkAt(o, peer.peerId)}
+                  <tr>
+                    <td title={o}>{shortPeer(o)}</td>
+                    <td style="color: {linkColor(l?.state ?? 'none')}">{l?.state ?? "none"}</td>
+                    <td class="text-dim">{l?.voice ?? "none"}</td>
+                    <td class="text-dim">{l?.media ?? "none"}</td>
+                    <td class="text-dim">{l?.proven ? "yes" : "no"}</td>
+                  </tr>
+                {/if}
+              {/each}
+            </tbody>
+          </table>
+        </section>
+
+        <div class="grid gap-3 xl:grid-cols-2">
+          <!-- Transport -->
+          <section class="panel">
+            <h2 class="panel-head">state transitions {transitions.length}</h2>
+            <div class="max-h-64 overflow-auto">
+              <table class="tbl">
+                <tbody>
+                  {#each transitions as r (r.i)}
+                    <tr>
+                      <td class="whitespace-nowrap">{fmtClock(r.e.at)}</td>
+                      <td class="text-dim">{shortPeer(r.e.observer)}</td>
+                      <td style="color: {sevColor(r.e.sev)}">{r.e.kind}</td>
+                      <td class="text-dim">{fmtDetail(r.e.d)}</td>
+                    </tr>
+                  {/each}
+                  {#if transitions.length === 0}
+                    <tr><td class="text-faint">No transport transition recorded.</td></tr>
+                  {/if}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <!-- Round trip -->
+          <section class="panel">
+            <h2 class="panel-head">
+              round trip
+              <span class="text-faint">
+                {rtt.length} probe(s), {rttPath.lost} lost, peak {Math.round(rttPath.max)}ms
+              </span>
+            </h2>
+            {#if rttPath.path === ""}
+              <p class="p-2.5 text-faint">
+                Fewer than two measured probes. `peer.rtt` is budgeted at two per
+                second, so a short capture can hold none.
+              </p>
+            {:else}
+              <svg viewBox="0 0 300 44" class="w-full p-2" role="img" aria-label="round trip series">
+                <line x1="0" y1="40" x2="300" y2="40" stroke="var(--color-line)" />
+                <path d={rttPath.path} fill="none" stroke="var(--color-ls-direct)" stroke-width="1.5" />
+              </svg>
+            {/if}
+          </section>
+
+          <!-- Voice -->
+          <section class="panel">
+            <h2 class="panel-head">voice state history {voiceHistory.length}</h2>
+            <div class="flex max-h-48 flex-wrap gap-1 overflow-auto p-2">
+              {#each voiceHistory as r (r.i)}
+                <span
+                  class="chip"
+                  style="color: {sevColor(r.e.sev)}"
+                  title="{fmtClock(r.e.at)} {r.e.kind} from {shortPeer(r.e.observer)}"
+                >
+                  {r.e.d?.state ?? r.e.kind}
+                </span>
+              {/each}
+              {#if voiceHistory.length === 0}
+                <span class="text-faint">No voice peer connection for this peer.</span>
+              {/if}
+            </div>
+          </section>
+
+          <!-- ICE and TURN -->
+          <section class="panel">
+            <h2 class="panel-head">ice and turn {iceEvents.length}</h2>
+            <div class="max-h-48 overflow-auto">
+              <table class="tbl">
+                <tbody>
+                  {#each iceEvents as r (r.i)}
+                    <tr>
+                      <td class="whitespace-nowrap">{fmtClock(r.e.at)}</td>
+                      <td style="color: {sevColor(r.e.sev)}">{r.e.kind}</td>
+                      <td class="text-dim">{fmtDetail(r.e.d)}</td>
+                    </tr>
+                  {/each}
+                  {#if iceEvents.length === 0}
+                    <tr>
+                      <td class="text-faint">
+                        No ICE or TURN event names this peer. A candidate TYPE is
+                        only recorded where the transport reports one, so this
+                        panel can be empty on a healthy direct link.
+                      </td>
+                    </tr>
+                  {/if}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+
+        <!-- Counters -->
+        <section class="panel">
+          <h2 class="panel-head">
+            counter series {counters.length}
+            <span class="text-faint">changed fields only, sampled every 5s</span>
+          </h2>
+          {#if counters.length === 0}
+            <p class="p-2.5 text-faint">
+              This peer uploaded no vantage, so it has no counter bag of its own.
+            </p>
+          {:else}
+            <div class="max-h-56 overflow-auto">
+              <table class="tbl">
+                <tbody>
+                  {#each counters as c, i (i)}
+                    <tr>
+                      <td class="whitespace-nowrap">{fmtClock(c.at)}</td>
+                      <td class="text-dim">{fmtDetail(c.d)}</td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {/if}
+        </section>
+
+        <!-- SFU -->
+        <section class="panel">
+          <h2 class="panel-head">
+            sfu view
+            <span class="text-faint">{snapshots.length} snapshot(s) in this capture</span>
+          </h2>
+
+          {#if ownSnapshot}
+            <div class="grid gap-2 p-2 xl:grid-cols-3">
+              <div>
+                <h3 class="font-mono text-[10px] tracking-wider text-faint uppercase">transports</h3>
+                <table class="tbl">
+                  <tbody>
+                    {#each ownSnapshot.self.transports as t (t.dir)}
+                      <tr>
+                        <td>{t.dir}</td>
+                        <td class="text-dim">ice {t.iceState} / dtls {t.dtlsState}</td>
+                        <td class="text-faint">
+                          {t.tuple ? `${t.tuple.protocol}:${t.tuple.localPort}` : "no tuple"}
+                        </td>
+                        <td class="text-right text-faint">
+                          {t.rtt === null ? "-" : `${Math.round(t.rtt)}ms`}
+                        </td>
+                      </tr>
+                    {/each}
+                  </tbody>
+                </table>
+              </div>
+              <div>
+                <h3 class="font-mono text-[10px] tracking-wider text-faint uppercase">producers</h3>
+                <table class="tbl">
+                  <tbody>
+                    {#each ownSnapshot.self.producers as p (p.id)}
+                      <tr>
+                        <td>{p.source}/{p.kind}</td>
+                        <td class="text-right text-dim">{p.consumers} viewer(s)</td>
+                        <td class="text-right text-faint">{Math.round(p.bitrate / 1000)}kbps</td>
+                        <td class="text-right text-faint">{p.packetsLost} lost</td>
+                      </tr>
+                    {/each}
+                    {#if ownSnapshot.self.producers.length === 0}
+                      <tr><td class="text-faint">none</td></tr>
+                    {/if}
+                  </tbody>
+                </table>
+              </div>
+              <div>
+                <h3 class="font-mono text-[10px] tracking-wider text-faint uppercase">consumers</h3>
+                <table class="tbl">
+                  <tbody>
+                    {#each ownSnapshot.self.consumers as c (c.id)}
+                      <tr>
+                        <td>{c.kind}</td>
+                        <td class="text-dim">score {c.score}</td>
+                        <td class="text-faint">
+                          {c.paused ? "paused" : c.producerPaused ? "producer paused" : "live"}
+                        </td>
+                        <td class="text-right text-faint">{c.packetsLost} lost</td>
+                      </tr>
+                    {/each}
+                    {#if ownSnapshot.self.consumers.length === 0}
+                      <tr><td class="text-faint">none</td></tr>
+                    {/if}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+            <p class="border-t border-line/50 px-2 py-1 font-mono text-[10px] text-faint">
+              taken {fmtClock(ownSnapshot.takenAt)} · {ownSnapshot.roomPeerCount} in room ·
+              {ownSnapshot.self.cumulativeProduces} cumulative produces ·
+              {ownSnapshot.self.backpressured ? "BACKPRESSURED" : "no backpressure"}
+            </p>
+          {:else if siblingProducers.length > 0}
+            <table class="tbl">
+              <thead>
+                <tr><th>producer</th><th>source</th><th class="text-right">viewers</th></tr>
+              </thead>
+              <tbody>
+                {#each siblingProducers as p (p.id)}
+                  <tr>
+                    <td class="text-faint">{p.id.slice(0, 8)}</td>
+                    <td>{p.source}/{p.kind}</td>
+                    <td class="text-right">{p.consumers}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+            <p class="border-t border-line/50 px-2 py-1 text-[11px] text-faint">
+              This is the sibling view another peer's snapshot carried. It has no
+              transport or consumer detail, because the SFU only reports those to
+              the peer they belong to.
+            </p>
+          {:else}
+            <p class="p-2.5 text-faint">
+              No SFU snapshot names this peer. A snapshot needs SFU_TELEMETRY=1 on
+              the SFU and a video or screen call in progress.
+            </p>
+          {/if}
+        </section>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/dashboard/src/lib/views/Sessions.svelte
+++ b/dashboard/src/lib/views/Sessions.svelte
@@ -1,0 +1,141 @@
+<!--
+  Sessions: the captures a workspace holds, newest first.
+
+  A capture is a set of vantages whose windows overlap and that share a peerId.
+  Selecting one drives every other view, so this is the second stop after
+  Sources and the place to check that the grouping is what the operator expects.
+-->
+<script lang="ts">
+  import {
+    app,
+    fmtDate,
+    fmtDur,
+    goTo,
+    selectCapture,
+    shortPeer,
+  } from "$lib/sources.svelte";
+</script>
+
+{#if app.captureRows.length === 0}
+  <p class="text-dim">
+    No capture yet. Load at least one client bundle in
+    <button class="text-key underline" onclick={() => goTo("sources")}>Sources</button>.
+  </p>
+{:else}
+  <div class="flex flex-col gap-3">
+    <table class="tbl">
+      <thead>
+        <tr>
+          <th></th>
+          <th>window</th>
+          <th class="text-right">span</th>
+          <th>vantages</th>
+          <th class="text-right">peers</th>
+          <th class="text-right">events</th>
+          <th class="text-right">skew</th>
+          <th>findings</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each app.captureRows as row (row.capture.id)}
+          {@const sel = app.capture?.id === row.capture.id}
+          <tr
+            class="cursor-pointer {sel ? 'bg-raise' : ''}"
+            onclick={() => selectCapture(row.capture.id)}
+          >
+            <td style="color: var(--color-key)">{sel ? "▸" : ""}</td>
+            <td>{fmtDate(row.capture.window.from)}</td>
+            <td class="text-right text-dim">
+              {fmtDur(row.capture.window.to - row.capture.window.from)}
+            </td>
+            <td>
+              {#each row.kinds as k (k)}
+                <span class="chip mr-1 text-dim">{k}</span>
+              {/each}
+              <span class="text-faint">({row.capture.vantages.length} file)</span>
+            </td>
+            <td class="text-right">{row.peerCount}</td>
+            <td class="text-right">{row.capture.timeline.length}</td>
+            <td
+              class="text-right"
+              style="color: {row.capture.maxSkewResidualMs > 2000
+                ? 'var(--color-sev-warn)'
+                : 'var(--color-faint)'}"
+            >
+              {Math.round(row.capture.maxSkewResidualMs)}ms
+            </td>
+            <td>
+              <span class="chip mr-1" style="color: var(--color-sev-error)">{row.counts.block}</span>
+              <span class="chip mr-1" style="color: var(--color-sev-warn)">{row.counts.warn}</span>
+              <span class="chip" style="color: var(--color-sev-info)">{row.counts.info}</span>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+
+    {#if app.capture}
+      {@const c = app.capture}
+      <div class="grid gap-3 lg:grid-cols-3">
+        <section class="panel">
+          <h2 class="panel-head">vantages</h2>
+          <table class="tbl">
+            <thead>
+              <tr><th>kind</th><th>observer</th><th class="text-right">offset</th><th class="text-right">events</th></tr>
+            </thead>
+            <tbody>
+              {#each c.vantages as v (v.source)}
+                <tr>
+                  <td class="text-dim">{v.kind}</td>
+                  <td title={v.observer || v.source}>{v.observer ? shortPeer(v.observer) : v.source}</td>
+                  <td class="text-right text-faint">{Math.round(v.offset)}ms</td>
+                  <td class="text-right">{v.events.length}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </section>
+
+        <section class="panel">
+          <h2 class="panel-head">rooms</h2>
+          {#if c.rooms.size === 0}
+            <p class="p-2.5 text-faint">No room ref in this capture.</p>
+          {:else}
+            <table class="tbl">
+              <thead>
+                <tr><th>ref</th><th>kind</th><th class="text-right">observers</th><th class="text-right">events</th></tr>
+              </thead>
+              <tbody>
+                {#each [...c.rooms.values()] as r (r.key)}
+                  <tr>
+                    <td title={r.key}>{r.ref}</td>
+                    <td class="text-dim">{r.kind}</td>
+                    <td class="text-right">{r.observers.length}</td>
+                    <td class="text-right">{r.eventCount}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+            <p class="border-t border-line/50 p-2 text-[11px] text-faint">
+              A ref is bundle-local. "r1" in two bundles names two different
+              rooms, because the room code is the room's only membership secret.
+            </p>
+          {/if}
+        </section>
+
+        <section class="panel">
+          <h2 class="panel-head">capture warnings</h2>
+          {#if c.warnings.length === 0}
+            <p class="p-2.5 text-faint">None.</p>
+          {:else}
+            <ul class="flex flex-col gap-1 p-2.5">
+              {#each c.warnings as w, i (i)}
+                <li class="text-[11px]" style="color: var(--color-sev-warn)">{w}</li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/dashboard/src/lib/views/Sources.svelte
+++ b/dashboard/src/lib/views/Sources.svelte
@@ -1,0 +1,230 @@
+<!--
+  Sources: get data in, and say exactly what happened to every file.
+
+  A file that is not a usable bundle stays in the list with its reason. A silent
+  drop would hide the real problem, which is usually a schema version or a
+  hand-edited JSON file.
+-->
+<script lang="ts">
+  import {
+    LOG_PARSERS,
+    app,
+    clearAll,
+    fmtBytes,
+    loadFiles,
+    loadFromRelay,
+    loadRelayBundle,
+    removeFile,
+    setParser,
+    shortPeer,
+    type LogParser,
+  } from "$lib/sources.svelte";
+
+  let hot = $state(false);
+
+  function drop(e: DragEvent): void {
+    e.preventDefault();
+    hot = false;
+    const list = e.dataTransfer?.files;
+    if (list) void loadFiles([...list]);
+  }
+
+  function pick(e: Event): void {
+    const input = e.currentTarget as HTMLInputElement;
+    if (input.files) void loadFiles([...input.files]);
+    input.value = "";
+  }
+</script>
+
+<div class="flex flex-col gap-3">
+  <div class="grid gap-3 lg:grid-cols-[1fr_22rem]">
+    <!-- Drop zone -->
+    <div
+      role="group"
+      aria-label="Load bundles and logs"
+      class="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed p-6
+             {hot ? 'border-key bg-raise' : 'border-line bg-surface'}"
+      ondragover={(e) => {
+        e.preventDefault();
+        hot = true;
+      }}
+      ondragleave={() => (hot = false)}
+      ondrop={drop}
+    >
+      <p class="text-dim">Drop bundles and container logs here.</p>
+      <p class="text-center text-[11px] text-faint">
+        A bundle is the JSON the Diagnostics pane exports. A log is the output of
+        <code>docker logs -t</code> for the relay or the SFU, or pasted browser console text.
+      </p>
+      <label class="btn">
+        Choose files
+        <input type="file" multiple class="hidden" onchange={pick} />
+      </label>
+    </div>
+
+    <!-- Relay -->
+    <section class="panel">
+      <h2 class="panel-head">relay console</h2>
+      <div class="flex flex-col gap-2 p-2.5">
+        <label class="flex flex-col gap-1">
+          <span class="font-mono text-[10px] tracking-wider text-faint uppercase">relay host</span>
+          <input
+            class="field"
+            placeholder="relay.example.com"
+            bind:value={app.relay.apiBase}
+          />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="font-mono text-[10px] tracking-wider text-faint uppercase">admin token</span>
+          <input
+            class="field"
+            type="password"
+            autocomplete="off"
+            placeholder="TELEMETRY_ADMIN_TOKEN"
+            bind:value={app.relay.token}
+          />
+        </label>
+        <p class="text-[11px] text-faint">
+          The token stays in memory. A reload loses it, and that is deliberate:
+          this console reads a production relay.
+        </p>
+        <button
+          class="btn self-start"
+          disabled={app.relay.busy}
+          onclick={() => void loadFromRelay()}
+        >
+          {app.relay.busy ? "…" : "List bundles"}
+        </button>
+
+        {#if app.relay.message}
+          <p
+            class="text-[11px]"
+            style="color: {app.relay.ok ? 'var(--color-dim)' : 'var(--color-sev-error)'}"
+          >
+            {app.relay.message}
+          </p>
+        {/if}
+
+        {#if app.relay.bundles.length > 0}
+          <ul class="flex max-h-56 flex-col gap-1 overflow-auto">
+            {#each app.relay.bundles as b (b.id)}
+              <li class="flex items-center justify-between gap-2 border-b border-line/40 pb-1">
+                <span class="min-w-0 font-mono text-[11px]">
+                  <span class="text-key">{shortPeer(b.peerId)}</span>
+                  <span class="text-faint">{fmtBytes(b.size)}</span>
+                </span>
+                <button
+                  class="btn"
+                  disabled={app.relay.busy}
+                  onclick={() => void loadRelayBundle(b)}>Load</button
+                >
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </section>
+  </div>
+
+  <!-- Loaded -->
+  <section class="panel">
+    <h2 class="panel-head">
+      loaded
+      <span class="text-faint">{app.files.length}</span>
+      <button class="btn ml-auto" disabled={app.files.length === 0} onclick={clearAll}>
+        Clear all
+      </button>
+    </h2>
+
+    {#if app.files.length === 0}
+      <p class="p-3 text-dim">
+        Nothing loaded. Two client bundles plus the relay and SFU logs give the
+        console every vantage it can use.
+      </p>
+    {:else}
+      <table class="tbl">
+        <thead>
+          <tr>
+            <th>file</th>
+            <th>role</th>
+            <th>observer</th>
+            <th class="text-right">events</th>
+            <th class="text-right">size</th>
+            <th>parser</th>
+            <th>notes</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each app.files as f (f.id)}
+            <tr>
+              <td class="max-w-[22rem] truncate" title={f.name}>
+                {f.name}
+                {#if f.fromRelay}<span class="chip ml-1 text-key">relay</span>{/if}
+              </td>
+              <td>
+                <span
+                  class="chip"
+                  style="color: {f.role === 'rejected'
+                    ? 'var(--color-sev-error)'
+                    : f.role === 'bundle'
+                      ? 'var(--color-sev-info)'
+                      : 'var(--color-dim)'}"
+                >
+                  {f.role}
+                </span>
+              </td>
+              <td class="text-dim" title={f.observer}>{shortPeer(f.observer)}</td>
+              <td class="text-right">{f.eventCount}</td>
+              <td class="text-right text-faint">{fmtBytes(f.bytes)}</td>
+              <td>
+                {#if f.role === "log"}
+                  <select
+                    class="field"
+                    value={f.parser}
+                    onchange={(e) =>
+                      setParser(f.id, (e.currentTarget as HTMLSelectElement).value as LogParser)}
+                  >
+                    {#each LOG_PARSERS as p (p.id)}
+                      <option value={p.id}>{p.label}</option>
+                    {/each}
+                  </select>
+                {:else}
+                  <span class="text-faint">-</span>
+                {/if}
+              </td>
+              <td class="max-w-[26rem]">
+                {#if f.error}
+                  <span style="color: var(--color-sev-error)">{f.error}</span>
+                {:else}
+                  {#if f.unmatched > 0}
+                    <span class="chip mr-1" style="color: var(--color-sev-warn)">
+                      {f.unmatched} unmatched line(s)
+                    </span>
+                  {/if}
+                  {#each f.warnings as w, i (i)}
+                    <span class="block text-[11px]" style="color: var(--color-sev-warn)">{w}</span>
+                  {/each}
+                {/if}
+              </td>
+              <td>
+                <button class="btn" onclick={() => removeFile(f.id)}>Drop</button>
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+
+  {#if app.warnings.length > 0}
+    <section class="panel">
+      <h2 class="panel-head">workspace warnings</h2>
+      <ul class="flex flex-col gap-1 p-2.5">
+        {#each app.warnings as w, i (i)}
+          <li class="text-[11px]" style="color: var(--color-sev-warn)">{w}</li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+</div>

--- a/dashboard/src/lib/views/Timeline.svelte
+++ b/dashboard/src/lib/views/Timeline.svelte
@@ -1,0 +1,292 @@
+<!--
+  Timeline: every vantage's events in one absolute-time stream, in lanes.
+
+  One lane per observer, plus a relay lane and an SFU lane. The lane strip is
+  the whole capture at a glance; the table below is the same filtered rows in
+  detail. The scrubber drives the Topology view, and the cursor drives the
+  scrubber, so `j`/`k` walks the graph forward and back.
+
+  Keys: j next event, k previous event, f next finding evidence.
+-->
+<script lang="ts">
+  import type { DiagSeverity } from "$lib/schema";
+  import {
+    app,
+    evidenceIndices,
+    fmtClock,
+    fmtDetail,
+    fmtDur,
+    goTo,
+    nextEvidence,
+    scrubTo,
+    setCursor,
+    setFilter,
+    sevColor,
+    shortPeer,
+    stepCursor,
+  } from "$lib/sources.svelte";
+
+  /** Ordered for the strip's "worst severity in this bucket" fold. */
+  const SEVS: readonly DiagSeverity[] = ["debug", "info", "warn", "error"];
+  const RANK: Record<DiagSeverity, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+  /** Strip resolution. 320 columns fits any window on a laptop screen. */
+  const BUCKETS = 320;
+  /** The DOM stays honest at this size; a bigger table is unreadable anyway. */
+  const MAX_ROWS = 3000;
+
+  const capture = $derived(app.capture);
+  const span = $derived(
+    capture ? Math.max(1, capture.window.to - capture.window.from) : 1
+  );
+  const evidence = $derived(new Set(evidenceIndices()));
+
+  const strip = $derived.by(() => {
+    if (!capture) return [];
+    const byLane = new Map<string, number[]>();
+    for (const lane of app.lanes) byLane.set(lane.key, new Array<number>(BUCKETS).fill(-1));
+    for (const r of app.rows) {
+      const arr = byLane.get(r.lane);
+      if (!arr) continue;
+      const b = Math.min(
+        BUCKETS - 1,
+        Math.floor(((r.e.at - capture.window.from) / span) * BUCKETS)
+      );
+      const rank = RANK[r.e.sev];
+      if (rank > arr[b]) arr[b] = rank;
+    }
+    return app.lanes.map((lane) => ({
+      lane,
+      cells: (byLane.get(lane.key) ?? []).flatMap((rank, i) =>
+        rank < 0 ? [] : [{ i, sev: SEVS[rank] }]
+      ),
+    }));
+  });
+
+  const scrubPct = $derived(
+    capture ? ((app.at - capture.window.from) / span) * 100 : 0
+  );
+
+  const visible = $derived(app.rows.slice(0, MAX_ROWS));
+
+  let body = $state<HTMLTableSectionElement | null>(null);
+
+  // Keep the cursor row on screen while `j`/`k` walks the stream.
+  $effect(() => {
+    const at = app.cursor;
+    if (at === null || !body) return;
+    body.children[at]?.scrollIntoView({ block: "nearest" });
+  });
+
+  function key(e: KeyboardEvent): void {
+    const el = e.target as HTMLElement | null;
+    const tag = el?.tagName ?? "";
+    if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.key === "j") stepCursor(1);
+    else if (e.key === "k") stepCursor(-1);
+    else if (e.key === "f") nextEvidence();
+    else return;
+    e.preventDefault();
+  }
+
+  /** Click anywhere on a lane strip to scrub to that instant. */
+  function scrubFromClick(e: MouseEvent): void {
+    if (!capture) return;
+    const box = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const frac = Math.min(Math.max((e.clientX - box.left) / box.width, 0), 1);
+    scrubTo(capture.window.from + frac * span);
+  }
+</script>
+
+<svelte:window onkeydown={key} />
+
+{#if !capture}
+  <p class="text-dim">
+    No capture selected. Pick one in
+    <button class="text-key underline" onclick={() => goTo("sessions")}>Sessions</button>.
+  </p>
+{:else}
+  <div class="flex h-full flex-col gap-2">
+    <!-- Filter -->
+    <div class="flex flex-wrap items-center gap-2">
+      <label class="flex items-center gap-1">
+        <span class="font-mono text-[10px] tracking-wider text-faint uppercase">sev</span>
+        <select
+          class="field"
+          value={app.filter.minSev}
+          onchange={(e) =>
+            setFilter({
+              minSev: (e.currentTarget as HTMLSelectElement).value as DiagSeverity,
+            })}
+        >
+          {#each SEVS as s (s)}
+            <option value={s}>{s}+</option>
+          {/each}
+        </select>
+      </label>
+
+      <input
+        class="field w-40"
+        placeholder="kind prefix, e.g. voice."
+        value={app.filter.kindPrefix}
+        oninput={(e) => setFilter({ kindPrefix: (e.currentTarget as HTMLInputElement).value })}
+      />
+
+      <select
+        class="field"
+        value={app.filter.peer}
+        onchange={(e) => setFilter({ peer: (e.currentTarget as HTMLSelectElement).value })}
+      >
+        <option value="">every peer</option>
+        {#each app.peers as p (p.peerId)}
+          <option value={p.peerId}>{shortPeer(p.peerId)}</option>
+        {/each}
+      </select>
+
+      <button
+        class="btn"
+        onclick={() =>
+          setFilter({ from: Math.round(app.at - 15_000), to: Math.round(app.at + 15_000) })}
+        >±15s of cursor</button
+      >
+      {#if app.filter.from !== null || app.filter.to !== null}
+        <button class="btn btn-on" onclick={() => setFilter({ from: null, to: null })}>
+          clear time range
+        </button>
+      {/if}
+
+      <span class="ml-auto font-mono text-[11px] text-faint">
+        {app.rows.length} of {capture.timeline.length} events
+        · <kbd class="text-dim">j/k</kbd> step · <kbd class="text-dim">f</kbd> next evidence
+      </span>
+    </div>
+
+    <!-- Lanes -->
+    <section class="panel shrink-0">
+      <h2 class="panel-head">
+        lanes
+        <span class="text-faint">{fmtClock(capture.window.from)} → {fmtClock(capture.window.to)}</span>
+        <span class="ml-auto" style="color: var(--color-key)">
+          cursor {fmtClock(app.at)} (+{fmtDur(app.at - capture.window.from)})
+        </span>
+      </h2>
+
+      <div class="relative">
+        {#each strip as row (row.lane.key)}
+          <div class="grid grid-cols-[7.5rem_1fr] items-center gap-2 px-2 py-px">
+            <span class="truncate font-mono text-[10px]" title={row.lane.key}>
+              <span
+                style="color: {row.lane.kind === 'client'
+                  ? 'var(--color-text)'
+                  : 'var(--color-dim)'}">{row.lane.label}</span
+              >
+              <span class="text-faint">{row.lane.kind}</span>
+            </span>
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <div class="h-3.5 bg-ink" onclick={scrubFromClick}>
+              <svg
+                viewBox="0 0 {BUCKETS} 10"
+                preserveAspectRatio="none"
+                class="h-full w-full"
+                aria-label="{row.lane.label} events over time"
+              >
+                {#each row.cells as cell (cell.i)}
+                  <rect
+                    x={cell.i}
+                    y={cell.sev === "error" ? 0 : cell.sev === "warn" ? 1.5 : 3}
+                    width="1"
+                    height={cell.sev === "error" ? 10 : cell.sev === "warn" ? 7 : 4}
+                    fill={sevColor(cell.sev)}
+                  />
+                {/each}
+              </svg>
+            </div>
+          </div>
+        {/each}
+
+        <!-- Keyframes: where the topology actually changed. -->
+        <div class="grid grid-cols-[7.5rem_1fr] items-center gap-2 px-2 pt-1 pb-0.5">
+          <span class="font-mono text-[10px] text-faint">keyframes</span>
+          <div class="relative h-2">
+            {#each app.keyframes as k (k)}
+              <span
+                class="absolute top-0 h-2 w-px bg-line"
+                style="left: {((k - capture.window.from) / span) * 100}%"
+              ></span>
+            {/each}
+          </div>
+        </div>
+
+        <!-- The scrubber. It sits over the whole strip so its instant is unambiguous. -->
+        <span
+          class="pointer-events-none absolute inset-y-0 w-px"
+          style="left: calc(7.5rem + 0.5rem + (100% - 8rem - 0.5rem) * {scrubPct / 100}); background-color: var(--color-key)"
+        ></span>
+      </div>
+
+      <div class="border-t border-line/50 px-2 py-1">
+        <input
+          type="range"
+          class="w-full accent-key"
+          aria-label="scrub time"
+          min={capture.window.from}
+          max={capture.window.to}
+          step="1"
+          value={app.at}
+          oninput={(e) => scrubTo(Number((e.currentTarget as HTMLInputElement).value))}
+        />
+      </div>
+    </section>
+
+    <!-- Events -->
+    <section class="panel min-h-0 flex-1 overflow-auto">
+      <table class="tbl">
+        <thead>
+          <tr>
+            <th>time</th>
+            <th>+</th>
+            <th>lane</th>
+            <th>sev</th>
+            <th>kind</th>
+            <th>peer</th>
+            <th>room</th>
+            <th>detail</th>
+          </tr>
+        </thead>
+        <tbody bind:this={body}>
+          {#each visible as row, n (row.i)}
+            <tr
+              class="cursor-pointer {app.cursor === n ? 'bg-raise' : ''}"
+              onclick={() => setCursor(n)}
+            >
+              <td class="whitespace-nowrap" style="color: {app.cursor === n ? 'var(--color-key)' : ''}">
+                {#if evidence.has(row.i)}<span style="color: var(--color-sev-error)">●</span>{:else}<span
+                    class="text-faint">·</span
+                  >{/if}
+                {fmtClock(row.e.at)}
+              </td>
+              <td class="text-right text-faint">{row.e.t === row.e.at ? "" : row.e.t}</td>
+              <td class="text-dim">{shortPeer(row.e.observer)}</td>
+              <td style="color: {sevColor(row.e.sev)}">{row.e.sev}</td>
+              <td>{row.e.kind}</td>
+              <td class="text-dim" title={row.e.peer ?? ""}>
+                {row.e.peer ? shortPeer(row.e.peer) : ""}
+              </td>
+              <td class="text-faint">{row.e.room ?? ""}</td>
+              <td class="max-w-[36rem] break-words text-dim">{fmtDetail(row.e.d)}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+
+      {#if app.rows.length > MAX_ROWS}
+        <p class="p-2 text-[11px]" style="color: var(--color-sev-warn)">
+          The table shows the first {MAX_ROWS} of {app.rows.length} rows. Narrow
+          the filter or set a time range to see the rest.
+        </p>
+      {/if}
+    </section>
+  </div>
+{/if}

--- a/dashboard/src/lib/views/Topology.svelte
+++ b/dashboard/src/lib/views/Topology.svelte
@@ -1,0 +1,470 @@
+<!--
+  Topology: the graph at the scrubbed instant.
+
+  Hand-rolled SVG on purpose. A graph library would add a dependency, hide the
+  layout and make the picture non-deterministic between runs. Here the layout is
+  a function of the peer set alone: peers sort by peerId and sit on one circle,
+  the relay is the left pole and the SFU is the right pole. The same capture
+  always draws the same picture, so two screenshots can be compared.
+
+  A link is DIRECTED: it is what `from` believed about `to`. That is the whole
+  point, so a one-way link must be impossible to mistake for a two-way one:
+
+    two-way  two solid arcs, one bowed each way, each with a filled arrowhead
+    one-way  a single DASHED arc with a HOLLOW arrowhead, plus a dotted stub
+             with an ✕ from the silent peer, but only when that peer uploaded a
+             vantage. Without a vantage its silence is ignorance, not evidence.
+-->
+<script lang="ts">
+  import type {
+    LinkState,
+    MediaLinkState,
+    TopologyNode,
+    VoiceLinkState,
+  } from "$lib/analysis/topology";
+  import { app, fmtClock, goTo, linkColor, scrubTo, shortPeer } from "$lib/sources.svelte";
+
+  interface Pt {
+    x: number;
+    y: number;
+  }
+
+  const W = 1000;
+  const H = 470;
+  const CX = 500;
+  const CY = 235;
+  const NODE_R = 10;
+  /** How far a peer-to-peer arc bows off the chord, so the reverse arc clears it. */
+  const BOW = 26;
+
+  const VOICE_COLOR: Record<VoiceLinkState, string> = {
+    none: "var(--color-ls-none)",
+    new: "var(--color-sev-info)",
+    connected: "var(--color-ls-proven)",
+    relayed: "var(--color-ls-relayed)",
+    degraded: "var(--color-sev-warn)",
+    stalled: "var(--color-sev-warn)",
+    failed: "var(--color-sev-error)",
+    "torn-down": "var(--color-faint)",
+  };
+
+  const LINK_STATES: readonly LinkState[] = [
+    "none",
+    "dialing",
+    "dial-failed",
+    "relayed",
+    "direct",
+    "proven",
+    "lost",
+    "dropped",
+  ];
+
+  const topo = $derived(app.topology);
+
+  /**
+   * The peers to draw.
+   *
+   * `Topology.nodes` names `self` separately and omits it, because a peer's
+   * online state is derived FROM self's point of view. A graph without its own
+   * observer is unreadable, so self is added back here. Server ids are dropped:
+   * the relay and the SFU are poles, never peers.
+   */
+  const nodes = $derived.by<TopologyNode[]>(() => {
+    const t = topo;
+    if (!t) return [];
+    const out = t.nodes.filter((n) => !app.serverIds.has(n.peerId));
+    if (t.self !== "" && !out.some((n) => n.peerId === t.self)) {
+      out.push({
+        peerId: t.self,
+        identityRef: null,
+        rooms: [],
+        // Self is the observer. It is never "offline" from its own point of view.
+        online: true,
+        connecting: false,
+      });
+    }
+    return out;
+  });
+
+  /** Deterministic: sort by peerId, then rotate so `self` sits at the top. */
+  const placed = $derived.by(() => {
+    const t = topo;
+    const out = new Map<string, Pt>();
+    if (!t) return out;
+    const ids = nodes.map((n) => n.peerId).sort();
+    const n = ids.length;
+    if (n === 0) return out;
+    if (n === 1) {
+      out.set(ids[0], { x: CX, y: CY });
+      return out;
+    }
+    const radius = n <= 6 ? 150 : 190;
+    const selfAt = Math.max(0, ids.indexOf(t.self));
+    ids.forEach((id, i) => {
+      const step = (((i - selfAt) % n) + n) % n;
+      const angle = -Math.PI / 2 + (2 * Math.PI * step) / n;
+      out.set(id, {
+        x: CX + radius * Math.cos(angle),
+        y: CY + radius * Math.sin(angle),
+      });
+    });
+    return out;
+  });
+
+  /**
+   * A quadratic arc from `a` to `b`, trimmed clear of both node circles and
+   * bowed to the LEFT of the a→b direction. The reverse call bows the other
+   * way, which is what separates the two directions of one pair.
+   */
+  function arcOf(a: Pt, b: Pt, bow: number, trim: number) {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const ux = dx / len;
+    const uy = dy / len;
+    const p0 = { x: a.x + ux * trim, y: a.y + uy * trim };
+    const p1 = { x: b.x - ux * trim, y: b.y - uy * trim };
+    const c = {
+      x: (p0.x + p1.x) / 2 - uy * bow,
+      y: (p0.y + p1.y) / 2 + ux * bow,
+    };
+    return {
+      d: `M${p0.x} ${p0.y} Q${c.x} ${c.y} ${p1.x} ${p1.y}`,
+      tip: p1,
+      tan: { x: p1.x - c.x, y: p1.y - c.y },
+      // The curve's own midpoint, for a badge that must sit on the line.
+      mid: { x: (p0.x + 2 * c.x + p1.x) / 4, y: (p0.y + 2 * c.y + p1.y) / 4 },
+    };
+  }
+
+  /** An arrowhead triangle at `tip`, aligned with the tangent `tan`. */
+  function headOf(tip: Pt, tan: Pt, size = 8): string {
+    const l = Math.hypot(tan.x, tan.y) || 1;
+    const ux = tan.x / l;
+    const uy = tan.y / l;
+    const bx = tip.x - ux * size;
+    const by = tip.y - uy * size;
+    const hx = -uy * size * 0.5;
+    const hy = ux * size * 0.5;
+    return `${tip.x},${tip.y} ${bx + hx},${by + hy} ${bx - hx},${by - hy}`;
+  }
+
+  interface Edge {
+    key: string;
+    d: string;
+    head: string;
+    color: string;
+    oneWay: boolean;
+    state: LinkState;
+    voice: VoiceLinkState;
+    voicePath: string | null;
+    media: MediaLinkState;
+    mid: Pt;
+    title: string;
+  }
+
+  interface Stub {
+    key: string;
+    d: string;
+    at: Pt;
+    title: string;
+  }
+
+  const drawn = $derived.by(() => {
+    const t = topo;
+    const edges: Edge[] = [];
+    const stubs: Stub[] = [];
+    if (!t) return { edges, stubs };
+
+    const live = t.links.filter((l) => l.state !== "none");
+    const has = new Set(live.map((l) => `${l.from}|${l.to}`));
+
+    for (const l of live) {
+      const a = placed.get(l.from);
+      const b = placed.get(l.to);
+      if (!a || !b) continue;
+      const back = has.has(`${l.to}|${l.from}`);
+      const arc = arcOf(a, b, BOW, NODE_R + 4);
+      const voiceArc = l.voice === "none" ? null : arcOf(a, b, BOW * 0.45, NODE_R + 4).d;
+      edges.push({
+        key: `${l.from}|${l.to}`,
+        d: arc.d,
+        head: headOf(arc.tip, arc.tan),
+        color: linkColor(l.state),
+        oneWay: !back,
+        state: l.state,
+        voice: l.voice,
+        voicePath: voiceArc,
+        media: l.media,
+        mid: arc.mid,
+        title: `${shortPeer(l.from)} → ${shortPeer(l.to)}: ${l.state}${
+          l.voice === "none" ? "" : `, voice ${l.voice}`
+        }${l.media === "none" ? "" : `, media ${l.media}`}${back ? "" : " (ONE WAY)"}`,
+      });
+
+      // The reverse peer never reported this link. Say so only when it could.
+      const reverse = app.peers.find((p) => p.peerId === l.to);
+      if (!back && reverse?.hasVantage) {
+        const tip = arcOf(b, a, BOW, NODE_R + 4).tip;
+        stubs.push({
+          key: `stub-${l.to}|${l.from}`,
+          d: `M${b.x} ${b.y} L${b.x + (tip.x - b.x) * 0.3} ${b.y + (tip.y - b.y) * 0.3}`,
+          at: { x: b.x + (tip.x - b.x) * 0.36, y: b.y + (tip.y - b.y) * 0.36 },
+          title: `${shortPeer(l.to)} never reported a link to ${shortPeer(l.from)}, and it uploaded a vantage.`,
+        });
+      }
+    }
+    return { edges, stubs };
+  });
+
+  const selfPt = $derived(topo ? placed.get(topo.self) : undefined);
+
+  function nudge(dir: 1 | -1): void {
+    const marks = app.keyframes;
+    const here = app.at;
+    const next =
+      dir > 0 ? marks.find((k) => k > here + 0.5) : [...marks].reverse().find((k) => k < here - 0.5);
+    if (next !== undefined) scrubTo(next);
+  }
+</script>
+
+{#if !topo}
+  <p class="text-dim">
+    No capture selected. Pick one in
+    <button class="text-key underline" onclick={() => goTo("sessions")}>Sessions</button>.
+  </p>
+{:else}
+  <div class="flex flex-col gap-2">
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="font-mono text-[11px]" style="color: var(--color-key)">
+        {fmtClock(topo.at)}
+      </span>
+      <button class="btn" onclick={() => nudge(-1)}>◂ keyframe</button>
+      <button class="btn" onclick={() => nudge(1)}>keyframe ▸</button>
+      <input
+        type="range"
+        class="min-w-48 flex-1 accent-key"
+        aria-label="scrub time"
+        min={app.capture?.window.from ?? 0}
+        max={app.capture?.window.to ?? 1}
+        step="1"
+        value={app.at}
+        oninput={(e) => scrubTo(Number((e.currentTarget as HTMLInputElement).value))}
+      />
+      <button class="btn" onclick={() => goTo("timeline")}>Open timeline</button>
+    </div>
+
+    <div class="panel overflow-hidden">
+      <svg viewBox="0 0 {W} {H}" class="w-full" role="img" aria-label="peer topology">
+        <!-- Poles -->
+        {#if topo.relay}
+          {#if selfPt}
+            <path
+              d={arcOf({ x: 110, y: CY }, selfPt, 0, NODE_R + 4).d}
+              fill="none"
+              stroke={topo.relay.reserved
+                ? "var(--color-ls-proven)"
+                : topo.relay.connected
+                  ? "var(--color-ls-relayed)"
+                  : "var(--color-ls-dial-failed)"}
+              stroke-width="1.5"
+              stroke-dasharray={topo.relay.connected ? "none" : "4 4"}
+            />
+          {/if}
+          <rect
+            x="60"
+            y={CY - 26}
+            width="100"
+            height="52"
+            rx="4"
+            fill="var(--color-surface)"
+            stroke={topo.relay.connected ? "var(--color-ls-proven)" : "var(--color-ls-dial-failed)"}
+          />
+          <text x="110" y={CY - 8} text-anchor="middle" class="fill-dim text-[11px]">relay</text>
+          <text x="110" y={CY + 6} text-anchor="middle" class="fill-text text-[11px]">
+            {shortPeer(topo.relay.peerId)}
+          </text>
+          <text
+            x="110"
+            y={CY + 19}
+            text-anchor="middle"
+            class="text-[10px]"
+            fill={topo.relay.reserved ? "var(--color-ls-proven)" : "var(--color-sev-warn)"}
+          >
+            {topo.relay.reserved ? "reserved" : "no reservation"}
+          </text>
+        {/if}
+
+        {#if topo.sfu}
+          {#if selfPt}
+            <path
+              d={arcOf({ x: W - 110, y: CY }, selfPt, 0, NODE_R + 4).d}
+              fill="none"
+              stroke={topo.sfu.connected
+                ? "var(--color-ls-direct)"
+                : "var(--color-ls-dial-failed)"}
+              stroke-width="1.5"
+              stroke-dasharray={topo.sfu.connected ? "none" : "4 4"}
+            />
+          {/if}
+          <rect
+            x={W - 170}
+            y={CY - 26}
+            width="120"
+            height="52"
+            rx="4"
+            fill="var(--color-surface)"
+            stroke={topo.sfu.connected ? "var(--color-ls-direct)" : "var(--color-ls-dial-failed)"}
+          />
+          <text x={W - 110} y={CY - 8} text-anchor="middle" class="fill-dim text-[11px]">sfu</text>
+          <text x={W - 110} y={CY + 6} text-anchor="middle" class="fill-text text-[11px]">
+            {topo.sfu.host || "unset"}
+          </text>
+          <text x={W - 110} y={CY + 19} text-anchor="middle" class="fill-faint text-[10px]">
+            {topo.sfu.roomPeerCount === null ? "no snapshot" : `${topo.sfu.roomPeerCount} in room`}
+          </text>
+        {/if}
+
+        <!-- Silent reverse direction -->
+        {#each drawn.stubs as s (s.key)}
+          <g>
+            <title>{s.title}</title>
+            <path
+              d={s.d}
+              fill="none"
+              stroke="var(--color-sev-error)"
+              stroke-width="1.25"
+              stroke-dasharray="2 4"
+            />
+            <text
+              x={s.at.x}
+              y={s.at.y + 4}
+              text-anchor="middle"
+              class="text-[13px]"
+              fill="var(--color-sev-error)">✕</text
+            >
+          </g>
+        {/each}
+
+        <!-- Directed links -->
+        {#each drawn.edges as e (e.key)}
+          <g>
+            <title>{e.title}</title>
+            <path
+              d={e.d}
+              fill="none"
+              stroke={e.color}
+              stroke-width={e.oneWay ? 2 : 1.75}
+              stroke-dasharray={e.oneWay ? "6 4" : "none"}
+            />
+            <polygon
+              points={e.head}
+              fill={e.oneWay ? "var(--color-ink)" : e.color}
+              stroke={e.color}
+              stroke-width="1.25"
+            />
+            {#if e.voicePath}
+              <path
+                d={e.voicePath}
+                fill="none"
+                stroke={VOICE_COLOR[e.voice]}
+                stroke-width="1"
+                stroke-dasharray="1 3"
+              />
+            {/if}
+            {#if e.media !== "none"}
+              <rect
+                x={e.mid.x - 3}
+                y={e.mid.y - 3}
+                width="6"
+                height="6"
+                fill={e.media === "flowing" ? "var(--color-ls-proven)" : "var(--color-sev-warn)"}
+              />
+            {/if}
+          </g>
+        {/each}
+
+        <!-- Peers -->
+        {#each nodes as n (n.peerId)}
+          {@const p = placed.get(n.peerId)}
+          {#if p}
+            {@const isSelf = n.peerId === topo.self}
+            <g>
+              <title>
+                {n.peerId}{isSelf
+                  ? " — the primary observer, so its own state is not derived"
+                  : ` · ${n.online ? "online" : n.connecting ? "connecting" : "offline"}`} · rooms {n
+                  .rooms.length}
+              </title>
+              <circle
+                cx={p.x}
+                cy={p.y}
+                r={NODE_R}
+                fill={isSelf
+                  ? "var(--color-ink)"
+                  : n.online
+                    ? "var(--color-ls-proven)"
+                    : "var(--color-ink)"}
+                stroke={isSelf
+                  ? "var(--color-key)"
+                  : n.online
+                    ? "var(--color-ls-proven)"
+                    : n.connecting
+                      ? "var(--color-sev-warn)"
+                      : "var(--color-faint)"}
+                stroke-width={isSelf ? 3.5 : 1.5}
+                stroke-dasharray={!isSelf && n.connecting && !n.online ? "3 3" : "none"}
+              />
+              <text
+                x={p.x}
+                y={p.y - NODE_R - 6}
+                text-anchor="middle"
+                class="text-[11px]"
+                fill={isSelf ? "var(--color-key)" : "var(--color-text)"}
+              >
+                {shortPeer(n.peerId)}{isSelf ? " ◂self" : ""}
+              </text>
+              {#if n.identityRef}
+                <text
+                  x={p.x}
+                  y={p.y + NODE_R + 13}
+                  text-anchor="middle"
+                  class="fill-faint text-[10px]">{n.identityRef}</text
+                >
+              {/if}
+            </g>
+          {/if}
+        {/each}
+      </svg>
+    </div>
+
+    <!-- Legend -->
+    <div class="panel flex flex-wrap items-center gap-x-4 gap-y-1 p-2">
+      {#each LINK_STATES as s (s)}
+        <span class="flex items-center gap-1 font-mono text-[10px] text-dim">
+          <svg width="22" height="6" aria-hidden="true"
+            ><line x1="0" y1="3" x2="22" y2="3" stroke={linkColor(s)} stroke-width="2" /></svg
+          >
+          {s}
+        </span>
+      {/each}
+      <span class="flex items-center gap-1 font-mono text-[10px]" style="color: var(--color-sev-error)">
+        <svg width="22" height="6" aria-hidden="true"
+          ><line
+            x1="0"
+            y1="3"
+            x2="22"
+            y2="3"
+            stroke="var(--color-sev-error)"
+            stroke-width="2"
+            stroke-dasharray="6 4"
+          /></svg
+        >
+        dashed + hollow head + ✕ = one way
+      </span>
+      <span class="font-mono text-[10px] text-faint">
+        thin dotted = voice · square = media
+      </span>
+    </div>
+  </div>
+{/if}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -1,0 +1,8 @@
+import { mount } from "svelte";
+import App from "./App.svelte";
+import "./app.css";
+
+const target = document.getElementById("app");
+if (!target) throw new Error("index.html must hold a #app element.");
+
+export default mount(App, { target });

--- a/dashboard/svelte.config.js
+++ b/dashboard/svelte.config.js
@@ -1,0 +1,3 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+export default { preprocess: vitePreprocess() };

--- a/dashboard/tsconfig.app.json
+++ b/dashboard/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "types": ["svelte", "vite/client"],
+    "noEmit": true,
+    "allowJs": false,
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "baseUrl": ".",
+    "paths": {
+      "$lib": ["./src/lib"],
+      "$lib/*": ["./src/lib/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "$lib": ["./src/lib"],
+      "$lib/*": ["./src/lib/*"]
+    },
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  }
+}

--- a/dashboard/tsconfig.node.json
+++ b/dashboard/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
+
+// The operator console. It is NOT deployed: it runs on a developer's own
+// machine and talks to a relay with an admin token. A console on the public
+// internet is not worth the risk, so there is no Dockerfile and no nginx
+// config here.
+export default defineConfig({
+  plugins: [svelte(), tailwindcss()],
+  resolve: {
+    alias: { $lib: path.resolve(import.meta.dirname, "./src/lib") },
+  },
+  server: { port: 5174 },
+});

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import path from "node:path";
+
+export default defineConfig({
+  // Compiled, so a rune-backed store (.svelte.ts) can be tested at all.
+  plugins: [svelte()],
+  resolve: {
+    alias: { $lib: path.resolve(import.meta.dirname, "./src/lib") },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/deploy/sfu-satellite/.env.example
+++ b/deploy/sfu-satellite/.env.example
@@ -40,3 +40,21 @@ SFU_HOSTNAME=
 # Rooms allowed to hold a live mediasoup router here. Counts ROOMS, not
 # participants, so it is not the capacity ceiling - the port range above is.
 #SFU_MAX_ROOMS=250
+
+# ── Telemetry (optional, off by default) ─────────────────────────────────────
+
+# Answers a client's ms:diag request with a live snapshot of this SFU's view of
+# the room, and prints one [sfu-telemetry] JSON line per room per 10s sweep.
+# The analysis dashboard reads both. Unset leaves the whole surface inert.
+#
+# The snapshot carries transport ICE and DTLS states, the local port, byte
+# counters and producer/consumer scores. It never carries a remote candidate
+# ADDRESS. The stdout lines DO carry room codes and peer ids in clear, exactly
+# like the rest of this container's log - keep the log private.
+#SFU_TELEMETRY=1
+
+# Floor between one peer's ms:diag requests, in milliseconds. Each request
+# calls getStats() on every transport, producer and consumer the peer holds,
+# which is a worker round-trip per object, so too low a value lets one client
+# make the worker sample continuously.
+#SFU_DIAG_MIN_INTERVAL_MS=10000

--- a/deploy/sfu-satellite/docker-compose.yml
+++ b/deploy/sfu-satellite/docker-compose.yml
@@ -58,6 +58,13 @@ services:
       ANNOUNCED_IP: ${PUBLIC_IP:?PUBLIC_IP must be the public address of THIS server}
       RTC_MIN_PORT: ${SFU_RTC_MIN_PORT:-61000}
       RTC_MAX_PORT: ${SFU_RTC_MAX_PORT:-61499}
+      # Optional diagnostics. "1" answers ms:diag with a live snapshot and
+      # prints one [sfu-telemetry] line per room per 10s sweep. Unset leaves
+      # both inert, and a client that asks gets "disabled".
+      SFU_TELEMETRY: ${SFU_TELEMETRY:-}
+      # Floor between one peer's ms:diag requests. Default 10000. Too low
+      # and one client can make the worker sample stats continuously.
+      SFU_DIAG_MIN_INTERVAL_MS: ${SFU_DIAG_MIN_INTERVAL_MS:-}
       # Rooms holding a live router. The port range above is the real ceiling
       # (roughly one port per transport, two per participant in a call), so
       # keep the two in step.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,10 @@ services:
       NODE_ENV: development
       HTTP_PORT: "8080"
       KLIPY_API_KEY: ${KLIPY_API_KEY:-dev-key}
+      # On locally, so the dashboard works out of the box: the relay stores
+      # uploaded bundles and serves the two operator read endpoints.
+      TELEMETRY_ENABLED: "1"
+      TELEMETRY_ADMIN_TOKEN: dev
     networks:
       - local-network
 
@@ -57,6 +61,9 @@ services:
       ANNOUNCED_IP: "127.0.0.1"
       RTC_MIN_PORT: "40000"
       RTC_MAX_PORT: "40003"
+      # On locally: answers ms:diag and prints one [sfu-telemetry] line per
+      # room per sweep, which `docker logs -t` then feeds to the dashboard.
+      SFU_TELEMETRY: "1"
     networks:
       - local-network
 

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -47,6 +47,18 @@ services:
       # receive them. What keeps API-using plugins "env + redeploy".
       - PLUGIN_PROXY_HOSTS=${PLUGIN_PROXY_HOSTS:-}
       - PLUGIN_PROXY_SECRETS=${PLUGIN_PROXY_SECRETS:-}
+      # Optional diagnostic collector. Unset means the /telemetry route
+      # answers 204 and stores nothing, so an upload silently does nothing and
+      # the app hides its Upload button. See docs/spec.md "Telemetry".
+      - TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-}
+      # The operator console's bearer token. Unset means /telemetry/list and
+      # /telemetry/get answer 404, so a console that is not there is never
+      # advertised. A weak token here hands every uploaded bundle to anyone.
+      - TELEMETRY_ADMIN_TOKEN=${TELEMETRY_ADMIN_TOKEN:-}
+      # Where bundles land. Defaults to /app/data/telemetry, inside the
+      # relay_data volume below - point it outside and bundles do not survive
+      # a redeploy.
+      - TELEMETRY_DIR=${TELEMETRY_DIR:-}
     volumes:
       - relay_data:/app/data
     networks:
@@ -114,6 +126,14 @@ services:
       - traefik.http.routers.${STACK:-awful}-mailbox.tls=true
       - traefik.http.routers.${STACK:-awful}-mailbox.tls.certresolver=letsencrypt
       - traefik.http.routers.${STACK:-awful}-mailbox.service=${STACK:-awful}-relay-api-service
+      # Port 8081 is routed per PathPrefix, so a route registered in main.go
+      # is unreachable in production without its own six labels here.
+      - traefik.http.routers.${STACK:-awful}-telemetry.rule=Host(`${RELAY_DOMAIN:-relay.${DOMAIN}}`) && PathPrefix(`/telemetry`)
+      - traefik.http.routers.${STACK:-awful}-telemetry.entrypoints=websecure
+      - traefik.http.routers.${STACK:-awful}-telemetry.middlewares=${STACK:-awful}-relay-sec
+      - traefik.http.routers.${STACK:-awful}-telemetry.tls=true
+      - traefik.http.routers.${STACK:-awful}-telemetry.tls.certresolver=letsencrypt
+      - traefik.http.routers.${STACK:-awful}-telemetry.service=${STACK:-awful}-relay-api-service
 
   sfu:
     build:
@@ -167,6 +187,13 @@ services:
       # Documented as an instance variable but never passed through, so
       # setting it in .env did nothing and the SFU kept its built-in default.
       SFU_MAX_ROOMS: ${SFU_MAX_ROOMS:-250}
+      # Optional. "1" answers ms:diag with a live snapshot and adds one
+      # [sfu-telemetry] JSON line per room per 10s sweep to this container's
+      # log. Unset leaves both inert, and ms:diag answers "disabled".
+      SFU_TELEMETRY: ${SFU_TELEMETRY:-}
+      # Floor between one peer's ms:diag requests. Default 10000. Too low and
+      # a client can make the mediasoup worker sample stats continuously.
+      SFU_DIAG_MIN_INTERVAL_MS: ${SFU_DIAG_MIN_INTERVAL_MS:-}
     networks:
       - dokploy-network
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -702,6 +702,133 @@ DM:    "dm-" + hex(sha256(sort([didA, didB]).join("|")))[0..40]
 
 ---
 
+## Telemetry
+
+A bounded in-memory flight recorder, always on from boot, plus three vantages
+on one session and a separate analysis application. Nothing leaves the tab
+unless the user exports a bundle or turns the opt-in on.
+
+```typescript
+// frontend/src/lib/telemetry/schema.ts - mirrored in dashboard/src/lib/schema.ts
+interface DiagEvent {
+  seq: number; // 1-based per session; a gap means the ring or throttle dropped
+  t: number; // ms since the session's startedAt, integer
+  kind: DiagKind; // 112 frozen literals: session.*, relay.*, rv.*, peer.*,
+  // stream.*, app.*, dm.*, ice.*, voice.*, sfu.*, file.*,
+  // storage.*, counters, fault.injected, meta.suppressed
+  sev: "debug" | "info" | "warn" | "error";
+  peer: string | null; // FULL peerId, or null
+  room: string | null; // a bundle-local ordinal ("r1"), NEVER a room code
+  d?: Record<string, string | number | boolean | null>; // <=12 keys, strings <=200
+}
+
+interface ClientBundle {
+  schemaVersion: 1;
+  bundleId: string; // 16 random bytes, minted at export
+  sessionId: string; // 16 random bytes, minted in LibP2PTransport.connect()
+  createdAt: number;
+  startedAt: number;
+  vantage: "client";
+  app: { version: string; commit: string };
+  env: { ua: string };
+  config: {
+    apiHost: string; // a HOST, never a URL with a path
+    relayPeerId: string;
+    sfuHosts: string[];
+    configured: boolean;
+  };
+  self: { peerId: string }; // NO did, not even the uploader's own
+  rooms: Array<{ ref: string; kind: "text" | "dm" | "sync"; joinedAt: number }>;
+  peers: Array<{
+    peerId: string;
+    identityRef: string | null; // "i1" - peerIds that PROVED one DID
+    firstSeen: number;
+    lastSeen: number;
+  }>;
+  counters: Record<string, number>; // t.* transport, a.* app, f.* faults
+  events: DiagEvent[];
+  sfuSnapshots: SfuSnapshot[]; // the last 8; too large for a d bag
+  meta: {
+    ringCapacity: number;
+    dropped: number; // evicted by wraparound
+    suppressed: Record<string, number>; // per kind, by the throttle
+    faultsActive: boolean;
+    truncated: boolean; // trimmed to fit an upload
+  };
+  relayView?: RelayVantage; // stapled by the relay at ingest
+}
+```
+
+```txt
+RECORDING
+  always on, in memory, from boot - a bug is over by the time anyone thinks
+  to flip a switch, so the switch is on every EXIT, never on the recording
+  ring:      4096 events, wraparound, per-kind budget of 20/s (60/s for an
+             error kind; 5/s for app.msg.*, 2/s for peer.rtt and
+             file.progress). One hot kind must not evict every rare event.
+             frontend/src/lib/telemetry/ring.ts
+  taps:      one edit inside each of the three buses' private emit, so every
+             event is recorded - including the nine TransportStatus variants
+             that reach no UI at all.
+             frontend/src/lib/telemetry/taps.ts
+  probes:    ~60 hand-placed rec(ev(...)) lines at the sites where the
+             information exists nowhere else: a silent catch, a console.warn,
+             a bare return.
+
+EXITS (each gated, all off by default)
+  disk:      diagPrefs.persist - sealed chunks in the `diagnostics` store,
+             3 sessions and 8 MB, never synced and never backed up.
+             frontend/src/lib/telemetry/store.ts
+  file:      the Diagnostics settings pane exports awful-diag-<id>.json.
+             frontend/src/lib/telemetry/bundle.ts
+  network:   diagPrefs.upload - POST <apiUrl>/telemetry, signed with the
+             DEVICE libp2p key. Without TELEMETRY_ENABLED=1 the relay answers
+             204 and the button hides.
+             frontend/src/lib/telemetry/upload.ts
+
+THREE VANTAGES ON ONE SESSION
+  client:    the bundle above
+  relay:     stapled at ingest - registry counts, per-stream open/close with
+             the REAL close reason, and a per-peer event ring.
+             relay/telemetry.go
+  sfu:       ms:diag returns a live snapshot (transports, producers,
+             consumers, room siblings); SFU_TELEMETRY=1 also prints one
+             [sfu-telemetry] JSON line per room per 10s sweep.
+             sfu/telemetry.ts
+  joined by peerId: no shared secret and no new wire message. Clock skew is
+  solved from peer.clock samples by least squares.
+  dashboard/src/lib/analysis/merge.ts
+
+REDACTION (enforced by tests, not by convention)
+  room code:      NEVER. A client bundle uses an ordinal ("r1"); a relay
+                  bundle uses "h:"+HMAC(bootSecret, code)[0..12], and the
+                  boot secret is never persisted.
+  did:key:        NEVER, not even the uploader's own. Devices that proved one
+                  DID share an ordinal ("i1") instead.
+  content:        NEVER. No content, no meta.files, no infoHash, no
+                  attachment bytes, no nickname, no avatar. A message becomes
+                  a byte length; a file becomes an ordinal ("f1").
+  peerId:         allowed in full - the relay and the SFU already have it.
+  ICE:            candidate TYPES and the selected tuple's protocol and LOCAL
+                  port only. Never a candidate address.
+  errors:         name and message only. Never a stack: a stack carries local
+                  filesystem paths.
+  upload auth:    the DEVICE libp2p key. An Ed25519 peerId is an identity
+                  multihash, so the public key is inside it and the relay can
+                  check a signature against the claimed peerId. Signing with
+                  the identity key would disclose a did:key -> peerId binding.
+  frontend/src/lib/telemetry/redact.ts, bundle.test.ts
+
+ANALYSIS
+  the frontend runs NONE. It records, persists, exports and uploads. A
+  separate operator console ingests bundles and raw container logs,
+  reconstructs the topology over time, runs 29 deterministic rules that name
+  what went wrong and where, and builds a prompt pack that asks an AI why.
+  dashboard/ - not deployed, run locally against a relay admin token.
+```
+
+---
+
 ## Server Privacy
 
 ```txt
@@ -714,6 +841,19 @@ never knows:   message content, file content, who sent a mailbox blob -
 SFU knows:     video/screen streams it routes (see landing page disclosure);
                voice never touches it
 all p2p:       messages, files, voice - direct between peers
+```
+
+```txt
+with telemetry (TELEMETRY_ENABLED=1, and the user opted in) the relay
+additionally knows: that peerId's own connection diagnostics - dial and
+reservation outcomes, ICE candidate TYPES, transport states, timings,
+counters and error codes. Never message or file content, never a did:key,
+never a room code (a bundle carries opaque room refs), never an ICE
+candidate address. Bundles expire after 7 days.
+with SFU telemetry (SFU_TELEMETRY=1) the SFU additionally LOGS, to its own
+container log, the room codes and peerIds it already routes for, plus its
+transport states and producer/consumer scores. Never a remote candidate
+address.
 ```
 
 ---

--- a/frontend/src/lib/components/SettingsDialog.svelte
+++ b/frontend/src/lib/components/SettingsDialog.svelte
@@ -43,6 +43,7 @@
     Volume2,
     RefreshCw,
     ChartPie,
+    Activity,
     Info,
     Heart,
     Puzzle,
@@ -56,6 +57,7 @@
   import SessionSettings from "./settings/SessionSettings.svelte";
   import AppSettings from "./settings/AppSettings.svelte";
   import DataSettings from "./settings/DataSettings.svelte";
+  import DiagnosticsSettings from "./settings/DiagnosticsSettings.svelte";
   import PluginSettings from "./settings/PluginSettings.svelte";
   import AvatarPickerDialog from "./AvatarPickerDialog.svelte";
   import QuirksNotice from "./QuirksNotice.svelte";
@@ -67,6 +69,7 @@
     | "app"
     | "session"
     | "data"
+    | "diagnostics"
     | "plugins"
     | "quirks"
     | "oss";
@@ -98,6 +101,11 @@
     { id: "app" as SettingsTab, label: "App", icon: SlidersHorizontal },
     { id: "session" as SettingsTab, label: "Session/Sync", icon: RefreshCw },
     { id: "data" as SettingsTab, label: "Data", icon: ChartPie },
+    {
+      id: "diagnostics" as SettingsTab,
+      label: "Diagnostics",
+      icon: Activity,
+    },
     { id: "plugins" as SettingsTab, label: "Plugins", icon: Puzzle },
     { id: "quirks" as SettingsTab, label: "Quirks", icon: Info },
     { id: "oss" as SettingsTab, label: "OSS", icon: Heart },
@@ -283,6 +291,8 @@
         <SessionSettings {isMobile} {onClose} {onOpenSync} />
       {:else if activeTab === "data"}
         <DataSettings {activeTab} />
+      {:else if activeTab === "diagnostics"}
+        <DiagnosticsSettings {activeTab} />
       {:else if activeTab === "plugins"}
         <PluginSettings />
       {:else if activeTab === "quirks"}
@@ -319,6 +329,8 @@
             <SessionSettings {isMobile} {onClose} {onOpenSync} />
           {:else if activeTab === "data"}
             <DataSettings {activeTab} />
+          {:else if activeTab === "diagnostics"}
+            <DiagnosticsSettings {activeTab} />
           {:else if activeTab === "plugins"}
             <PluginSettings />
           {:else if activeTab === "quirks"}

--- a/frontend/src/lib/components/settings/DiagnosticsSettings.svelte
+++ b/frontend/src/lib/components/settings/DiagnosticsSettings.svelte
@@ -1,0 +1,557 @@
+<script lang="ts">
+  import { Label } from "$lib/components/ui/label";
+  import { Button } from "$lib/components/ui/button";
+  import { Switch } from "$lib/components/ui/switch";
+  import {
+    Activity,
+    Check,
+    Copy,
+    Download,
+    Trash2,
+    Upload as UploadIcon,
+  } from "@lucide/svelte";
+  import {
+    recorderSnapshot,
+    type RecorderSnapshot,
+  } from "$lib/telemetry/recorder";
+  import {
+    diagPrefs,
+    setDiagPersist,
+    setDiagUpload,
+  } from "$lib/telemetry/prefs.svelte";
+  import { buildClientBundle } from "$lib/telemetry/bundle";
+  import {
+    DIAG_KEEP_SESSIONS,
+    DIAG_MAX_BYTES,
+    clearStoredDiagnostics,
+    startDiagPersistence,
+    stopDiagPersistence,
+    storedDiagSessions,
+  } from "$lib/telemetry/store";
+  import { collectorAvailable, uploadBundle } from "$lib/telemetry/upload";
+  import type { DiagSessionSummary } from "$lib/storage";
+  import type { DiagSeverity } from "$lib/telemetry/schema";
+
+  interface Props {
+    activeTab?: string;
+  }
+
+  let { activeTab = "diagnostics" }: Props = $props();
+
+  /** The newest 50 events reach the table. Older events stay in the bundle. */
+  const RECENT_LIMIT = 50;
+  /** How many suppressed kinds the summary names. */
+  const TOP_SUPPRESSED = 3;
+  /** Refresh cadence for the in-memory numbers while the pane is open. */
+  const REFRESH_MS = 1000;
+  /** Refresh cadence for the disk list. A cursor walk is not a per-second job. */
+  const STORED_REFRESH_MS = 5000;
+
+  /**
+   * One rendered row. Flat strings on purpose: the table stays dumb, and the
+   * detail bag is formatted once per refresh instead of once per render.
+   */
+  interface EventRow {
+    seq: number;
+    t: number;
+    kind: string;
+    sev: DiagSeverity;
+    peerTail: string;
+    detail: string;
+  }
+
+  /** A display-only projection. It holds no event object and no nested bag. */
+  interface RecorderView {
+    sessionId: string;
+    held: number;
+    dropped: number;
+    ringCapacity: number;
+    faultsActive: boolean;
+    topSuppressed: Array<{ kind: string; count: number }>;
+    recent: EventRow[];
+  }
+
+  // A `RecorderSnapshot` NEVER enters a rune: a `$state` proxy cannot be
+  // structured-cloned, and `JSON.stringify` of a proxy is the bug
+  // `DataSettings.svelte:124-127` records. So the render path holds this flat
+  // projection, and the export path passes a fresh plain snapshot straight to
+  // `buildClientBundle`.
+  let view = $state<RecorderView | null>(null);
+
+  let stored = $state<DiagSessionSummary[]>([]);
+  let collectorOk = $state(false);
+  let copied = $state(false);
+  let busy = $state(false);
+  let actionNote = $state<string | null>(null);
+  let actionFailed = $state(false);
+  let confirmClear = $state(false);
+
+  function project(s: RecorderSnapshot): RecorderView {
+    const recent = s.events.slice(-RECENT_LIMIT).map((e) => ({
+      seq: e.seq,
+      t: e.t,
+      kind: e.kind as string,
+      sev: e.sev,
+      peerTail: e.peer ? e.peer.slice(-8) : "",
+      detail: e.d
+        ? Object.entries(e.d)
+            .map(([k, v]) => `${k}=${String(v)}`)
+            .join(" ")
+        : "",
+    }));
+    const topSuppressed = Object.entries(s.suppressed)
+      .map(([kind, count]) => ({ kind, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, TOP_SUPPRESSED);
+    return {
+      sessionId: s.sessionId,
+      held: s.events.length,
+      dropped: s.dropped,
+      ringCapacity: s.ringCapacity,
+      faultsActive: s.faultsActive,
+      topSuppressed,
+      recent,
+    };
+  }
+
+  function refreshView(): void {
+    view = project(recorderSnapshot());
+  }
+
+  async function refreshStored(): Promise<void> {
+    stored = await storedDiagSessions();
+  }
+
+  // A 204 from the ingest route means the operator never set the collector up.
+  // The probe runs only while the pane is open, and the module memoizes it.
+  async function probeCollector(): Promise<void> {
+    collectorOk = await collectorAvailable();
+  }
+
+  $effect(() => {
+    if (activeTab !== "diagnostics") return;
+    refreshView();
+    void refreshStored();
+    void probeCollector();
+    const live = setInterval(refreshView, REFRESH_MS);
+    // The disk list is live too, so a user who just turned persist on sees the
+    // first chunk arrive instead of a stale "None on disk".
+    const disk = setInterval(() => void refreshStored(), STORED_REFRESH_MS);
+    return () => {
+      clearInterval(live);
+      clearInterval(disk);
+    };
+  });
+
+  // This pane is the ONLY place that starts persistence, so a user who never
+  // opens Settings pays nothing: no timer, no IndexedDB write, no sealed row.
+  // The timer outlives the pane on purpose - a closed dialog must not stop a
+  // capture that the user asked for.
+  $effect(() => {
+    if (diagPrefs.persist) startDiagPersistence();
+    else stopDiagPersistence();
+  });
+
+  function randomHex(bytes: number): string {
+    const b = new Uint8Array(bytes);
+    crypto.getRandomValues(b);
+    return [...b].map((x) => x.toString(16).padStart(2, "0")).join("");
+  }
+
+  /**
+   * The bundle is built from a FRESH plain snapshot, so an export holds every
+   * event up to the click rather than the last table refresh.
+   */
+  function currentBundle() {
+    const fresh = recorderSnapshot();
+    view = project(fresh);
+    return buildClientBundle(fresh, {
+      version: __APP_VERSION__,
+      commit: __APP_COMMIT__,
+      ua: navigator.userAgent,
+      now: Date.now(),
+      randomHex,
+    });
+  }
+
+  function note(text: string, failed: boolean): void {
+    actionNote = text;
+    actionFailed = failed;
+  }
+
+  async function copySessionId(): Promise<void> {
+    if (!view?.sessionId) return;
+    try {
+      await navigator.clipboard.writeText(view.sessionId);
+      copied = true;
+      setTimeout(() => (copied = false), 1200);
+    } catch {
+      // Clipboard blocked: the id is visible to select by hand.
+    }
+  }
+
+  function handleExport(): void {
+    const bundle = currentBundle();
+    const blob = new Blob([JSON.stringify(bundle, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    try {
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `awful-diag-${bundle.bundleId}.json`;
+      a.click();
+      note(`The app wrote awful-diag-${bundle.bundleId}.json.`, false);
+    } finally {
+      // Revoked in a `finally`: a leaked object URL holds the whole bundle in
+      // memory for the life of the document.
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  /** Plain words for every refusal. A reason code alone helps nobody. */
+  function uploadReasonText(reason: string): string {
+    switch (reason) {
+      case "disabled":
+        return "The operator did not set a collector up on this instance.";
+      case "off":
+        return "The upload switch is off. Turn it on first.";
+      case "too-large":
+        return "The bundle is too large, even after a trim.";
+      case "unauthorized":
+        return "The relay refused the signature on this upload.";
+      case "rate-limited":
+        return "The relay took too many uploads. Wait a minute.";
+      case "network":
+        return "The relay did not answer. Check your connection.";
+      default:
+        return `The upload failed: ${reason}.`;
+    }
+  }
+
+  async function handleUpload(): Promise<void> {
+    busy = true;
+    try {
+      const result = await uploadBundle(currentBundle());
+      if (result.ok)
+        note(`The relay took the bundle. Id ${result.bundleId}.`, false);
+      else note(uploadReasonText(result.reason), true);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleClear(): Promise<void> {
+    busy = true;
+    confirmClear = false;
+    try {
+      await clearStoredDiagnostics();
+      await refreshStored();
+      note("The app deleted every stored chunk.", false);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function formatBytes(bytes: number): string {
+    if (bytes <= 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.min(
+      Math.floor(Math.log(bytes) / Math.log(k)),
+      sizes.length - 1
+    );
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+  }
+
+  function formatStart(ms: number): string {
+    return ms > 0 ? new Date(ms).toLocaleString() : "unknown";
+  }
+
+  const SEV_CLASS: Record<DiagSeverity, string> = {
+    debug: "text-muted-foreground/70",
+    info: "text-muted-foreground",
+    warn: "text-amber-500",
+    error: "text-destructive",
+  };
+</script>
+
+<div class="flex flex-col gap-6">
+  <!-- Recorder Section -->
+  <div
+    class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+  >
+    <div class="flex items-center gap-2">
+      <div class="w-1 h-4 bg-sky-500 rounded-full"></div>
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+        >Recorder</Label
+      >
+    </div>
+    <p class="text-xs font-mono text-muted-foreground leading-relaxed">
+      The recorder is always on, in memory, from the first connection. Nothing
+      leaves this tab until you export a bundle, or you turn the upload switch
+      on.
+    </p>
+
+    {#if view}
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs font-mono text-muted-foreground">Session</span>
+          <div class="flex items-center gap-1 min-w-0">
+            <span class="text-xs font-mono truncate">
+              {view.sessionId || "no session yet"}
+            </span>
+            {#if view.sessionId}
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-6 px-1.5 font-mono text-xs text-muted-foreground"
+                onclick={copySessionId}
+                aria-label="Copy session id"
+              >
+                {#if copied}
+                  <Check class="w-3 h-3" />
+                {:else}
+                  <Copy class="w-3 h-3" />
+                {/if}
+              </Button>
+            {/if}
+          </div>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs font-mono text-muted-foreground">Events held</span
+          >
+          <span class="text-xs font-mono"
+            >{view.held} / {view.ringCapacity}</span
+          >
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs font-mono text-muted-foreground">Dropped</span>
+          <span class="text-xs font-mono">{view.dropped}</span>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs font-mono text-muted-foreground">Suppressed</span>
+          <span class="text-xs font-mono text-right truncate">
+            {#if view.topSuppressed.length === 0}
+              none
+            {:else}
+              {view.topSuppressed
+                .map((s) => `${s.kind} ${s.count}`)
+                .join(", ")}
+            {/if}
+          </span>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <span class="text-xs font-mono text-muted-foreground"
+            >Fault injection</span
+          >
+          <span
+            class="text-xs font-mono {view.faultsActive
+              ? 'text-amber-500'
+              : ''}">{view.faultsActive ? "active" : "off"}</span
+          >
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Exits Section -->
+  <div
+    class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+  >
+    <div class="flex items-center gap-2">
+      <div class="w-1 h-4 bg-sky-500 rounded-full"></div>
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+        >Exits</Label
+      >
+    </div>
+    <div class="flex items-center justify-between gap-3">
+      <div class="flex flex-col gap-1 min-w-0">
+        <span class="text-xs font-mono">Keep diagnostics across reloads</span>
+        <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+          The app writes sealed event chunks to this device, so a crash or a
+          reload keeps the history. Off holds the events in memory only.
+        </span>
+      </div>
+      <Switch
+        checked={diagPrefs.persist}
+        onCheckedChange={(checked) => setDiagPersist(checked)}
+      />
+    </div>
+    <div class="flex items-center justify-between gap-3">
+      <div class="flex flex-col gap-1 min-w-0">
+        <span class="text-xs font-mono">Allow upload to this instance</span>
+        <span class="text-xs font-mono text-muted-foreground leading-relaxed">
+          An upload hands the relay your connection diagnostics: dial outcomes,
+          ICE candidate TYPES, transport states, timings, counters and error
+          codes. It never sends message content, never a did:key, never a room
+          code, and never an ICE candidate address.
+        </span>
+      </div>
+      <Switch
+        checked={diagPrefs.upload}
+        onCheckedChange={(checked) => setDiagUpload(checked)}
+      />
+    </div>
+  </div>
+
+  <!-- Actions Section -->
+  <div
+    class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+  >
+    <div class="flex items-center gap-2">
+      <div class="w-1 h-4 bg-sky-500 rounded-full"></div>
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+        >Actions</Label
+      >
+    </div>
+    <div class="flex flex-col gap-2 sm:flex-row">
+      <Button
+        variant="outline"
+        class="flex-1 font-mono text-xs"
+        disabled={busy || !view?.sessionId}
+        onclick={handleExport}
+      >
+        <Download class="w-3.5 h-3.5 mr-2" />
+        Export bundle
+      </Button>
+      <!-- Hidden, not disabled, when the collector answers 204: the operator
+           never set one up, so a button here would promise a route that is
+           not there. -->
+      {#if collectorOk}
+        <Button
+          variant="outline"
+          class="flex-1 font-mono text-xs"
+          disabled={busy || !view?.sessionId}
+          onclick={handleUpload}
+        >
+          <UploadIcon class="w-3.5 h-3.5 mr-2" />
+          Upload bundle
+        </Button>
+      {/if}
+    </div>
+
+    {#if actionNote}
+      <p
+        class="text-xs font-mono leading-relaxed {actionFailed
+          ? 'text-destructive'
+          : 'text-muted-foreground'}"
+      >
+        {actionNote}
+      </p>
+    {/if}
+
+    <div class="flex flex-col gap-2 bg-muted/50 rounded-lg p-3">
+      <span class="text-xs font-mono text-muted-foreground">
+        Stored sessions
+      </span>
+      {#if stored.length === 0}
+        <span class="text-xs font-mono text-muted-foreground/70">
+          None on disk. The persist switch above is what writes them.
+        </span>
+      {:else}
+        {#each stored as s (s.sessionId)}
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-xs font-mono truncate"
+              >{s.sessionId.slice(0, 12)}… · {formatStart(s.startedAt)}</span
+            >
+            <span class="text-xs font-mono text-muted-foreground shrink-0"
+              >{s.chunks} chunks · {formatBytes(s.bytes)}</span
+            >
+          </div>
+        {/each}
+      {/if}
+      <span class="text-xs font-mono text-muted-foreground/70 leading-relaxed">
+        This device keeps {DIAG_KEEP_SESSIONS} sessions and {formatBytes(
+          DIAG_MAX_BYTES
+        )} of diagnostics. Past either limit, the app deletes the oldest session
+        first.
+      </span>
+    </div>
+
+    {#if !confirmClear}
+      <Button
+        variant="ghost"
+        class="w-full font-mono text-xs text-muted-foreground
+          hover:bg-destructive/10! hover:text-destructive!"
+        disabled={busy || stored.length === 0}
+        onclick={() => (confirmClear = true)}
+      >
+        <Trash2 class="w-3.5 h-3.5 mr-2" />
+        Clear stored diagnostics
+      </Button>
+    {:else}
+      <div class="flex gap-2">
+        <Button
+          variant="outline"
+          class="flex-1 font-mono text-xs"
+          onclick={() => (confirmClear = false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="destructive"
+          class="flex-1 font-mono text-xs"
+          disabled={busy}
+          onclick={handleClear}
+        >
+          Delete every chunk
+        </Button>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Recent Events Section -->
+  <div
+    class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+  >
+    <div class="flex items-center gap-2">
+      <div class="w-1 h-4 bg-sky-500 rounded-full"></div>
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+        >Recent Events</Label
+      >
+    </div>
+    {#if !view || view.recent.length === 0}
+      <div class="flex items-center gap-2 py-4">
+        <Activity class="w-4 h-4 text-muted-foreground" />
+        <span class="text-xs font-mono text-muted-foreground">
+          No events yet. The recorder starts with the first connection.
+        </span>
+      </div>
+    {:else}
+      <div class="overflow-x-auto">
+        <table class="w-full font-mono text-[11px] border-collapse">
+          <thead>
+            <tr class="text-muted-foreground/70 text-left">
+              <th class="pr-3 pb-1 font-normal">ms</th>
+              <th class="pr-3 pb-1 font-normal">kind</th>
+              <th class="pr-3 pb-1 font-normal">peer</th>
+              <th class="pb-1 font-normal">detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each view.recent as e (e.seq)}
+              <tr class={SEV_CLASS[e.sev]}>
+                <td class="pr-3 align-top tabular-nums whitespace-nowrap"
+                  >{e.t}</td
+                >
+                <td class="pr-3 align-top whitespace-nowrap">{e.kind}</td>
+                <td class="pr-3 align-top whitespace-nowrap">{e.peerTail}</td>
+                <td class="align-top break-all">{e.detail}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+      <p class="text-xs font-mono text-muted-foreground/70 leading-relaxed">
+        The newest {RECENT_LIMIT} events, with the time in milliseconds after the
+        session start. A gap in the times means the ring or the throttle dropped
+        events.
+      </p>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/lib/palette/commands/settings.ts
+++ b/frontend/src/lib/palette/commands/settings.ts
@@ -1,4 +1,5 @@
 import {
+  Activity,
   ChartPie,
   Heart,
   Info,
@@ -63,6 +64,7 @@ const SETTINGS_TABS = [
   { id: "app", label: "App", icon: SlidersHorizontal },
   { id: "session", label: "Session/Sync", icon: RefreshCw },
   { id: "data", label: "Data", icon: ChartPie },
+  { id: "diagnostics", label: "Diagnostics", icon: Activity },
   { id: "plugins", label: "Plugins", icon: Puzzle },
   { id: "quirks", label: "Quirks", icon: Info },
   { id: "oss", label: "OSS", icon: Heart },

--- a/frontend/src/lib/storage-crypto.ts
+++ b/frontend/src/lib/storage-crypto.ts
@@ -37,6 +37,9 @@
  * path this file already relies on for the blinding migration.
  */
 
+import { ev } from "./telemetry/event";
+import { rec } from "./telemetry/recorder";
+
 interface EncBlob {
   iv: Uint8Array;
   ct: ArrayBuffer;
@@ -429,6 +432,11 @@ export async function openRows<T>(
   }
   if (dropped > 0) {
     console.warn(`[storage] dropped ${dropped} undecryptable row(s)`);
+    rec(
+      ev("storage.drop", {
+        d: { store: spec.storeName ?? "unknown", count: dropped },
+      })
+    );
   }
   return out;
 }
@@ -550,6 +558,18 @@ export const STORE_SPECS = {
     key: "roomCode",
     clear: ["lastLamport"],
     blind: ["roomCode"],
+    bytes: ["data"],
+  },
+  // Diagnostic event chunks. sessionId and startedAt are random or opaque, so
+  // they stay clear for the prune query. The events carry peer ids and error
+  // strings, so they ride in `bytes` and are sealed like attachment data.
+  //
+  // Nothing needs `blind`: no room code and no DID ever enters this store, and
+  // nothing is queried by an identifier a blind would have to match.
+  diagnostics: {
+    storeName: "diagnostics",
+    key: "id",
+    clear: ["id", "sessionId", "startedAt", "seqFrom", "seqTo"],
     bytes: ["data"],
   },
 } as const satisfies Record<string, StoreCryptoSpec>;

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -30,6 +30,8 @@ import type {
   MnemonicRecord,
   WebAuthnRecord,
 } from "./identity/identity";
+import { ev } from "./telemetry/event";
+import { rec } from "./telemetry/recorder";
 
 export type RoomType = "text" | "dm";
 
@@ -199,6 +201,11 @@ type AppDB = IDBPDatabase<{
     key: Blinded;
     value: SearchIndexRecord;
   };
+  diagnostics: {
+    key: string;
+    value: DiagChunkRecord;
+    indexes: { bySession: string };
+  };
 }>;
 
 /** Sealed per-room search index: entries serialized as encrypted bytes. */
@@ -208,6 +215,29 @@ export interface SearchIndexRecord {
    *  staleness is checkable without a decrypt. */
   lastLamport: number;
   /** JSON bytes of SearchEntry[]; sealed via the `bytes` spec. */
+  data: ArrayBuffer;
+}
+
+/**
+ * One sealed slice of the diagnostic ring.
+ *
+ * Chunked, not one growing row: a flush must not rewrite the whole session,
+ * and a prune must be able to drop the oldest slices without a decrypt.
+ *
+ * NEVER synced and NEVER backed up. `backup.ts`, `backup-restore.ts` and
+ * `sync.svelte.ts` deliberately do not know this store exists - a diagnostic
+ * buffer must not ride an encrypted backup to another device.
+ * `wipeLocalDatabase()` uses `deleteDB`, so duress erase already covers it.
+ */
+export interface DiagChunkRecord {
+  /** `${sessionId}:${chunkSeq}` zero-padded, so a key sort is a time sort. */
+  id: string;
+  sessionId: string;
+  /** The session's wall-clock start. Clear, for the prune query. */
+  startedAt: number;
+  seqFrom: number;
+  seqTo: number;
+  /** JSON bytes of DiagEvent[]; sealed via the `bytes` spec. */
   data: ArrayBuffer;
 }
 
@@ -231,7 +261,7 @@ export async function getDB(): Promise<AppDB> {
 }
 
 async function openDatabase(): Promise<AppDB> {
-  db = (await openDB("awful-chat", 5, {
+  db = (await openDB("awful-chat", 6, {
     async upgrade(database, oldVersion, _newVersion, transaction) {
       if (oldVersion < 1) {
         // messages
@@ -314,6 +344,12 @@ async function openDatabase(): Promise<AppDB> {
         // Message-search index, one sealed row per room (see STORE_SPECS).
         database.createObjectStore("searchIndex", { keyPath: "roomCode" });
       }
+
+      if (oldVersion < 6) {
+        // Diagnostic event chunks, sealed (see STORE_SPECS). Never synced.
+        const s = database.createObjectStore("diagnostics", { keyPath: "id" });
+        s.createIndex("bySession", "sessionId", { unique: false });
+      }
     },
     blocking() {
       // Someone wants to delete (or upgrade) this database and our open
@@ -365,6 +401,7 @@ async function _open<T>(
     // One undecryptable row (truncated blob, foreign key) degrades to one
     // missing row, never to a thrown query.
     console.warn(`[storage] dropped undecryptable ${store} row:`, err);
+    rec(ev("storage.drop", { d: { store, count: 1 } }));
     return undefined;
   }
 }
@@ -889,6 +926,133 @@ export async function putSearchIndex(record: SearchIndexRecord): Promise<void> {
 export async function deleteSearchIndex(roomCode: string): Promise<void> {
   const database = await getDB();
   await database.delete("searchIndex", await blindValue(roomCode));
+}
+
+// ── diagnostic chunks ────────────────────────────────────────────────────────
+// Every helper here is best-effort by design. A diagnostic buffer that throws
+// would break the app it exists to explain, so the CALLER decides what a
+// failure means; see `telemetry/store.ts`.
+
+export async function putDiagChunk(record: DiagChunkRecord): Promise<void> {
+  const database = await getDB();
+  await database.put("diagnostics", await _seal("diagnostics", record));
+}
+
+/** One session's chunks, oldest first. An undecryptable chunk is dropped. */
+export async function getDiagChunks(
+  sessionId: string
+): Promise<DiagChunkRecord[]> {
+  const database = await getDB();
+  const rows = await database.getAllFromIndex(
+    "diagnostics",
+    "bySession",
+    sessionId
+  );
+  rows.sort((a, b) => a.id.localeCompare(b.id));
+  return _openAll("diagnostics", rows);
+}
+
+export interface DiagSessionSummary {
+  sessionId: string;
+  startedAt: number;
+  chunks: number;
+  /** Sealed size on disk, in bytes. */
+  bytes: number;
+}
+
+/**
+ * On-disk size of one chunk, read without a key.
+ *
+ * A sealed row does NOT carry `data`: `sealRow` moves every `bytes` field into
+ * `_encBytes.<field>.ct`. A plaintext row - one written during a locked import,
+ * before the at-rest sweep - still has `data`. Both shapes are measured, so a
+ * prune is never fooled into thinking the store is empty.
+ */
+function sealedChunkBytes(row: DiagChunkRecord): number {
+  const loose = row as unknown as {
+    data?: unknown;
+    _encBytes?: Record<string, { ct?: unknown }>;
+  };
+  const sealed = loose._encBytes?.data?.ct;
+  if (sealed instanceof ArrayBuffer) return sealed.byteLength;
+  if (loose.data instanceof ArrayBuffer) return loose.data.byteLength;
+  if (ArrayBuffer.isView(loose.data)) return loose.data.byteLength;
+  return 0;
+}
+
+/**
+ * Every stored session, newest first. Reads CLEAR fields only, so it works
+ * before unlock and costs no decrypt.
+ */
+export async function listDiagSessions(): Promise<DiagSessionSummary[]> {
+  const database = await getDB();
+  const byId = new Map<string, DiagSessionSummary>();
+  let cursor = await database.transaction("diagnostics").store.openCursor();
+  while (cursor) {
+    const row = cursor.value;
+    const hit = byId.get(row.sessionId);
+    const bytes = sealedChunkBytes(row);
+    if (hit) {
+      hit.chunks++;
+      hit.bytes += bytes;
+      hit.startedAt = Math.min(hit.startedAt, row.startedAt);
+    } else {
+      byId.set(row.sessionId, {
+        sessionId: row.sessionId,
+        startedAt: row.startedAt,
+        chunks: 1,
+        bytes,
+      });
+    }
+    cursor = await cursor.continue();
+  }
+  return [...byId.values()].sort((a, b) => b.startedAt - a.startedAt);
+}
+
+/**
+ * Keep the newest `keepSessions` sessions, and keep the total under
+ * `maxBytes`. The oldest session goes first, whole, so a surviving session is
+ * never a partial history with an unexplained gap.
+ *
+ * @returns the number of sessions removed
+ */
+export async function pruneDiagnostics(
+  keepSessions: number,
+  maxBytes: number,
+  keepSessionId?: string
+): Promise<number> {
+  const sessions = await listDiagSessions();
+  const doomed: string[] = [];
+  let total = sessions.reduce((n, s) => n + s.bytes, 0);
+
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i];
+    if (s.sessionId === keepSessionId) continue;
+    const overCount = i >= keepSessions;
+    const overBytes = total > maxBytes;
+    if (!overCount && !overBytes) continue;
+    doomed.push(s.sessionId);
+    total -= s.bytes;
+  }
+
+  for (const sessionId of doomed) await deleteDiagSession(sessionId);
+  return doomed.length;
+}
+
+export async function deleteDiagSession(sessionId: string): Promise<void> {
+  const database = await getDB();
+  const keys = await database.getAllKeysFromIndex(
+    "diagnostics",
+    "bySession",
+    sessionId
+  );
+  const tx = database.transaction("diagnostics", "readwrite");
+  await Promise.all([...keys.map((k) => tx.store.delete(k)), tx.done]);
+}
+
+export async function deleteDiagnostics(): Promise<void> {
+  const database = await getDB();
+  await database.clear("diagnostics");
 }
 
 /**

--- a/frontend/src/lib/telemetry/bundle.test.ts
+++ b/frontend/src/lib/telemetry/bundle.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildClientBundle, trimBundleForUpload } from "./bundle";
+import { ev } from "./event";
+import {
+  beginSession,
+  initRecorder,
+  noteIdentity,
+  rec,
+  recordCounters,
+  recordSfuSnapshot,
+  recorderSnapshot,
+  refs,
+  resetRecorderForTest,
+} from "./recorder";
+import { transportEvent } from "./taps";
+import type { ClientBundle, DiagEvent, SfuSnapshot } from "./schema";
+
+const ROOM_CODE = "a1b2c3d4e5f60718";
+const DID = "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG";
+const PAYLOAD_TEXT = "the secret plan for the weekend";
+const INFO_HASH = "0123456789abcdef0123456789abcdef01234567";
+
+const CTX = {
+  version: "1.2.3",
+  commit: "abc1234",
+  ua: "Mozilla/5.0 (test)",
+  now: 1_750_000_000_000,
+  randomHex: (bytes: number) => "b".repeat(bytes * 2),
+};
+
+function sfuFixture(takenAt: number): SfuSnapshot {
+  return {
+    schemaVersion: 1,
+    takenAt,
+    roomPeerCount: 2,
+    self: {
+      peerId: "12D3KooWSELF",
+      transports: [
+        {
+          dir: "send",
+          iceState: "completed",
+          dtlsState: "connected",
+          tuple: { protocol: "udp", localPort: 40000 },
+          bytesSent: 1,
+          bytesReceived: 2,
+          rtt: 30,
+        },
+      ],
+      producers: [],
+      consumers: [],
+      cumulativeProduces: 1,
+      backpressured: false,
+    },
+    room: [],
+    ceilings: {
+      peersPerRoom: 32,
+      producersPerPeer: 8,
+      consumersPerPeer: 256,
+      rooms: 1,
+      maxRooms: 64,
+    },
+  };
+}
+
+describe("buildClientBundle", () => {
+  beforeEach(() => {
+    resetRecorderForTest();
+    initRecorder({
+      selfPeerId: () => "12D3KooWSELF",
+      runtime: () => ({
+        apiHost: "relay.example.org",
+        relayPeerId: "12D3KooWRELAY",
+        sfuHosts: ["sfu.example.org"],
+        configured: true,
+      }),
+      faultsActive: () => false,
+    });
+    beginSession("s0s0s0s0s0s0s0s0", 1_749_999_000_000);
+  });
+
+  it("never leaks a room code, a DID, a payload or an infoHash", () => {
+    // THE GATE for the whole feature. Feed the recorder every category of
+    // secret through the paths that really carry them, then assert none of the
+    // four strings survives serialization.
+    const body = transportEvent("message", [
+      "12D3KooWPEER",
+      new TextEncoder().encode(PAYLOAD_TEXT),
+      ROOM_CODE,
+    ]);
+    expect(body).not.toBeNull();
+    if (body) rec(body);
+    noteIdentity("12D3KooWPEER", DID);
+    rec(ev("file.announce", { d: { fileRef: refs().fileRef(INFO_HASH) } }));
+    rec(ev("app.msg.out", { room: refs().roomRef(ROOM_CODE), d: { bytes: 31 } }));
+
+    const json = JSON.stringify(buildClientBundle(recorderSnapshot(), CTX));
+    expect(json).not.toContain(ROOM_CODE);
+    expect(json).not.toContain(DID);
+    expect(json).not.toContain("did:key:");
+    expect(json).not.toContain(PAYLOAD_TEXT);
+    expect(json).not.toContain(INFO_HASH);
+  });
+
+  it("names the room by its bundle-local ordinal", () => {
+    rec(ev("app.join", { room: refs().roomRef(ROOM_CODE) }));
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(bundle.rooms).toHaveLength(1);
+    expect(bundle.rooms[0].ref).toBe("r1");
+    expect(bundle.rooms[0].kind).toBe("text");
+    expect(bundle.events[0].room).toBe("r1");
+  });
+
+  it("keeps full peerIds, which both servers already have", () => {
+    rec(ev("peer.connect", { peer: "12D3KooWPEER" }));
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(bundle.self.peerId).toBe("12D3KooWSELF");
+    expect(bundle.peers[0].peerId).toBe("12D3KooWPEER");
+  });
+
+  it("carries no did field at all, not even the uploader's own", () => {
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(Object.keys(bundle.self)).toEqual(["peerId"]);
+  });
+
+  it("records a host, never a URL with a path", () => {
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(bundle.config.apiHost).toBe("relay.example.org");
+    expect(bundle.config.apiHost).not.toContain("/");
+    expect(bundle.config.sfuHosts.every((h) => !h.includes("/"))).toBe(true);
+  });
+
+  it("stamps the schema version, the ids and the session window", () => {
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(bundle).toMatchObject({
+      schemaVersion: 1,
+      vantage: "client",
+      bundleId: "b".repeat(32),
+      sessionId: "s0s0s0s0s0s0s0s0",
+      createdAt: CTX.now,
+      startedAt: 1_749_999_000_000,
+      app: { version: "1.2.3", commit: "abc1234" },
+    });
+  });
+
+  it("truncates the user agent", () => {
+    const bundle = buildClientBundle(recorderSnapshot(), {
+      ...CTX,
+      ua: "u".repeat(1000),
+    });
+    expect(bundle.env.ua).toHaveLength(200);
+  });
+
+  it("reports the recorder's own losses", () => {
+    recordCounters({ "t.connects": 4 });
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(bundle.counters).toEqual({ "t.connects": 4 });
+    expect(bundle.meta).toMatchObject({
+      dropped: 0,
+      suppressed: {},
+      faultsActive: false,
+      truncated: false,
+    });
+  });
+
+  it("survives structured cloning, so it can be written to IndexedDB", () => {
+    rec(ev("session.start"));
+    recordSfuSnapshot(sfuFixture(1));
+    const bundle = buildClientBundle(recorderSnapshot(), CTX);
+    expect(structuredClone(bundle)).toEqual(bundle);
+  });
+});
+
+describe("trimBundleForUpload", () => {
+  function bundleWith(events: DiagEvent[], snapshots = 0): ClientBundle {
+    resetRecorderForTest();
+    beginSession("s", 0);
+    const base = buildClientBundle(recorderSnapshot(), CTX);
+    for (let i = 0; i < snapshots; i++) base.sfuSnapshots.push(sfuFixture(i));
+    base.events = events;
+    return base;
+  }
+
+  function eventsOfEachSeverity(perClass: number): DiagEvent[] {
+    const out: DiagEvent[] = [];
+    let seq = 1;
+    const kinds = [
+      ["peer.rtt", "debug"],
+      ["session.config", "info"],
+      ["peer.disconnect", "warn"],
+      ["peer.dial.fail", "error"],
+    ] as const;
+    for (const [kind, sev] of kinds) {
+      for (let i = 0; i < perClass; i++) {
+        out.push({
+          seq: seq++,
+          t: seq,
+          kind,
+          sev,
+          peer: null,
+          room: null,
+          d: { pad: "x".repeat(150) },
+        });
+      }
+    }
+    return out;
+  }
+
+  it("returns the bundle untouched when it already fits", () => {
+    const bundle = bundleWith(eventsOfEachSeverity(1));
+    const trimmed = trimBundleForUpload(bundle, 1_000_000);
+    expect(trimmed).toBe(bundle);
+    expect(trimmed.meta.truncated).toBe(false);
+  });
+
+  it("sacrifices debug before error and marks the bundle truncated", () => {
+    const bundle = bundleWith(eventsOfEachSeverity(20));
+    const trimmed = trimBundleForUpload(bundle, 6000);
+    expect(trimmed.meta.truncated).toBe(true);
+    expect(trimmed.events.length).toBeLessThan(bundle.events.length);
+    const kept = new Set(trimmed.events.map((e) => e.sev));
+    expect(kept.has("error")).toBe(true);
+    expect(kept.has("debug")).toBe(false);
+  });
+
+  it("drops the SFU snapshots first, since sfu.diag keeps their summary", () => {
+    const bundle = bundleWith(eventsOfEachSeverity(2), 8);
+    const before = JSON.stringify(bundle).length;
+    const trimmed = trimBundleForUpload(bundle, Math.floor(before / 2));
+    expect(trimmed.sfuSnapshots.length).toBeLessThan(8);
+    expect(trimmed.events).toHaveLength(bundle.events.length);
+  });
+
+  it("keeps the events it keeps in their original order", () => {
+    const bundle = bundleWith(eventsOfEachSeverity(20));
+    const trimmed = trimBundleForUpload(bundle, 6000);
+    const seqs = trimmed.events.map((e) => e.seq);
+    expect([...seqs].sort((a, b) => a - b)).toEqual(seqs);
+  });
+
+  it("never mutates the bundle it was given", () => {
+    const bundle = bundleWith(eventsOfEachSeverity(20), 4);
+    const originalCount = bundle.events.length;
+    trimBundleForUpload(bundle, 4000);
+    expect(bundle.events).toHaveLength(originalCount);
+    expect(bundle.sfuSnapshots).toHaveLength(4);
+    expect(bundle.meta.truncated).toBe(false);
+  });
+
+  it("gives up gracefully when even an empty event list does not fit", () => {
+    const bundle = bundleWith(eventsOfEachSeverity(4));
+    const trimmed = trimBundleForUpload(bundle, 1);
+    expect(trimmed.events).toEqual([]);
+    expect(trimmed.meta.truncated).toBe(true);
+  });
+});

--- a/frontend/src/lib/telemetry/bundle.ts
+++ b/frontend/src/lib/telemetry/bundle.ts
@@ -1,0 +1,129 @@
+/**
+ * Bundle assembly. The bundle is the ONLY artifact that leaves the tab, so
+ * this module and `redact.ts` are the two files a privacy review must read.
+ *
+ * `bundle.test.ts` holds the gate for the whole feature: it feeds a recorder a
+ * real room code, a real `did:key:`, a chat payload and an infoHash, and
+ * asserts that none of the four strings survives into `JSON.stringify` of the
+ * result.
+ */
+
+import type { ClientBundle, DiagEvent, DiagSeverity } from "./schema";
+import { DIAG_SCHEMA_VERSION } from "./schema";
+import type { RecorderSnapshot } from "./recorder";
+import { MAX_DETAIL_STRING } from "./event";
+
+/**
+ * What only the caller knows.
+ *
+ * Everything else - the peerId, the runtime config, the fault flag - comes from
+ * the `RecorderSnapshot`, deliberately: two sources for one field is how a
+ * bundle ends up disagreeing with the events inside it.
+ */
+export interface BundleContext {
+  /** `__APP_VERSION__`. A vite define, so it is not readable from a test. */
+  version: string;
+  /** `__APP_COMMIT__`. */
+  commit: string;
+  /** `navigator.userAgent`, truncated here. */
+  ua: string;
+  /** Wall clock ms at export. */
+  now: number;
+  randomHex(bytes: number): string;
+}
+
+export function buildClientBundle(
+  snap: RecorderSnapshot,
+  ctx: BundleContext
+): ClientBundle {
+  return {
+    schemaVersion: DIAG_SCHEMA_VERSION,
+    bundleId: ctx.randomHex(16),
+    sessionId: snap.sessionId,
+    createdAt: ctx.now,
+    startedAt: snap.startedAt,
+    vantage: "client",
+    app: { version: ctx.version, commit: ctx.commit },
+    env: { ua: ctx.ua.slice(0, MAX_DETAIL_STRING) },
+    config: { ...snap.runtime, sfuHosts: [...snap.runtime.sfuHosts] },
+    self: { peerId: snap.selfPeerId },
+    rooms: snap.rooms.map((r) => ({ ...r })),
+    peers: snap.peers.map((p) => ({ ...p })),
+    counters: { ...snap.counters },
+    events: snap.events,
+    sfuSnapshots: snap.sfuSnapshots,
+    meta: {
+      ringCapacity: snap.ringCapacity,
+      dropped: snap.dropped,
+      suppressed: { ...snap.suppressed },
+      faultsActive: snap.faultsActive,
+      truncated: false,
+    },
+  };
+}
+
+/** The order in which insight is sacrificed. An error is never lost first. */
+const SACRIFICE_ORDER: readonly DiagSeverity[] = ["debug", "info", "warn", "error"];
+
+/**
+ * Shrink a bundle to fit an upload.
+ *
+ * The SFU snapshots go first: each one is kilobytes, and its summary already
+ * rides an `sfu.diag` event that stays. Events then go by severity class,
+ * oldest first inside a class, so a `debug` sample is always lost before an
+ * `error`.
+ *
+ * `maxBytes` is measured against `JSON.stringify` length, which is a character
+ * count. That under-counts a multi-byte character, so the caller must leave
+ * headroom below the collector's real byte limit.
+ */
+export function trimBundleForUpload(
+  b: ClientBundle,
+  maxBytes: number
+): ClientBundle {
+  if (JSON.stringify(b).length <= maxBytes) return b;
+
+  const out: ClientBundle = {
+    ...b,
+    sfuSnapshots: [...b.sfuSnapshots],
+    events: [...b.events],
+    meta: { ...b.meta, truncated: true },
+  };
+
+  while (out.sfuSnapshots.length > 0) {
+    out.sfuSnapshots.shift();
+    if (JSON.stringify(out).length <= maxBytes) return out;
+  }
+
+  // Index the events once, in sacrifice order. Re-sorting or re-filtering per
+  // removal would be quadratic on a 4096-event ring.
+  const doomed: number[] = [];
+  for (const sev of SACRIFICE_ORDER) {
+    for (let i = 0; i < out.events.length; i++) {
+      if (out.events[i].sev === sev) doomed.push(i);
+    }
+  }
+
+  // Remove in shrinking batches. One `JSON.stringify` per batch, not per
+  // event: a full measurement of a large bundle is the expensive part.
+  const keep = new Set<number>(out.events.map((_, i) => i));
+  let cut = 0;
+  while (cut < doomed.length) {
+    const batch = Math.max(1, Math.ceil((doomed.length - cut) / 8));
+    for (let i = 0; i < batch && cut < doomed.length; i++, cut++) {
+      keep.delete(doomed[cut]);
+    }
+    out.events = pick(b.events, keep);
+    if (JSON.stringify(out).length <= maxBytes) return out;
+  }
+
+  return out;
+}
+
+function pick(events: DiagEvent[], keep: Set<number>): DiagEvent[] {
+  const out: DiagEvent[] = [];
+  for (let i = 0; i < events.length; i++) {
+    if (keep.has(i)) out.push(events[i]);
+  }
+  return out;
+}

--- a/frontend/src/lib/telemetry/event.test.ts
+++ b/frontend/src/lib/telemetry/event.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { errText, ev, MAX_DETAIL_KEYS, MAX_DETAIL_STRING } from "./event";
+
+describe("ev", () => {
+  it("resolves the default severity from the kind", () => {
+    expect(ev("relay.dial.fail").sev).toBe("error");
+    expect(ev("peer.rtt").sev).toBe("debug");
+    expect(ev("session.start").sev).toBe("info");
+  });
+
+  it("lets a caller override the severity", () => {
+    expect(ev("session.config", { sev: "warn" }).sev).toBe("warn");
+  });
+
+  it("defaults peer and room to null, never undefined", () => {
+    // A `DiagEvent` with `peer: undefined` loses the field through
+    // `JSON.stringify`, and the dashboard distinguishes "not about a peer"
+    // from "unknown peer".
+    expect(ev("session.start")).toEqual({
+      kind: "session.start",
+      sev: "info",
+      peer: null,
+      room: null,
+    });
+  });
+
+  it("truncates a long string to exactly the limit", () => {
+    const e = ev("session.config", { d: { s: "x".repeat(1000) } });
+    expect((e.d?.s as string).length).toBe(MAX_DETAIL_STRING);
+  });
+
+  it("drops keys past the detail limit in insertion order", () => {
+    const d: Record<string, number> = {};
+    for (let i = 1; i <= 20; i++) d[`k${i}`] = i;
+    const e = ev("counters", { d });
+    expect(Object.keys(e.d ?? {})).toHaveLength(MAX_DETAIL_KEYS);
+    expect(e.d?.k1).toBe(1);
+    expect(e.d?.k13).toBeUndefined();
+  });
+
+  it("drops an empty detail bag entirely", () => {
+    expect(ev("session.start", { d: {} }).d).toBeUndefined();
+    expect(ev("session.start", { d: { gone: undefined } }).d).toBeUndefined();
+  });
+
+  it("replaces a non-finite number with null rather than losing the key", () => {
+    const e = ev("peer.rtt", { d: { a: NaN, b: Infinity, c: -0 } });
+    expect(e.d).toEqual({ a: null, b: null, c: -0 });
+  });
+
+  it("never throws for a circular object", () => {
+    const circular: Record<string, unknown> = { name: "loop" };
+    circular.self = circular;
+    const e = ev("session.config", { d: { circular } });
+    expect(e.d?.circular).toBe("[object Object]");
+  });
+
+  it("never throws for a Symbol, a BigInt or a function", () => {
+    const e = ev("session.config", {
+      d: { sym: Symbol("s"), big: 10n, fn: () => 1 },
+    });
+    expect(e.d?.sym).toBe("[object Symbol]");
+    expect(e.d?.big).toBe("[object BigInt]");
+    expect(e.d?.fn).toBe("[object Function]");
+  });
+
+  it("never throws for a Proxy that throws on get", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("no");
+        },
+        ownKeys() {
+          throw new Error("no");
+        },
+      }
+    );
+    const e = ev("session.config", { d: hostile as Record<string, unknown> });
+    expect(e.kind).toBe("session.config");
+  });
+
+  it("never throws when a getter on the detail bag throws", () => {
+    const d = {
+      get boom(): string {
+        throw new Error("no");
+      },
+      fine: 1,
+    };
+    const e = ev("session.config", { d });
+    expect(e.d?.fine).toBe(1);
+    expect(e.d?.boom).toBeNull();
+  });
+
+  it("keeps a 1 MB string bounded", () => {
+    const e = ev("session.config", { d: { s: "y".repeat(1024 * 1024) } });
+    expect((e.d?.s as string).length).toBe(MAX_DETAIL_STRING);
+  });
+});
+
+describe("errText", () => {
+  it("names an Error without its stack", () => {
+    const err = new TypeError("bad thing");
+    expect(errText(err)).toBe("TypeError: bad thing");
+    expect(errText(err)).not.toContain("at ");
+  });
+
+  it("stringifies a non-Error", () => {
+    expect(errText("plain")).toBe("plain");
+    expect(errText(undefined)).toBe("undefined");
+  });
+
+  it("truncates a huge message", () => {
+    expect(errText(new Error("z".repeat(5000))).length).toBe(MAX_DETAIL_STRING);
+  });
+
+  it("survives an object whose toString throws", () => {
+    const hostile = {
+      toString() {
+        throw new Error("no");
+      },
+    };
+    expect(errText(hostile)).toBe("unknown");
+  });
+});

--- a/frontend/src/lib/telemetry/event.ts
+++ b/frontend/src/lib/telemetry/event.ts
@@ -1,0 +1,111 @@
+/**
+ * The only place a `DiagEvent` is constructed, which makes it the only place
+ * the redaction contract can be violated. Read `schema.ts`'s header before
+ * changing anything here.
+ *
+ * `ev` MUST NOT throw for ANY input. It is called from inside `catch` blocks,
+ * from event emitters and from a `finally`, so a throw here would turn a
+ * diagnosable bug into an undiagnosable one.
+ */
+
+import {
+  KIND_SEV,
+  type DiagEvent,
+  type DiagKind,
+  type DiagSeverity,
+} from "./schema";
+
+export const MAX_DETAIL_KEYS = 12;
+export const MAX_DETAIL_STRING = 200;
+
+type DetailValue = string | number | boolean | null;
+
+/**
+ * Coerce one detail value to a JSON primitive.
+ *
+ * `JSON.stringify` is deliberately NOT used: a circular object throws, a
+ * getter can throw, and a `BigInt` throws. `Object.prototype.toString.call`
+ * cannot throw for any value.
+ */
+function coerce(v: unknown): DetailValue | undefined {
+  if (v === null) return null;
+  if (v === undefined) return undefined;
+  const t = typeof v;
+  if (t === "string") return (v as string).slice(0, MAX_DETAIL_STRING);
+  if (t === "number") return Number.isFinite(v as number) ? (v as number) : null;
+  if (t === "boolean") return v as boolean;
+  try {
+    return Object.prototype.toString.call(v).slice(0, MAX_DETAIL_STRING);
+  } catch {
+    // A Proxy can throw from a trap even here.
+    return null;
+  }
+}
+
+/**
+ * Build an event body. `seq` and `t` are assigned by the ring, so a caller
+ * cannot forge an ordering.
+ */
+export function ev(
+  kind: DiagKind,
+  opts?: {
+    peer?: string | null;
+    room?: string | null;
+    sev?: DiagSeverity;
+    d?: Record<string, unknown>;
+  }
+): Omit<DiagEvent, "seq" | "t"> {
+  let peer: string | null = null;
+  let room: string | null = null;
+  let sev: DiagSeverity = KIND_SEV[kind] ?? "info";
+  let d: Record<string, DetailValue> | undefined;
+
+  try {
+    if (opts) {
+      if (typeof opts.peer === "string") peer = opts.peer;
+      if (typeof opts.room === "string") room = opts.room;
+      if (opts.sev) sev = opts.sev;
+      if (opts.d) {
+        const out: Record<string, DetailValue> = {};
+        let n = 0;
+        for (const key in opts.d) {
+          if (n >= MAX_DETAIL_KEYS) break;
+          let raw: unknown;
+          try {
+            raw = opts.d[key];
+          } catch {
+            // A getter or a Proxy trap threw.
+            raw = null;
+          }
+          const value = coerce(raw);
+          if (value === undefined) continue;
+          out[key.slice(0, MAX_DETAIL_STRING)] = value;
+          n++;
+        }
+        if (n > 0) d = out;
+      }
+    }
+  } catch {
+    // Iterating a hostile object failed. Keep the event, lose the detail.
+  }
+
+  return d ? { kind, sev, peer, room, d } : { kind, sev, peer, room };
+}
+
+/**
+ * A one-line, bounded description of a thrown value.
+ *
+ * NEVER a stack: a stack carries local filesystem paths and, in a bundled
+ * build, source-map hints about the user's own machine.
+ */
+export function errText(err: unknown): string {
+  try {
+    if (err instanceof Error) {
+      return `${err.name}: ${err.message}`.slice(0, MAX_DETAIL_STRING);
+    }
+    return String(err).slice(0, MAX_DETAIL_STRING);
+  } catch {
+    // `String()` calls `toString`, which a hostile object can override.
+    return "unknown";
+  }
+}

--- a/frontend/src/lib/telemetry/net-probe.test.ts
+++ b/frontend/src/lib/telemetry/net-probe.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { probeTurnAllocation, turnOnly } from "./net-probe";
+
+const TURN: RTCIceServer = {
+  urls: ["turn:turn.example:3478?transport=udp", "stun:turn.example:3478"],
+  username: "u",
+  credential: "c",
+};
+const STUN: RTCIceServer = { urls: "stun:stun.example:19302" };
+
+/** A peer connection that gathers exactly what the case asks it to. */
+function fakePc(script: {
+  candidates?: Array<{ candidate: string; type?: string }>;
+  gathered?: boolean;
+}) {
+  const pc = {
+    onicecandidate: null as null | ((e: unknown) => void),
+    onicegatheringstatechange: null as null | (() => void),
+    iceGatheringState: "gathering",
+    closed: false,
+    createDataChannel: vi.fn(),
+    createOffer: vi.fn(async () => ({ type: "offer", sdp: "v=0" })),
+    setLocalDescription: vi.fn(async () => {
+      // Gathering starts after the local description, as in a real browser.
+      queueMicrotask(() => {
+        for (const c of script.candidates ?? []) {
+          pc.onicecandidate?.({ candidate: c });
+        }
+        if (script.gathered) {
+          pc.iceGatheringState = "complete";
+          pc.onicegatheringstatechange?.();
+        }
+      });
+    }),
+    close: vi.fn(() => {
+      pc.closed = true;
+    }),
+  };
+  return pc;
+}
+
+describe("turnOnly", () => {
+  it("keeps only credentialled TURN urls", () => {
+    expect(turnOnly([TURN, STUN])).toEqual([
+      { urls: ["turn:turn.example:3478?transport=udp"], username: "u", credential: "c" },
+    ]);
+  });
+
+  it("drops a TURN entry with no credential - it can never allocate", () => {
+    expect(turnOnly([{ urls: "turn:turn.example:3478" }])).toEqual([]);
+  });
+});
+
+describe("probeTurnAllocation", () => {
+  it("passes when a relay candidate is gathered", async () => {
+    const pc = fakePc({
+      candidates: [{ candidate: "candidate:1 1 udp 1 1.2.3.4 1 typ relay", type: "relay" }],
+    });
+    const res = await probeTurnAllocation([TURN], { createPc: () => pc as never });
+    expect(res).toMatchObject({ ok: true, outcome: "candidate", relayCandidates: 1 });
+    // The probe must not add to the very budget it helps diagnose.
+    expect(pc.close).toHaveBeenCalled();
+  });
+
+  it("fails when gathering completes with nothing", async () => {
+    // The verdict that matters: credentials were fine, the network is not.
+    const pc = fakePc({ gathered: true });
+    const res = await probeTurnAllocation([TURN], { createPc: () => pc as never });
+    expect(res).toMatchObject({ ok: false, outcome: "gathered-none", relayCandidates: 0 });
+    expect(pc.close).toHaveBeenCalled();
+  });
+
+  it("fails on the clock when nothing is ever gathered", async () => {
+    const pc = fakePc({});
+    const res = await probeTurnAllocation([TURN], {
+      createPc: () => pc as never,
+      timeoutMs: 10,
+    });
+    expect(res).toMatchObject({ ok: false, outcome: "timeout" });
+  });
+
+  it("refuses to call a host candidate a passing TURN probe", async () => {
+    // A browser that ignores iceTransportPolicy would otherwise turn a local
+    // candidate into proof that a TURN server answered.
+    const pc = fakePc({
+      candidates: [{ candidate: "candidate:1 1 udp 1 192.168.0.2 1 typ host", type: "host" }],
+      gathered: true,
+    });
+    const res = await probeTurnAllocation([TURN], { createPc: () => pc as never });
+    expect(res).toMatchObject({ ok: false, outcome: "gathered-none" });
+  });
+
+  it("says nothing when there is no TURN to ask", async () => {
+    // Not a failure: the credential path already reports a missing
+    // credential, and reporting it twice double-counts it in every rule.
+    expect(await probeTurnAllocation([STUN], { createPc: () => fakePc({}) as never })).toBeNull();
+  });
+
+  it("reports a throw instead of propagating it", async () => {
+    const res = await probeTurnAllocation([TURN], {
+      createPc: () => {
+        throw new Error("no webrtc");
+      },
+    });
+    expect(res).toMatchObject({ ok: false, outcome: "threw" });
+    expect(String(res?.err)).toContain("no webrtc");
+  });
+});

--- a/frontend/src/lib/telemetry/net-probe.ts
+++ b/frontend/src/lib/telemetry/net-probe.ts
@@ -1,0 +1,145 @@
+/**
+ * Ground truth about the network, measured OUTSIDE the app's own machinery.
+ *
+ * Every other probe in this bundle observes the app observing the network, so
+ * every one of them fails in the same two ways at once: "no candidate pair
+ * succeeded" is what a broken ICE path looks like AND what a bug that never
+ * applied its ICE servers looks like. Nothing already recorded can separate
+ * them, and that is the whole of the question a user asks when a call fails:
+ * is it my internet or is it the app.
+ *
+ * A TURN allocation is the one measurement that answers it. It uses nothing
+ * from the transport layer - no libp2p, no mediasoup, no signalling, no peer -
+ * so its verdict is independent of every bug those can have. With
+ * `iceTransportPolicy: "relay"` the browser gathers relay candidates and
+ * NOTHING else, which makes the outcome unambiguous: a relay candidate means
+ * the TURN server accepted an allocation from this network right now; zero
+ * candidates at gathering-complete means it did not.
+ */
+
+/** How long an allocation may take before the network is the answer. */
+export const TURN_PROBE_TIMEOUT_MS = 5000;
+
+export interface TurnProbeResult {
+  ok: boolean;
+  /** Wall time until the verdict. */
+  ms: number;
+  /** Relay candidates gathered. Zero with `ok: false` is the useful case. */
+  relayCandidates: number;
+  /** Why it ended: a gathered candidate, an empty gathering, or the clock. */
+  outcome: "candidate" | "gathered-none" | "timeout" | "threw";
+  err?: string;
+}
+
+type PcFactory = (config: RTCConfiguration) => RTCPeerConnection;
+
+/** Only entries that can actually allocate: a TURN url with a credential. */
+export function turnOnly(servers: readonly RTCIceServer[]): RTCIceServer[] {
+  const out: RTCIceServer[] = [];
+  for (const s of servers) {
+    const urls = typeof s.urls === "string" ? [s.urls] : (s.urls ?? []);
+    const turn = urls.filter((u) => /^turns?:/i.test(u));
+    if (turn.length === 0) continue;
+    if (typeof s.username !== "string" || typeof s.credential !== "string") {
+      continue;
+    }
+    out.push({ ...s, urls: turn });
+  }
+  return out;
+}
+
+/**
+ * Ask the TURN server for an allocation and time it.
+ *
+ * Returns null when there is nothing to ask - no credentialled TURN entry, or
+ * no WebRTC at all. That is not a failure: the credential path reports a
+ * missing credential itself, and reporting it twice would double-count it in
+ * every rule that reads these events.
+ */
+export async function probeTurnAllocation(
+  servers: readonly RTCIceServer[],
+  opts: {
+    createPc?: PcFactory;
+    timeoutMs?: number;
+    now?: () => number;
+  } = {}
+): Promise<TurnProbeResult | null> {
+  const iceServers = turnOnly(servers);
+  if (iceServers.length === 0) return null;
+
+  const g = globalThis as unknown as { RTCPeerConnection?: PcFactory };
+  const create =
+    opts.createPc ??
+    (typeof g.RTCPeerConnection === "function"
+      ? (config: RTCConfiguration) =>
+          new (g.RTCPeerConnection as unknown as new (
+            c: RTCConfiguration
+          ) => RTCPeerConnection)(config)
+      : null);
+  if (!create) return null;
+
+  const now = opts.now ?? (() => Date.now());
+  const timeoutMs = opts.timeoutMs ?? TURN_PROBE_TIMEOUT_MS;
+  const startedAt = now();
+  let pc: RTCPeerConnection | null = null;
+  let relayCandidates = 0;
+
+  try {
+    pc = create({ iceServers, iceTransportPolicy: "relay" });
+    const settled = new Promise<TurnProbeResult["outcome"]>((resolve) => {
+      const timer = setTimeout(() => resolve("timeout"), timeoutMs);
+      const done = (outcome: TurnProbeResult["outcome"]) => {
+        clearTimeout(timer);
+        resolve(outcome);
+      };
+      pc!.onicecandidate = ({ candidate }) => {
+        // The end-of-candidates signal, not a candidate.
+        if (!candidate || !candidate.candidate) {
+          done(relayCandidates > 0 ? "candidate" : "gathered-none");
+          return;
+        }
+        // With a relay-only policy every candidate IS a relay candidate, but
+        // read the type rather than trust the policy: a browser that ignores
+        // the policy would otherwise turn a host candidate into a passing
+        // TURN probe, which is the one wrong answer that matters here.
+        if (candidate.type === "relay" || / typ relay /.test(candidate.candidate)) {
+          relayCandidates++;
+          done("candidate");
+        }
+      };
+      pc!.onicegatheringstatechange = () => {
+        if (pc?.iceGatheringState !== "complete") return;
+        done(relayCandidates > 0 ? "candidate" : "gathered-none");
+      };
+    });
+
+    // A data channel is what gives the offer something to gather for; no
+    // media, no getUserMedia, no permission prompt.
+    pc.createDataChannel("turn-probe");
+    await pc.setLocalDescription(await pc.createOffer());
+
+    const outcome = await settled;
+    return {
+      ok: outcome === "candidate",
+      ms: now() - startedAt,
+      relayCandidates,
+      outcome,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      ms: now() - startedAt,
+      relayCandidates,
+      outcome: "threw",
+      err: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+    };
+  } finally {
+    // The probe must never be the thing that exhausts the connection budget
+    // it exists to help diagnose.
+    try {
+      pc?.close();
+    } catch {
+      // Nothing left to do about it.
+    }
+  }
+}

--- a/frontend/src/lib/telemetry/pc-census.test.ts
+++ b/frontend/src/lib/telemetry/pc-census.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { installPcCensus, pcCensus, uninstallPcCensus } from "./pc-census";
+
+/** The smallest thing that can stand in for the global: jsdom has none. */
+class FakePc {
+  connectionState = "new";
+  closed = false;
+  #listeners: Array<() => void> = [];
+  constructor(public config?: unknown) {}
+  addEventListener(_type: string, fn: () => void): void {
+    this.#listeners.push(fn);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  /** Drive the path where the BROWSER closes a connection we did not. */
+  browserClosed(): void {
+    this.connectionState = "closed";
+    for (const fn of this.#listeners) fn();
+  }
+}
+
+type G = { RTCPeerConnection?: unknown };
+
+function withFakeGlobal(): void {
+  (globalThis as G).RTCPeerConnection = FakePc;
+  installPcCensus();
+}
+
+afterEach(() => {
+  uninstallPcCensus();
+  delete (globalThis as G).RTCPeerConnection;
+});
+
+describe("pc census", () => {
+  it("counts what is open, not what was made", () => {
+    withFakeGlobal();
+    const Ctor = (globalThis as G).RTCPeerConnection as new () => {
+      close(): void;
+    };
+
+    const a = new Ctor();
+    const b = new Ctor();
+    expect(pcCensus()).toMatchObject({ live: 2, created: 2, peak: 2 });
+
+    a.close();
+    // The leak this exists to catch: `created` and `peak` remember the two,
+    // `live` reports the one still holding a slot in the browser's budget.
+    expect(pcCensus()).toMatchObject({ live: 1, created: 2, peak: 2 });
+    b.close();
+    expect(pcCensus().live).toBe(0);
+  });
+
+  it("decrements once, however many times close is called", () => {
+    withFakeGlobal();
+    const Ctor = (globalThis as G).RTCPeerConnection as new () => {
+      close(): void;
+    };
+    const pc = new Ctor();
+    pc.close();
+    pc.close();
+    pc.close();
+    // A double decrement would read as negative live connections, which is
+    // worse than no gauge at all - it hides a real leak.
+    expect(pcCensus().live).toBe(0);
+  });
+
+  it("notices a connection the browser closed on its own", () => {
+    withFakeGlobal();
+    const Ctor = (globalThis as G).RTCPeerConnection as new () => FakePc;
+    const pc = new Ctor();
+    expect(pcCensus().live).toBe(1);
+    pc.browserClosed();
+    expect(pcCensus().live).toBe(0);
+  });
+
+  it("still constructs a working connection, and stays an instanceof", () => {
+    withFakeGlobal();
+    const Ctor = (globalThis as G).RTCPeerConnection as new (
+      c?: unknown
+    ) => FakePc;
+    const pc = new Ctor({ iceServers: [] });
+    // The wrapper must be invisible to every consumer: libp2p, webtorrent and
+    // mediasoup-client all hold these and one behavioural difference would be
+    // a telemetry feature breaking the app it measures.
+    expect(pc).toBeInstanceOf(FakePc);
+    expect(pc.config).toEqual({ iceServers: [] });
+    pc.close();
+    expect(pc.closed).toBe(true);
+  });
+
+  it("is a no-op where there is no WebRTC at all", () => {
+    delete (globalThis as G).RTCPeerConnection;
+    installPcCensus();
+    expect(pcCensus().installed).toBe(false);
+  });
+});

--- a/frontend/src/lib/telemetry/pc-census.ts
+++ b/frontend/src/lib/telemetry/pc-census.ts
@@ -1,0 +1,116 @@
+/**
+ * How many `RTCPeerConnection`s this tab is holding open, right now.
+ *
+ * Chrome refuses the 500th with "Cannot create so many PeerConnections", and
+ * a tab that reaches it loses EVERYTHING at once - voice, the SFU transports
+ * and libp2p's own WebRTC dials all fail on the same line, so the first
+ * symptom is never the cause. Nothing in the platform reports this number,
+ * and no per-module counter can: the connections come from four independent
+ * places (voice, mediasoup, libp2p, webtorrent) and three of them are inside
+ * dependencies. The only vantage that sees all four is the constructor.
+ *
+ * So this wraps the global. That is a real cost and it is deliberate:
+ *
+ *   - The wrapper is a SUBCLASS, so `instanceof RTCPeerConnection` still
+ *     holds and every method, property and event behaves as before.
+ *   - It adds nothing to the instance except a private "already counted"
+ *     flag, and it never inspects arguments, SDP or candidates.
+ *   - It cannot throw into the caller: the count is updated inside a
+ *     try/catch, and `close()` calls `super.close()` first.
+ *
+ * `live` counts what the BROWSER counts, which is not what is reachable: a
+ * connection dropped without `close()` keeps its slot until it is collected,
+ * and that is precisely the leak worth seeing. Only an explicit `close()` (or
+ * the browser closing it itself) decrements.
+ */
+
+type PcCtor = typeof RTCPeerConnection;
+
+interface Census {
+  /** Open now: constructed and not yet closed. */
+  live: number;
+  /** Constructed since boot. A rebuild loop shows up here first. */
+  created: number;
+  /** The high-water mark of `live`. */
+  peak: number;
+  /** Whether the wrapper is in place; false in a context with no WebRTC. */
+  installed: boolean;
+}
+
+let live = 0;
+let created = 0;
+let peak = 0;
+let installed = false;
+let native: PcCtor | null = null;
+
+export function installPcCensus(): void {
+  if (installed) return;
+  const g = globalThis as unknown as { RTCPeerConnection?: PcCtor };
+  const Native = g.RTCPeerConnection;
+  // No WebRTC here at all: a test environment, or a browser that has it
+  // disabled. Everything below stays a no-op and the gauge reads zero.
+  if (typeof Native !== "function") return;
+
+  class CountedPeerConnection extends Native {
+    /** Guards the decrement: close() and the state change can both fire. */
+    #counted = false;
+
+    constructor(...args: ConstructorParameters<PcCtor>) {
+      super(...args);
+      try {
+        this.#counted = true;
+        created++;
+        live++;
+        if (live > peak) peak = live;
+        // Covers the connections the browser closes on its own - a worker
+        // teardown, a crashed process - which never reach close() below.
+        this.addEventListener("connectionstatechange", () => {
+          if (this.connectionState === "closed") this.#uncount();
+        });
+      } catch {
+        // Counting must never break a connection the app needs.
+      }
+    }
+
+    #uncount(): void {
+      if (!this.#counted) return;
+      this.#counted = false;
+      live--;
+    }
+
+    close(): void {
+      // The app's close comes first, always: if the count threw, the
+      // connection would still have been closed.
+      try {
+        super.close();
+      } finally {
+        try {
+          this.#uncount();
+        } catch {
+          // As above.
+        }
+      }
+    }
+  }
+
+  native = Native;
+  g.RTCPeerConnection = CountedPeerConnection as unknown as PcCtor;
+  installed = true;
+}
+
+/** The current gauge. Safe to call at any time, including before install. */
+export function pcCensus(): Census {
+  return { live, created, peak, installed };
+}
+
+/** Restore the untouched global. For tests, and for a clean teardown. */
+export function uninstallPcCensus(): void {
+  if (!installed || !native) return;
+  (globalThis as unknown as { RTCPeerConnection?: PcCtor }).RTCPeerConnection =
+    native;
+  native = null;
+  installed = false;
+  live = 0;
+  created = 0;
+  peak = 0;
+}

--- a/frontend/src/lib/telemetry/prefs.svelte.ts
+++ b/frontend/src/lib/telemetry/prefs.svelte.ts
@@ -1,0 +1,69 @@
+/**
+ * Diagnostic preferences. Device-local, like `display-prefs`.
+ *
+ * Neither switch controls the RECORDER. The flight recorder is always on, in
+ * memory, from boot, because a bug is over by the time anyone thinks to flip a
+ * switch. These two switches gate the two EXITS from the tab:
+ *
+ * - `persist` - write sealed chunks to IndexedDB, so a crash or a reload keeps
+ *   the history.
+ * - `upload` - allow a bundle to reach this instance's collector. That is a
+ *   real disclosure change: the relay gains ICE states, timings, counters and
+ *   error codes it did not have. See `docs/spec.md` "Server Privacy".
+ *
+ * Its own module rather than a lodger in `display-prefs.svelte.ts`: that module
+ * pulls in `chat-font`, and a diagnostic switch must not drag a font stack into
+ * every importer.
+ */
+
+const PERSIST_KEY = "awful:diag-persist:v1";
+const UPLOAD_KEY = "awful:diag-upload:v1";
+
+// Copied, not imported, from display-prefs for the reason in the header, with
+// one addition: node 25 defines a `localStorage` global that throws unless the
+// process was started with `--localstorage-file`, so a `typeof` test is not
+// enough on its own.
+function readStored(key: string, defaultValue: boolean): boolean {
+  try {
+    if (typeof localStorage === "undefined") return defaultValue;
+    const v = localStorage.getItem(key);
+    return v === null ? defaultValue : v === "1";
+  } catch {
+    return defaultValue;
+  }
+}
+
+export const diagPrefs = $state({
+  /** Keep the diagnostic ring across reloads and crashes, sealed on disk. */
+  persist: readStored(PERSIST_KEY, false),
+  /** Allow an upload of a bundle to this instance's collector. */
+  upload: readStored(UPLOAD_KEY, false),
+});
+
+export function setDiagPersist(on: boolean): void {
+  diagPrefs.persist = on;
+  try {
+    localStorage.setItem(PERSIST_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
+export function setDiagUpload(on: boolean): void {
+  diagPrefs.upload = on;
+  try {
+    localStorage.setItem(UPLOAD_KEY, on ? "1" : "0");
+  } catch {
+    // Storage blocked: the choice just does not survive a reload.
+  }
+}
+
+// A second tab flipping a switch should be reflected here, not fought. Both
+// keys are listed: `display-prefs.svelte.ts:179-181` records the bug that one
+// forgotten key causes.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === PERSIST_KEY) diagPrefs.persist = e.newValue === "1";
+    if (e.key === UPLOAD_KEY) diagPrefs.upload = e.newValue === "1";
+  });
+}

--- a/frontend/src/lib/telemetry/prefs.test.ts
+++ b/frontend/src/lib/telemetry/prefs.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type * as PrefsModule from "./prefs.svelte";
+
+// Node has no localStorage and no window; the module reads both defensively.
+// Both stubs must exist BEFORE the import, because the `$state` initializer
+// reads storage and the cross-tab listener registers at import time.
+const store = new Map<string, string>();
+let storageHandler: ((e: { key: string; newValue: string | null }) => void) | null =
+  null;
+
+beforeEach(() => {
+  store.clear();
+  storageHandler = null;
+  (globalThis as Record<string, unknown>).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  };
+  (globalThis as Record<string, unknown>).window = {
+    addEventListener: (
+      type: string,
+      handler: (e: { key: string; newValue: string | null }) => void
+    ) => {
+      if (type === "storage") storageHandler = handler;
+    },
+  };
+});
+
+async function freshModule(): Promise<typeof PrefsModule> {
+  // A new module registry per test, so the `$state` initializer re-reads the
+  // stub above rather than a value cached by an earlier test.
+  vi.resetModules();
+  return import("./prefs.svelte");
+}
+
+describe("diagPrefs", () => {
+  it("defaults both exits to off, so a fresh install discloses nothing", async () => {
+    // The recorder is always on in memory. These two gate disk and network.
+    const { diagPrefs } = await freshModule();
+    expect(diagPrefs.persist).toBe(false);
+    expect(diagPrefs.upload).toBe(false);
+  });
+
+  it("reads a stored choice", async () => {
+    store.set("awful:diag-persist:v1", "1");
+    store.set("awful:diag-upload:v1", "1");
+    const { diagPrefs } = await freshModule();
+    expect(diagPrefs.persist).toBe(true);
+    expect(diagPrefs.upload).toBe(true);
+  });
+
+  it("persists each setter under its own key", async () => {
+    const { diagPrefs, setDiagPersist, setDiagUpload } = await freshModule();
+    setDiagPersist(true);
+    expect(diagPrefs.persist).toBe(true);
+    expect(store.get("awful:diag-persist:v1")).toBe("1");
+    setDiagUpload(true);
+    expect(store.get("awful:diag-upload:v1")).toBe("1");
+    setDiagPersist(false);
+    expect(store.get("awful:diag-persist:v1")).toBe("0");
+  });
+
+  it("survives blocked storage", async () => {
+    const { setDiagPersist, diagPrefs } = await freshModule();
+    (globalThis as Record<string, unknown>).localStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(() => setDiagPersist(true)).not.toThrow();
+    expect(diagPrefs.persist).toBe(true);
+  });
+
+  it("follows both keys across tabs", async () => {
+    const { diagPrefs } = await freshModule();
+    expect(storageHandler).not.toBeNull();
+    storageHandler?.({ key: "awful:diag-persist:v1", newValue: "1" });
+    storageHandler?.({ key: "awful:diag-upload:v1", newValue: "1" });
+    expect(diagPrefs.persist).toBe(true);
+    expect(diagPrefs.upload).toBe(true);
+    storageHandler?.({ key: "awful:diag-upload:v1", newValue: null });
+    expect(diagPrefs.upload).toBe(false);
+    expect(diagPrefs.persist).toBe(true);
+  });
+
+  it("ignores an unrelated key", async () => {
+    const { diagPrefs } = await freshModule();
+    storageHandler?.({ key: "awful:italic-own-name:v1", newValue: "1" });
+    expect(diagPrefs.persist).toBe(false);
+    expect(diagPrefs.upload).toBe(false);
+  });
+});

--- a/frontend/src/lib/telemetry/recorder.test.ts
+++ b/frontend/src/lib/telemetry/recorder.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ev } from "./event";
+import {
+  beginSession,
+  initRecorder,
+  noteIdentity,
+  rec,
+  recordCounters,
+  recordSfuSnapshot,
+  recorderSnapshot,
+  refs,
+  resetRecorderForTest,
+} from "./recorder";
+import type { SfuSnapshot } from "./schema";
+
+function snapshotFixture(takenAt: number): SfuSnapshot {
+  return {
+    schemaVersion: 1,
+    takenAt,
+    roomPeerCount: 2,
+    self: {
+      peerId: "p1",
+      transports: [],
+      producers: [],
+      consumers: [],
+      cumulativeProduces: 0,
+      backpressured: false,
+    },
+    room: [],
+    ceilings: {
+      peersPerRoom: 32,
+      producersPerPeer: 8,
+      consumersPerPeer: 256,
+      rooms: 1,
+      maxRooms: 64,
+    },
+  };
+}
+
+describe("recorder", () => {
+  beforeEach(() => {
+    resetRecorderForTest();
+  });
+
+  it("records before initRecorder and before beginSession", () => {
+    // Boot, config and relay failures all happen before anything is wired.
+    // A recorder that needs setup would miss exactly those.
+    rec(ev("session.config"));
+    expect(recorderSnapshot().events).toHaveLength(1);
+  });
+
+  it("numbers events from 1 again after a new session", () => {
+    beginSession("s1", 1000);
+    rec(ev("session.start"));
+    rec(ev("session.config"));
+    expect(recorderSnapshot().events.map((e) => e.seq)).toEqual([1, 2]);
+
+    beginSession("s2", 2000);
+    rec(ev("session.start"));
+    const snap = recorderSnapshot();
+    expect(snap.sessionId).toBe("s2");
+    expect(snap.startedAt).toBe(2000);
+    expect(snap.events.map((e) => e.seq)).toEqual([1]);
+  });
+
+  it("tracks first and last sight of every peer it names", () => {
+    beginSession("s", 0);
+    rec(ev("peer.connect", { peer: "p1" }));
+    rec(ev("peer.connect", { peer: "p2" }));
+    rec(ev("peer.disconnect", { peer: "p1" }));
+    const peers = recorderSnapshot().peers;
+    expect(peers.map((p) => p.peerId)).toEqual(["p1", "p2"]);
+    expect(peers[0].lastSeen).toBeGreaterThanOrEqual(peers[0].firstSeen);
+    expect(peers[0].identityRef).toBeNull();
+  });
+
+  it("does not track a peer for an event with no peer", () => {
+    beginSession("s", 0);
+    rec(ev("session.config"));
+    expect(recorderSnapshot().peers).toEqual([]);
+  });
+
+  it("groups two devices of one identity under one ordinal", () => {
+    beginSession("s", 0);
+    rec(ev("peer.connect", { peer: "pA" }));
+    rec(ev("peer.connect", { peer: "pB" }));
+    rec(ev("peer.connect", { peer: "pC" }));
+    noteIdentity("pA", "did:key:zALICE");
+    noteIdentity("pB", "did:key:zALICE");
+    noteIdentity("pC", "did:key:zBOB");
+    const byId = new Map(recorderSnapshot().peers.map((p) => [p.peerId, p]));
+    expect(byId.get("pA")?.identityRef).toBe("i1");
+    expect(byId.get("pB")?.identityRef).toBe("i1");
+    expect(byId.get("pC")?.identityRef).toBe("i2");
+  });
+
+  it("never puts a DID in the snapshot", () => {
+    beginSession("s", 0);
+    noteIdentity("pA", "did:key:zALICE");
+    expect(JSON.stringify(recorderSnapshot())).not.toContain("did:key:zALICE");
+  });
+
+  it("notes an identity for a peer it has not seen yet", () => {
+    beginSession("s", 0);
+    noteIdentity("pNew", "did:key:zX");
+    expect(recorderSnapshot().peers[0]).toMatchObject({
+      peerId: "pNew",
+      identityRef: "i1",
+    });
+  });
+
+  it("swallows a throwing context rather than breaking a caller", () => {
+    initRecorder({
+      selfPeerId() {
+        throw new Error("no");
+      },
+      runtime() {
+        throw new Error("no");
+      },
+      faultsActive() {
+        throw new Error("no");
+      },
+    });
+    const snap = recorderSnapshot();
+    expect(snap.selfPeerId).toBe("");
+    expect(snap.faultsActive).toBe(false);
+    expect(snap.runtime).toEqual({
+      apiHost: "",
+      relayPeerId: "",
+      sfuHosts: [],
+      configured: false,
+    });
+  });
+
+  it("keeps only the newest SFU snapshots", () => {
+    beginSession("s", 0);
+    for (let i = 0; i < 12; i++) recordSfuSnapshot(snapshotFixture(i));
+    const kept = recorderSnapshot().sfuSnapshots;
+    expect(kept).toHaveLength(8);
+    expect(kept[0].takenAt).toBe(4);
+    expect(kept[7].takenAt).toBe(11);
+  });
+
+  it("replaces the absolute counter snapshot", () => {
+    beginSession("s", 0);
+    recordCounters({ "t.connects": 3 });
+    recordCounters({ "t.connects": 5 });
+    expect(recorderSnapshot().counters).toEqual({ "t.connects": 5 });
+  });
+
+  it("clears the ref table on a new session so ordinals never correlate", () => {
+    beginSession("s1", 0);
+    refs().roomRef("first-room-code");
+    expect(recorderSnapshot().rooms).toHaveLength(1);
+    beginSession("s2", 0);
+    expect(recorderSnapshot().rooms).toEqual([]);
+    expect(refs().roomRef("second-room-code")).toBe("r1");
+  });
+
+  it("returns plain objects, not a reactive proxy", () => {
+    // A `$state` proxy cannot be structured-cloned into IndexedDB and must not
+    // be JSON.stringify'd into a bundle.
+    beginSession("s", 0);
+    rec(ev("session.start"));
+    const snap = recorderSnapshot();
+    expect(structuredClone(snap)).toEqual(snap);
+  });
+});

--- a/frontend/src/lib/telemetry/recorder.ts
+++ b/frontend/src/lib/telemetry/recorder.ts
@@ -1,0 +1,231 @@
+/**
+ * The flight recorder. A module singleton, deliberately NOT a `$state` rune:
+ * it is written from inside `emit`, from `catch` blocks and from a `finally`,
+ * thousands of times per session, and a reactive proxy there would both cost
+ * per-write work and invalidate components on every event.
+ *
+ * Recording is ALWAYS ON, in memory, from boot. A bug is over by the time
+ * anyone thinks to flip a switch, so the switch cannot be on the recording -
+ * it is on every EXIT: disk (`store.ts`), network (`upload.ts`) and file
+ * (`bundle.ts` + the Diagnostics pane). Nothing here leaves the tab.
+ */
+
+import { ev } from "./event";
+import { RefTable } from "./redact";
+import { DiagRing, RING_CAPACITY } from "./ring";
+import type {
+  DiagEvent,
+  DiagPeerRef,
+  DiagRoomRef,
+  DiagRuntimeConfig,
+  SfuSnapshot,
+} from "./schema";
+
+/** The last N SFU snapshots kept for a bundle. They are large. */
+const MAX_SFU_SNAPSHOTS = 8;
+
+export interface RecorderContext {
+  selfPeerId(): string;
+  runtime(): DiagRuntimeConfig;
+  faultsActive(): boolean;
+}
+
+export interface RecorderSnapshot {
+  sessionId: string;
+  /** Wall clock ms of `session.start`, or 0 before a session began. */
+  startedAt: number;
+  events: DiagEvent[];
+  dropped: number;
+  suppressed: Record<string, number>;
+  nextSeq: number;
+  ringCapacity: number;
+  rooms: DiagRoomRef[];
+  peers: DiagPeerRef[];
+  /** Latest ABSOLUTE counter values, prefixed by bag. */
+  counters: Record<string, number>;
+  sfuSnapshots: SfuSnapshot[];
+  selfPeerId: string;
+  runtime: DiagRuntimeConfig;
+  faultsActive: boolean;
+}
+
+const NO_CONTEXT: RecorderContext = {
+  selfPeerId: () => "",
+  runtime: () => ({
+    apiHost: "",
+    relayPeerId: "",
+    sfuHosts: [],
+    configured: false,
+  }),
+  faultsActive: () => false,
+};
+
+let ctx: RecorderContext = NO_CONTEXT;
+let ring = new DiagRing();
+let refTable = new RefTable();
+let peers = new Map<string, DiagPeerRef>();
+let counters: Record<string, number> = {};
+let sfuSnapshots: SfuSnapshot[] = [];
+let sessionId = "";
+let startedAt = 0;
+/** `performance.now()` at `session.start`, so `t` is monotonic. */
+let perfBase = 0;
+
+export function initRecorder(context: RecorderContext): void {
+  ctx = context;
+}
+
+/**
+ * Start a session. Called once from `LibP2PTransport.connect()`, which is also
+ * where `sessionId` is minted - a reconnect inside one tab keeps the session,
+ * so a bundle covers the whole story rather than the last attempt.
+ */
+export function beginSession(id: string, startedAtMs: number): void {
+  sessionId = id;
+  startedAt = startedAtMs;
+  perfBase = now();
+  ring.reset();
+  refTable = new RefTable();
+  peers = new Map();
+  counters = {};
+  sfuSnapshots = [];
+}
+
+/** Always true today. The seam exists so a future kill switch has one place. */
+export function isRecording(): boolean {
+  return true;
+}
+
+export function refs(): RefTable {
+  return refTable;
+}
+
+/**
+ * Record one event. NEVER throws, for any input, in any state - including
+ * before `initRecorder` and before `beginSession`.
+ */
+export function rec(e: Omit<DiagEvent, "seq" | "t">): void {
+  try {
+    const nowMs = now();
+    if (e.peer) {
+      const hit = peers.get(e.peer);
+      if (hit) hit.lastSeen = nowMs - perfBase;
+      else
+        peers.set(e.peer, {
+          peerId: e.peer,
+          identityRef: null,
+          firstSeen: nowMs - perfBase,
+          lastSeen: nowMs - perfBase,
+        });
+    }
+    ring.push(e, nowMs - perfBase, nowMs);
+  } catch {
+    // The recorder never breaks the app.
+  }
+}
+
+/**
+ * Bind a peerId to an identity ordinal. ONLY a proven binding may call this -
+ * see the `app.profile.in` probe. A forged binding would group two different
+ * people's devices under one `identityRef`.
+ */
+export function noteIdentity(peerId: string, did: string): void {
+  try {
+    const ref = refTable.identityRef(did);
+    const hit = peers.get(peerId);
+    if (hit) hit.identityRef = ref;
+    else {
+      const t = now() - perfBase;
+      peers.set(peerId, {
+        peerId,
+        identityRef: ref,
+        firstSeen: t,
+        lastSeen: t,
+      });
+    }
+  } catch {
+    // The recorder never breaks the app.
+  }
+}
+
+/** Replace the absolute counter snapshot. The delta rides a `counters` event. */
+export function recordCounters(absolute: Record<string, number>): void {
+  counters = { ...absolute };
+}
+
+/** Keep the newest snapshots only; each one is far too large for a `d` bag. */
+export function recordSfuSnapshot(snapshot: SfuSnapshot): void {
+  sfuSnapshots.push(snapshot);
+  if (sfuSnapshots.length > MAX_SFU_SNAPSHOTS) sfuSnapshots.shift();
+}
+
+/**
+ * A plain-object view for `bundle.ts` and for the Diagnostics pane. Plain on
+ * purpose: a `$state` proxy cannot be structured-cloned into IndexedDB.
+ */
+export function recorderSnapshot(): RecorderSnapshot {
+  const snap = ring.snapshot();
+  return {
+    sessionId,
+    startedAt,
+    events: snap.events,
+    dropped: snap.dropped,
+    suppressed: snap.suppressed,
+    nextSeq: snap.nextSeq,
+    ringCapacity: RING_CAPACITY,
+    rooms: refTable.rooms(),
+    peers: [...peers.values()].map((p) => ({ ...p })),
+    counters: { ...counters },
+    sfuSnapshots: sfuSnapshots.map((s) => s),
+    selfPeerId: safeSelfPeerId(),
+    runtime: safeRuntime(),
+    faultsActive: safeFaultsActive(),
+  };
+}
+
+export function resetRecorderForTest(): void {
+  ctx = NO_CONTEXT;
+  ring = new DiagRing();
+  refTable = new RefTable();
+  peers = new Map();
+  counters = {};
+  sfuSnapshots = [];
+  sessionId = "";
+  startedAt = 0;
+  perfBase = 0;
+}
+
+/** A synthetic event announcing that persistence could not start earlier. */
+export function recUnlocked(): void {
+  rec(ev("session.unlock"));
+}
+
+function now(): number {
+  // Monotonic: immune to a wall-clock jump, which is exactly what a laptop
+  // does when it wakes from sleep - the case this recorder exists to explain.
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function safeSelfPeerId(): string {
+  try {
+    return ctx.selfPeerId();
+  } catch {
+    return "";
+  }
+}
+
+function safeRuntime(): RecorderSnapshot["runtime"] {
+  try {
+    return ctx.runtime();
+  } catch {
+    return NO_CONTEXT.runtime();
+  }
+}
+
+function safeFaultsActive(): boolean {
+  try {
+    return ctx.faultsActive();
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/lib/telemetry/redact.test.ts
+++ b/frontend/src/lib/telemetry/redact.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { RefTable, roomKind } from "./redact";
+
+describe("roomKind", () => {
+  it("classifies a DM room by its documented prefix", () => {
+    expect(roomKind("dm-" + "a".repeat(40))).toBe("dm");
+  });
+
+  it("classifies the device-sync pseudo-room", () => {
+    expect(roomKind("__sync_deadbeefdeadbeef")).toBe("sync");
+  });
+
+  it("classifies an 8-byte hex code as text", () => {
+    expect(roomKind("0123456789abcdef")).toBe("text");
+  });
+
+  it("classifies a legacy 3-byte code as text", () => {
+    expect(roomKind("a1b2c3")).toBe("text");
+  });
+});
+
+describe("RefTable", () => {
+  it("assigns ordinals in first-seen order and is stable", () => {
+    const refs = new RefTable(() => 1000);
+    expect(refs.roomRef("aaaaaaaaaaaaaaaa")).toBe("r1");
+    expect(refs.roomRef("bbbbbbbbbbbbbbbb")).toBe("r2");
+    expect(refs.roomRef("aaaaaaaaaaaaaaaa")).toBe("r1");
+  });
+
+  it("assigns identity and file ordinals in their own namespaces", () => {
+    const refs = new RefTable(() => 0);
+    expect(refs.identityRef("did:key:zAAA")).toBe("i1");
+    expect(refs.identityRef("did:key:zBBB")).toBe("i2");
+    expect(refs.identityRef("did:key:zAAA")).toBe("i1");
+    expect(refs.fileRef("hash-a")).toBe("f1");
+    expect(refs.fileRef("hash-a")).toBe("f1");
+    expect(refs.fileRef("hash-b")).toBe("f2");
+  });
+
+  it("records the join time from the injected clock", () => {
+    let now = 5000;
+    const refs = new RefTable(() => now);
+    refs.roomRef("aaaaaaaaaaaaaaaa");
+    now = 9000;
+    refs.roomRef("dm-" + "b".repeat(40));
+    expect(refs.rooms()).toEqual([
+      { ref: "r1", kind: "text", joinedAt: 5000 },
+      { ref: "r2", kind: "dm", joinedAt: 9000 },
+    ]);
+  });
+
+  it("keeps codes out of the serializable room list", () => {
+    const refs = new RefTable(() => 0);
+    const code = "0123456789abcdef";
+    refs.roomRef(code);
+    expect(JSON.stringify(refs.rooms())).not.toContain(code);
+    // The code is reachable ONLY through knownRooms, which is never serialized.
+    expect(refs.knownRooms()[0].code).toBe(code);
+  });
+
+  it("never correlates across two tables", () => {
+    // A new session gets a new table, so "r1" in two bundles means nothing.
+    const a = new RefTable(() => 0);
+    const b = new RefTable(() => 0);
+    a.roomRef("first");
+    b.roomRef("second");
+    expect(a.knownRooms()[0].ref).toBe(b.knownRooms()[0].ref);
+    expect(a.knownRooms()[0].code).not.toBe(b.knownRooms()[0].code);
+  });
+});

--- a/frontend/src/lib/telemetry/redact.ts
+++ b/frontend/src/lib/telemetry/redact.ts
@@ -1,0 +1,95 @@
+/**
+ * Redaction primitives. Every identifier that must never leave the tab is
+ * replaced by a bundle-local ordinal here, and nowhere else.
+ *
+ * Why ordinals and not a hash: a hash of a room code is a guessable
+ * commitment - the code is only 64 bits and the hash would be stable across
+ * bundles, so a collector holding two bundles could link rooms and, with a
+ * dictionary, invert the code. An ordinal is meaningful only inside the one
+ * bundle that defines it, which is exactly the amount of meaning a reader
+ * needs: "these events are about the same room".
+ */
+
+import type { DiagRoomRef } from "./schema";
+
+/** `"dm-" + hex(sha256(...))` - see `docs/spec.md` "Room Codes". */
+const DM_PREFIX = "dm-";
+/** The device-sync pseudo-room - see `transport/sync.svelte.ts`. */
+const SYNC_PREFIX = "__sync_";
+
+/**
+ * Classify a room without revealing it. The prefix is the only thing read, and
+ * the prefix is a documented structural fact, not a secret.
+ */
+export function roomKind(roomCode: string): "text" | "dm" | "sync" {
+  if (roomCode.startsWith(SYNC_PREFIX)) return "sync";
+  if (roomCode.startsWith(DM_PREFIX)) return "dm";
+  return "text";
+}
+
+/**
+ * Assigns and remembers bundle-local ordinals. One instance per session; a new
+ * session gets a new table so ordinals never correlate across sessions.
+ */
+export class RefTable {
+  #rooms = new Map<string, DiagRoomRef>();
+  #identities = new Map<string, string>();
+  #files = new Map<string, string>();
+  #now: () => number;
+
+  constructor(now: () => number = () => Date.now()) {
+    this.#now = now;
+  }
+
+  /** "r1", "r2", ... Stable for the life of the table. */
+  roomRef(roomCode: string): string {
+    const hit = this.#rooms.get(roomCode);
+    if (hit) return hit.ref;
+    const ref = `r${this.#rooms.size + 1}`;
+    this.#rooms.set(roomCode, {
+      ref,
+      kind: roomKind(roomCode),
+      joinedAt: this.#now(),
+    });
+    return ref;
+  }
+
+  /**
+   * "i1", "i2", ... Only a PROVEN peerId -> DID binding may call this: it is
+   * what groups one person's devices, and a forged binding would group two
+   * different people.
+   */
+  identityRef(did: string): string {
+    const hit = this.#identities.get(did);
+    if (hit) return hit;
+    const ref = `i${this.#identities.size + 1}`;
+    this.#identities.set(did, ref);
+    return ref;
+  }
+
+  /** "f1", "f2", ... An infoHash names retrievable content, so it is redacted. */
+  fileRef(infoHash: string): string {
+    const hit = this.#files.get(infoHash);
+    if (hit) return hit;
+    const ref = `f${this.#files.size + 1}`;
+    this.#files.set(infoHash, ref);
+    return ref;
+  }
+
+  /**
+   * The room table, INCLUDING the codes. NEVER serialized - `bundle.ts` copies
+   * the `DiagRoomRef` half and drops the code.
+   */
+  knownRooms(): Array<{ ref: string; code: string; entry: DiagRoomRef }> {
+    const out: Array<{ ref: string; code: string; entry: DiagRoomRef }> = [];
+    for (const [code, entry] of this.#rooms) {
+      out.push({ ref: entry.ref, code, entry });
+    }
+    return out;
+  }
+
+  /** The serializable room list. */
+  rooms(): DiagRoomRef[] {
+    return [...this.#rooms.values()].map((r) => ({ ...r }));
+  }
+}

--- a/frontend/src/lib/telemetry/redact.ts
+++ b/frontend/src/lib/telemetry/redact.ts
@@ -92,4 +92,35 @@ export class RefTable {
   rooms(): DiagRoomRef[] {
     return [...this.#rooms.values()].map((r) => ({ ...r }));
   }
+
+  /**
+   * Replace everything this table knows to be sensitive with its ordinal, and
+   * every URL with a placeholder.
+   *
+   * For text this bundle did not compose: a thrown error's message, which can
+   * quote the very things the schema has no field for. "Failed to fetch
+   * https://relay.example/invite/<code>" is a real message from a real failure
+   * path, and it would carry a room code out of a bundle that redacts room
+   * codes everywhere else. URLs go first, so a code inside one is gone before
+   * the per-code pass even looks.
+   *
+   * Only what this session actually touched can be replaced by an ordinal, so
+   * a bare `did:key:` gets a blanket placeholder instead: an unbound identity
+   * has no ordinal to become.
+   */
+  scrub(text: string): string {
+    try {
+      let out = text.replace(/\b[a-z][a-z0-9+.-]*:\/\/\S+/gi, "<url>");
+      for (const [code, entry] of this.#rooms) {
+        out = out.split(code).join(entry.ref);
+      }
+      for (const [did, ref] of this.#identities) {
+        out = out.split(did).join(ref);
+      }
+      return out.replace(/did:key:[A-Za-z0-9]+/g, "<did>");
+    } catch {
+      // A hostile string subclass can throw from replace via Symbol.replace.
+      return "<unprintable>";
+    }
+  }
 }

--- a/frontend/src/lib/telemetry/ring.test.ts
+++ b/frontend/src/lib/telemetry/ring.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { ev } from "./event";
+import { DiagRing, RING_CAPACITY } from "./ring";
+
+describe("DiagRing", () => {
+  it("keeps the newest events and counts the evicted ones", () => {
+    const ring = new DiagRing(4, {});
+    for (let i = 0; i < 10; i++) ring.push(ev("session.config"), i, i * 1000);
+    const snap = ring.snapshot();
+    expect(snap.events).toHaveLength(4);
+    expect(snap.dropped).toBe(6);
+    expect(snap.events.map((e) => e.seq)).toEqual([7, 8, 9, 10]);
+  });
+
+  it("returns events oldest first before it has wrapped", () => {
+    const ring = new DiagRing(8, {});
+    ring.push(ev("session.start"), 0, 0);
+    ring.push(ev("session.end"), 5, 1000);
+    expect(ring.snapshot().events.map((e) => e.kind)).toEqual([
+      "session.start",
+      "session.end",
+    ]);
+    expect(ring.size).toBe(2);
+  });
+
+  it("numbers events from 1 and rounds t to an integer", () => {
+    const ring = new DiagRing(4, {});
+    ring.push(ev("session.start"), 12.7, 0);
+    const [e] = ring.snapshot().events;
+    expect(e.seq).toBe(1);
+    expect(e.t).toBe(13);
+  });
+
+  it("suppresses past the per-kind budget inside one window", () => {
+    const ring = new DiagRing(1024, {});
+    let accepted = 0;
+    // DEFAULT_BUDGET is 20 and `session.config` is an "info" kind.
+    for (let i = 0; i < 25; i++) {
+      if (ring.push(ev("session.config"), i, 500)) accepted++;
+    }
+    expect(accepted).toBe(20);
+    expect(ring.snapshot().suppressed).toEqual({ "session.config": 5 });
+  });
+
+  it("gives an error kind the bigger budget", () => {
+    const ring = new DiagRing(1024, {});
+    let accepted = 0;
+    for (let i = 0; i < 70; i++) {
+      if (ring.push(ev("peer.dial.fail"), i, 500)) accepted++;
+    }
+    expect(accepted).toBe(60);
+  });
+
+  it("honours a per-kind override", () => {
+    const ring = new DiagRing(1024, { "peer.rtt": 2 });
+    let accepted = 0;
+    for (let i = 0; i < 5; i++) {
+      if (ring.push(ev("peer.rtt"), i, 0)) accepted++;
+    }
+    expect(accepted).toBe(2);
+  });
+
+  it("opens a fresh window after a second", () => {
+    const ring = new DiagRing(1024, { "peer.rtt": 1 });
+    expect(ring.push(ev("peer.rtt"), 0, 0)).toBe(true);
+    expect(ring.push(ev("peer.rtt"), 1, 500)).toBe(false);
+    expect(ring.push(ev("peer.rtt"), 2, 1000)).toBe(true);
+  });
+
+  it("announces a gap with exactly one meta.suppressed in a later window", () => {
+    const ring = new DiagRing(1024, { "peer.rtt": 1 });
+    ring.push(ev("peer.rtt"), 0, 0);
+    ring.push(ev("peer.rtt"), 1, 100); // suppressed
+    ring.push(ev("peer.rtt"), 2, 200); // suppressed
+    ring.push(ev("session.config"), 3, 2000); // later window: announces
+    ring.push(ev("session.config"), 4, 2001); // must NOT announce again
+
+    const kinds = ring.snapshot().events.map((e) => e.kind);
+    expect(kinds).toEqual([
+      "peer.rtt",
+      "meta.suppressed",
+      "session.config",
+      "session.config",
+    ]);
+    const meta = ring.snapshot().events[1];
+    expect(meta.d).toEqual({ "peer.rtt": 2 });
+  });
+
+  it("does not announce a gap inside the window that produced it", () => {
+    const ring = new DiagRing(1024, { "peer.rtt": 1 });
+    ring.push(ev("peer.rtt"), 0, 0);
+    ring.push(ev("peer.rtt"), 1, 100); // suppressed
+    ring.push(ev("session.config"), 2, 200); // same window
+    expect(ring.snapshot().events.map((e) => e.kind)).toEqual([
+      "peer.rtt",
+      "session.config",
+    ]);
+  });
+
+  it("resets to an empty ring", () => {
+    const ring = new DiagRing(4, {});
+    ring.push(ev("session.start"), 0, 0);
+    ring.reset();
+    expect(ring.snapshot()).toEqual({
+      events: [],
+      dropped: 0,
+      suppressed: {},
+      nextSeq: 1,
+    });
+  });
+
+  it("defaults to a capacity that covers a useful window", () => {
+    expect(new DiagRing().capacity).toBe(RING_CAPACITY);
+  });
+
+  it("never accepts a zero or negative capacity", () => {
+    expect(new DiagRing(0).capacity).toBe(1);
+    expect(new DiagRing(-5).capacity).toBe(1);
+  });
+});

--- a/frontend/src/lib/telemetry/ring.ts
+++ b/frontend/src/lib/telemetry/ring.ts
@@ -1,0 +1,152 @@
+/**
+ * The flight recorder's storage: a bounded ring with a per-kind rate budget.
+ *
+ * Two properties are load-bearing and both are why this is not just an array:
+ *
+ * 1. Bounded memory. Recording is always on, from boot, for the life of the
+ *    tab. An unbounded log is a leak.
+ * 2. Bounded per KIND. Without the throttle, one hot kind (a message storm, an
+ *    ICE state flap) evicts every rare event - and the rare events are the
+ *    ones that name the bug.
+ */
+
+import { ev } from "./event";
+import {
+  DEFAULT_BUDGET,
+  ERROR_BUDGET,
+  KIND_BUDGET,
+  type DiagEvent,
+  type DiagKind,
+} from "./schema";
+
+export const RING_CAPACITY = 4096;
+
+/** The throttle's fixed window. */
+const WINDOW_MS = 1000;
+
+export interface RingSnapshot {
+  /** Oldest first. */
+  events: DiagEvent[];
+  dropped: number;
+  suppressed: Record<string, number>;
+  nextSeq: number;
+}
+
+export class DiagRing {
+  readonly capacity: number;
+
+  #buf: Array<DiagEvent | undefined>;
+  #head = 0;
+  #count = 0;
+  #dropped = 0;
+  #nextSeq = 1;
+
+  /** Cumulative per-kind suppression counts, for the bundle envelope. */
+  #suppressed: Record<string, number> = {};
+  /** Suppressions not yet announced by a synthetic `meta.suppressed`. */
+  #pending: Record<string, number> | null = null;
+  /** The window start of the most recent suppression. */
+  #pendingWindow = -1;
+
+  #windows = new Map<DiagKind, { windowStart: number; count: number }>();
+  #budgets: Readonly<Partial<Record<DiagKind, number>>>;
+
+  constructor(
+    capacity: number = RING_CAPACITY,
+    budgets: Readonly<Partial<Record<DiagKind, number>>> = KIND_BUDGET
+  ) {
+    this.capacity = Math.max(1, Math.floor(capacity));
+    this.#buf = new Array<DiagEvent | undefined>(this.capacity);
+    this.#budgets = budgets;
+  }
+
+  get size(): number {
+    return this.#count;
+  }
+
+  /**
+   * Append an event.
+   *
+   * @param t milliseconds since the session started, integer
+   * @param nowMs a monotonic clock for the throttle window
+   * @returns false when the throttle suppressed it. Never throws.
+   */
+  push(e: Omit<DiagEvent, "seq" | "t">, t: number, nowMs: number): boolean {
+    try {
+      const budget =
+        this.#budgets[e.kind] ??
+        (e.sev === "error" ? ERROR_BUDGET : DEFAULT_BUDGET);
+
+      let w = this.#windows.get(e.kind);
+      if (!w || nowMs - w.windowStart >= WINDOW_MS) {
+        w = { windowStart: nowMs, count: 0 };
+        this.#windows.set(e.kind, w);
+      }
+
+      if (w.count >= budget) {
+        this.#suppressed[e.kind] = (this.#suppressed[e.kind] ?? 0) + 1;
+        if (!this.#pending) this.#pending = {};
+        this.#pending[e.kind] = (this.#pending[e.kind] ?? 0) + 1;
+        this.#pendingWindow = w.windowStart;
+        return false;
+      }
+      w.count++;
+
+      // A reader who has only the events - a log paste, a trimmed bundle -
+      // must still see that a gap exists, so announce it inline once the
+      // window that produced it has closed.
+      if (this.#pending && nowMs - this.#pendingWindow >= WINDOW_MS) {
+        const counts = this.#pending;
+        this.#pending = null;
+        this.#pendingWindow = -1;
+        this.#write(ev("meta.suppressed", { d: counts }), t);
+      }
+
+      this.#write(e, t);
+      return true;
+    } catch {
+      // The recorder never breaks the app.
+      return false;
+    }
+  }
+
+  snapshot(): RingSnapshot {
+    const events: DiagEvent[] = [];
+    const start = this.#count < this.capacity ? 0 : this.#head;
+    for (let i = 0; i < this.#count; i++) {
+      const e = this.#buf[(start + i) % this.capacity];
+      if (e) events.push(e);
+    }
+    return {
+      events,
+      dropped: this.#dropped,
+      suppressed: { ...this.#suppressed },
+      nextSeq: this.#nextSeq,
+    };
+  }
+
+  reset(): void {
+    this.#buf = new Array<DiagEvent | undefined>(this.capacity);
+    this.#head = 0;
+    this.#count = 0;
+    this.#dropped = 0;
+    this.#nextSeq = 1;
+    this.#suppressed = {};
+    this.#pending = null;
+    this.#pendingWindow = -1;
+    this.#windows.clear();
+  }
+
+  #write(body: Omit<DiagEvent, "seq" | "t">, t: number): void {
+    const full = this.#count === this.capacity;
+    if (full) this.#dropped++;
+    // Events are immutable once written, so `snapshot()` needs no copy.
+    this.#buf[this.#head] = {
+      ...body,
+      seq: this.#nextSeq++,
+      t: Math.round(t),
+    } as DiagEvent;
+    this.#head = (this.#head + 1) % this.capacity;
+    if (!full) this.#count++;
+  }
+}

--- a/frontend/src/lib/telemetry/schema.test.ts
+++ b/frontend/src/lib/telemetry/schema.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  DIAG_KIND_COUNT,
+  DIAG_SCHEMA_VERSION,
+  KIND_BUDGET,
+  KIND_SEV,
+  type DiagKind,
+} from "./schema";
+
+describe("KIND_SEV", () => {
+  it("has an entry for every DiagKind", () => {
+    // `satisfies Record<DiagKind, DiagSeverity>` in the source catches a
+    // MISSING entry at compile time. This catches the other half: a kind added
+    // to the union AND to the table but never counted, which would let the two
+    // drift apart silently in a schema mirror.
+    expect(Object.keys(KIND_SEV)).toHaveLength(DIAG_KIND_COUNT);
+  });
+
+  it("never yields an undefined severity", () => {
+    for (const kind of Object.keys(KIND_SEV) as DiagKind[]) {
+      expect(["debug", "info", "warn", "error"]).toContain(KIND_SEV[kind]);
+    }
+  });
+
+  it("rates every named failure kind as an error", () => {
+    const failures: DiagKind[] = [
+      "relay.dial.fail",
+      "relay.reservation.timeout",
+      "relay.reconnect.fail",
+      "rv.open.fail",
+      "rv.send.fail",
+      "rv.frame.oversize",
+      "peer.dial.fail",
+      "peer.upgrade.fail",
+      "peer.drop.liveness",
+      "stream.open.fail",
+      "stream.confirm.fail",
+      "stream.write.fail",
+      "app.msg.reject",
+      "app.profile.reject",
+      "app.sync.drop",
+      "dm.mailbox.drop",
+      "ice.turn.fail",
+      "ice.turn.unavailable",
+      "voice.signal.invalid",
+      "voice.failed",
+      "sfu.transport.timeout",
+      "sfu.consume.failed",
+      "sfu.error",
+      "sfu.ws.error",
+      "file.fail",
+      "storage.locked",
+      "storage.drop",
+    ];
+    for (const kind of failures) expect(KIND_SEV[kind]).toBe("error");
+  });
+
+  it("rates the high-rate samples as debug so a trim sacrifices them first", () => {
+    const samples: DiagKind[] = [
+      "peer.rtt",
+      "peer.clock",
+      "counters",
+      "sfu.diag",
+      "voice.ice.state",
+    ];
+    for (const kind of samples) expect(KIND_SEV[kind]).toBe("debug");
+  });
+});
+
+describe("KIND_BUDGET", () => {
+  it("throttles only the kinds that can storm", () => {
+    expect(KIND_BUDGET).toEqual({
+      "app.msg.in": 5,
+      "app.msg.out": 5,
+      "file.progress": 2,
+      "voice.ice.state": 5,
+      "peer.rtt": 2,
+    });
+  });
+});
+
+describe("DIAG_SCHEMA_VERSION", () => {
+  it("is 1 until a field changes shape", () => {
+    // A bump here is a reminder to bump the two mirrors: the dashboard's
+    // schema.ts and sfu/telemetry.ts's SFU_DIAG_SCHEMA_VERSION.
+    expect(DIAG_SCHEMA_VERSION).toBe(1);
+  });
+});

--- a/frontend/src/lib/telemetry/schema.test.ts
+++ b/frontend/src/lib/telemetry/schema.test.ts
@@ -70,6 +70,7 @@ describe("KIND_SEV", () => {
 describe("KIND_BUDGET", () => {
   it("throttles only the kinds that can storm", () => {
     expect(KIND_BUDGET).toEqual({
+      "voice.media.sample": 4,
       "runtime.error": 5,
       "runtime.resources": 2,
       "app.msg.in": 5,

--- a/frontend/src/lib/telemetry/schema.test.ts
+++ b/frontend/src/lib/telemetry/schema.test.ts
@@ -70,6 +70,8 @@ describe("KIND_SEV", () => {
 describe("KIND_BUDGET", () => {
   it("throttles only the kinds that can storm", () => {
     expect(KIND_BUDGET).toEqual({
+      "runtime.error": 5,
+      "runtime.resources": 2,
       "app.msg.in": 5,
       "app.msg.out": 5,
       "file.progress": 2,

--- a/frontend/src/lib/telemetry/schema.ts
+++ b/frontend/src/lib/telemetry/schema.ts
@@ -1,0 +1,526 @@
+/**
+ * Diagnostic wire schema - the flight recorder's only contract.
+ *
+ * MIRRORED, byte-for-byte, in `dashboard/src/lib/schema.ts`, exactly as the
+ * `ms:*` protocol is mirrored between `sfu/index.ts` and
+ * `frontend/src/lib/transport/mediasoup.ts`. The SFU-side view types below are
+ * mirrored a THIRD time, in `sfu/telemetry.ts`.
+ *
+ * A change here MUST be made in every copy, in the same commit. There is no
+ * negotiation step and no version handshake: a bundle carries
+ * `schemaVersion`, and a reader that sees an unknown version refuses the
+ * bundle rather than guessing.
+ *
+ * PRIVACY - this file defines what CAN be transmitted, so it is the first
+ * place a leak would appear. A room code, a `did:key:`, message content, file
+ * content, a nickname, an avatar and an ICE candidate ADDRESS have no field
+ * here and must never be given one. See `docs/spec.md` "Server Privacy".
+ */
+
+export const DIAG_SCHEMA_VERSION = 1;
+
+export type DiagSeverity = "debug" | "info" | "warn" | "error";
+
+export interface DiagEvent {
+  /** 1-based, per session. A gap means the ring or the throttle dropped events. */
+  seq: number;
+  /** Milliseconds since the session's `startedAt`, integer. */
+  t: number;
+  kind: DiagKind;
+  sev: DiagSeverity;
+  /** FULL peerId when the event is about a peer, else null. */
+  peer: string | null;
+  /** Bundle-local room ordinal ("r1"). NEVER a room code. */
+  room: string | null;
+  /** Flat detail bag: JSON primitives only, <=12 keys, strings <=200 chars. */
+  d?: Record<string, string | number | boolean | null>;
+}
+
+/**
+ * The exhaustive event vocabulary. Each literal is a wire contract: the
+ * dashboard's rule engine matches on these strings, so renaming one is a
+ * breaking change that needs a `DIAG_SCHEMA_VERSION` bump.
+ */
+export type DiagKind =
+  // session
+  | "session.start"
+  | "session.config"
+  | "session.unlock"
+  | "session.visibility"
+  | "session.online"
+  | "session.end"
+  // relay
+  | "relay.dial.attempt"
+  | "relay.dial.ok"
+  | "relay.dial.fail"
+  | "relay.reservation.request"
+  | "relay.reservation.ok"
+  | "relay.reservation.timeout"
+  | "relay.disconnect"
+  | "relay.reconnect.schedule"
+  | "relay.reconnect.fail"
+  // rendezvous
+  | "rv.open"
+  | "rv.open.fail"
+  | "rv.register"
+  | "rv.unregister"
+  | "rv.peers"
+  | "rv.peer.joined"
+  | "rv.peer.left"
+  | "rv.send.fail"
+  | "rv.frame.oversize"
+  | "rv.close"
+  // peer
+  | "peer.dial.start"
+  | "peer.dial.ok"
+  | "peer.dial.fail"
+  | "peer.connect"
+  | "peer.disconnect"
+  | "peer.relayed"
+  | "peer.direct"
+  | "peer.upgrade.attempt"
+  | "peer.upgrade.ok"
+  | "peer.upgrade.fail"
+  | "peer.drop.liveness"
+  | "peer.redial"
+  | "peer.rtt"
+  | "peer.clock"
+  // direct stream
+  | "stream.open"
+  | "stream.open.fail"
+  | "stream.proven"
+  | "stream.lost"
+  | "stream.confirm.fail"
+  | "stream.reset"
+  | "stream.write.fail"
+  // app layer
+  | "app.join"
+  | "app.leave"
+  | "app.roomusers"
+  | "app.msg.in"
+  | "app.msg.out"
+  | "app.msg.reject"
+  | "app.profile.in"
+  | "app.profile.reject"
+  | "app.digest.out"
+  | "app.digest.in"
+  | "app.sync.drop"
+  // dm + mailbox
+  | "dm.send"
+  | "dm.queue"
+  | "dm.flush"
+  | "dm.mailbox.deposit"
+  | "dm.mailbox.collect"
+  | "dm.mailbox.drop"
+  // ice / turn
+  | "ice.turn.ok"
+  | "ice.turn.unavailable"
+  | "ice.turn.fail"
+  | "ice.servers.changed"
+  // voice (p2p mesh)
+  | "voice.join"
+  | "voice.leave"
+  | "voice.pc.new"
+  | "voice.offer.out"
+  | "voice.offer.in"
+  | "voice.answer.in"
+  | "voice.signal.invalid"
+  | "voice.ice.state"
+  | "voice.pc.state"
+  | "voice.ice.connected"
+  | "voice.degraded"
+  | "voice.failed"
+  | "voice.restart"
+  | "voice.teardown"
+  | "voice.redial.ask"
+  | "voice.redial.serve"
+  | "voice.media.stall"
+  | "voice.media.resume"
+  // sfu
+  | "sfu.pick"
+  | "sfu.ws.open"
+  | "sfu.ws.close"
+  | "sfu.ws.error"
+  | "sfu.join"
+  | "sfu.caps"
+  | "sfu.transport.create"
+  | "sfu.transport.state"
+  | "sfu.transport.timeout"
+  | "sfu.produce"
+  | "sfu.consume"
+  | "sfu.consume.failed"
+  | "sfu.error"
+  | "sfu.rejoin"
+  | "sfu.track.added"
+  | "sfu.track.stalled"
+  | "sfu.diag"
+  // files
+  | "file.announce"
+  | "file.request"
+  | "file.progress"
+  | "file.fail"
+  // local infrastructure
+  | "storage.locked"
+  | "storage.quota"
+  | "storage.drop"
+  | "counters"
+  | "fault.injected"
+  | "meta.suppressed";
+
+/**
+ * The number of members of `DiagKind`. `KIND_SEV` is asserted against it at
+ * test time, so a kind added without a severity is a test failure rather than
+ * an `undefined` severity on the wire.
+ */
+export const DIAG_KIND_COUNT = 112;
+
+/**
+ * Default severity per kind. Classes, in the order they were decided:
+ *
+ * - "error": a named failure - `*.fail`, `*.failed`, `*.timeout`, `*.reject`,
+ *   `*.drop*`, `*.invalid`, `*.oversize`, plus `storage.locked` (an offline
+ *   queue write was silently lost), `sfu.error` and `sfu.ws.error` (both are
+ *   failures whose names predate this table), and `ice.turn.unavailable` (no
+ *   TURN is a hard failure for a peer behind a symmetric NAT).
+ * - "warn": a degradation that still works - `*.degraded`, `*.stall*`,
+ *   `*.retry`, `rv.close`, `peer.disconnect`, `storage.quota`.
+ * - "debug": high-rate sampling - `peer.rtt`, `peer.clock`, `counters`,
+ *   `sfu.diag`, `voice.ice.state`.
+ * - "info": everything else.
+ *
+ * `sev` decides the order `trimBundleForUpload` sacrifices events in, and it
+ * is what the dashboard's severity filter reads. It is deliberately NOT what
+ * the rule engine keys on - a finding's severity comes from `RULES`.
+ */
+export const KIND_SEV = {
+  // session
+  "session.start": "info",
+  "session.config": "info",
+  "session.unlock": "info",
+  "session.visibility": "info",
+  "session.online": "info",
+  "session.end": "info",
+  // relay
+  "relay.dial.attempt": "info",
+  "relay.dial.ok": "info",
+  "relay.dial.fail": "error",
+  "relay.reservation.request": "info",
+  "relay.reservation.ok": "info",
+  "relay.reservation.timeout": "error",
+  "relay.disconnect": "info",
+  "relay.reconnect.schedule": "info",
+  "relay.reconnect.fail": "error",
+  // rendezvous
+  "rv.open": "info",
+  "rv.open.fail": "error",
+  "rv.register": "info",
+  "rv.unregister": "info",
+  "rv.peers": "info",
+  "rv.peer.joined": "info",
+  "rv.peer.left": "info",
+  "rv.send.fail": "error",
+  "rv.frame.oversize": "error",
+  "rv.close": "warn",
+  // peer
+  "peer.dial.start": "info",
+  "peer.dial.ok": "info",
+  "peer.dial.fail": "error",
+  "peer.connect": "info",
+  "peer.disconnect": "warn",
+  "peer.relayed": "info",
+  "peer.direct": "info",
+  "peer.upgrade.attempt": "info",
+  "peer.upgrade.ok": "info",
+  "peer.upgrade.fail": "error",
+  "peer.drop.liveness": "error",
+  "peer.redial": "info",
+  "peer.rtt": "debug",
+  "peer.clock": "debug",
+  // direct stream
+  "stream.open": "info",
+  "stream.open.fail": "error",
+  "stream.proven": "info",
+  "stream.lost": "info",
+  "stream.confirm.fail": "error",
+  "stream.reset": "info",
+  "stream.write.fail": "error",
+  // app layer
+  "app.join": "info",
+  "app.leave": "info",
+  "app.roomusers": "info",
+  "app.msg.in": "info",
+  "app.msg.out": "info",
+  "app.msg.reject": "error",
+  "app.profile.in": "info",
+  "app.profile.reject": "error",
+  "app.digest.out": "info",
+  "app.digest.in": "info",
+  "app.sync.drop": "error",
+  // dm + mailbox
+  "dm.send": "info",
+  "dm.queue": "info",
+  "dm.flush": "info",
+  "dm.mailbox.deposit": "info",
+  "dm.mailbox.collect": "info",
+  "dm.mailbox.drop": "error",
+  // ice / turn
+  "ice.turn.ok": "info",
+  "ice.turn.unavailable": "error",
+  "ice.turn.fail": "error",
+  "ice.servers.changed": "info",
+  // voice
+  "voice.join": "info",
+  "voice.leave": "info",
+  "voice.pc.new": "info",
+  "voice.offer.out": "info",
+  "voice.offer.in": "info",
+  "voice.answer.in": "info",
+  "voice.signal.invalid": "error",
+  "voice.ice.state": "debug",
+  "voice.pc.state": "info",
+  "voice.ice.connected": "info",
+  "voice.degraded": "warn",
+  "voice.failed": "error",
+  "voice.restart": "info",
+  "voice.teardown": "info",
+  "voice.redial.ask": "info",
+  "voice.redial.serve": "info",
+  "voice.media.stall": "warn",
+  "voice.media.resume": "info",
+  // sfu
+  "sfu.pick": "info",
+  "sfu.ws.open": "info",
+  "sfu.ws.close": "info",
+  "sfu.ws.error": "error",
+  "sfu.join": "info",
+  "sfu.caps": "info",
+  "sfu.transport.create": "info",
+  "sfu.transport.state": "info",
+  "sfu.transport.timeout": "error",
+  "sfu.produce": "info",
+  "sfu.consume": "info",
+  "sfu.consume.failed": "error",
+  "sfu.error": "error",
+  "sfu.rejoin": "info",
+  "sfu.track.added": "info",
+  "sfu.track.stalled": "warn",
+  "sfu.diag": "debug",
+  // files
+  "file.announce": "info",
+  "file.request": "info",
+  "file.progress": "info",
+  "file.fail": "error",
+  // local infrastructure
+  "storage.locked": "error",
+  "storage.quota": "warn",
+  "storage.drop": "error",
+  counters: "debug",
+  "fault.injected": "info",
+  "meta.suppressed": "info",
+} as const satisfies Record<DiagKind, DiagSeverity>;
+
+/** Events per second, per kind, before the ring's throttle suppresses. */
+export const DEFAULT_BUDGET = 20;
+/** A failure is worth more than a sample, so it gets a bigger allowance. */
+export const ERROR_BUDGET = 60;
+
+/**
+ * Per-kind overrides for kinds that can arrive in a storm. Without these one
+ * hot kind evicts the whole ring, which is the failure mode the throttle
+ * exists to prevent.
+ */
+export const KIND_BUDGET: Readonly<Partial<Record<DiagKind, number>>> = {
+  "app.msg.in": 5,
+  "app.msg.out": 5,
+  "file.progress": 2,
+  "voice.ice.state": 5,
+  "peer.rtt": 2,
+};
+
+// ---------------------------------------------------------------------------
+// Bundle envelope
+// ---------------------------------------------------------------------------
+
+export interface DiagBundleHead {
+  schemaVersion: typeof DIAG_SCHEMA_VERSION;
+  /** 16 random bytes, hex, minted at export. */
+  bundleId: string;
+  /** 16 random bytes, hex, minted in `LibP2PTransport.connect()`. */
+  sessionId: string;
+  /** Wall clock ms at export. */
+  createdAt: number;
+  /** Wall clock ms of `session.start`. */
+  startedAt: number;
+}
+
+export interface DiagRoomRef {
+  /** Bundle-local ordinal, "r1". NEVER a room code. */
+  ref: string;
+  kind: "text" | "dm" | "sync";
+  joinedAt: number;
+}
+
+export interface DiagPeerRef {
+  /** FULL peerId. The relay and the SFU already have it. */
+  peerId: string;
+  /**
+   * Bundle-local ordinal shared by peerIds that PROVED the same DID. It
+   * preserves "these are one person's devices" without naming the person.
+   */
+  identityRef: string | null;
+  firstSeen: number;
+  lastSeen: number;
+}
+
+/**
+ * What this build was configured to talk to. HOSTS only: a full URL can carry
+ * a path or a query, and `isConfigured()` is the flag that tells a reader the
+ * instance was never set up at all.
+ */
+export interface DiagRuntimeConfig {
+  apiHost: string;
+  relayPeerId: string;
+  sfuHosts: string[];
+  configured: boolean;
+}
+
+export interface ClientBundle extends DiagBundleHead {
+  vantage: "client";
+  app: { version: string; commit: string };
+  /** `ua` truncated to 200 chars. */
+  env: { ua: string };
+  config: DiagRuntimeConfig;
+  /** NO `did`, not even the uploader's own. */
+  self: { peerId: string };
+  rooms: DiagRoomRef[];
+  peers: DiagPeerRef[];
+  counters: Record<string, number>;
+  events: DiagEvent[];
+  /** The last 8 SFU snapshots, which are too large for a `d` bag. */
+  sfuSnapshots: SfuSnapshot[];
+  meta: {
+    ringCapacity: number;
+    /** Evicted by wraparound. */
+    dropped: number;
+    /** Per kind, by the throttle. */
+    suppressed: Record<string, number>;
+    faultsActive: boolean;
+    /** Trimmed to fit an upload. */
+    truncated: boolean;
+  };
+  /** Stapled by the relay at ingest; absent in a file export. */
+  relayView?: RelayVantage;
+}
+
+export interface RelayVantage {
+  vantage: "relay";
+  relayPeerId: string;
+  observedPeerId: string;
+  registry: {
+    totalRegistrations: number;
+    streamsForPeer: number;
+    atTotalCap: boolean;
+  };
+  rooms: Array<{ ref: string; size: number; members: string[] }>;
+  streams: Array<{
+    ref: string;
+    openedAt: number;
+    closedAt: number | null;
+    closeReason: RelayCloseReason | null;
+    rooms: number;
+    registers: number;
+    unregisters: number;
+    capped: number;
+    oracleSilenced: number;
+  }>;
+  events: DiagEvent[];
+}
+
+/**
+ * Why a rendezvous stream ended. Today the relay collapses all of these into
+ * one log line, which is the difference between "a peer left" and "a peer
+ * wedged". See `relay/telemetry.go`.
+ */
+export type RelayCloseReason =
+  | "graceful"
+  | "liveness-timeout"
+  | "idle-timeout"
+  | "read-error"
+  | "frame-oversize"
+  | "frame-invalid"
+  | "outbox-full"
+  | "stream-cap"
+  | "peer-disconnect"
+  | "evicted";
+
+/**
+ * Anything the dashboard can load from a file. Only a client bundle is ever
+ * exported; a relay vantage always arrives stapled inside one.
+ */
+export type DiagBundle = ClientBundle;
+
+// ---------------------------------------------------------------------------
+// SFU vantage - mirrored a third time in `sfu/telemetry.ts`
+// ---------------------------------------------------------------------------
+
+export interface DiagTransportView {
+  dir: "send" | "recv";
+  iceState: string;
+  dtlsState: string;
+  /** Protocol and LOCAL port only. NEVER a remote address. */
+  tuple: { protocol: string; localPort: number } | null;
+  bytesSent: number;
+  bytesReceived: number;
+  rtt: number | null;
+}
+
+export interface DiagProducerView {
+  id: string;
+  kind: string;
+  source: string;
+  score: number;
+  consumers: number;
+  bitrate: number;
+  packetsLost: number;
+}
+
+export interface DiagConsumerView {
+  id: string;
+  producerId: string;
+  kind: string;
+  score: number;
+  paused: boolean;
+  producerPaused: boolean;
+  bitrate: number;
+  packetsLost: number;
+}
+
+export interface SfuSnapshot {
+  schemaVersion: number;
+  takenAt: number;
+  roomPeerCount: number;
+  self: {
+    peerId: string;
+    transports: DiagTransportView[];
+    producers: DiagProducerView[];
+    consumers: DiagConsumerView[];
+    cumulativeProduces: number;
+    backpressured: boolean;
+  };
+  room: Array<{
+    peerId: string;
+    producers: Array<{
+      id: string;
+      source: string;
+      kind: string;
+      consumers: number;
+    }>;
+  }>;
+  ceilings: {
+    peersPerRoom: number;
+    producersPerPeer: number;
+    consumersPerPeer: number;
+    rooms: number;
+    maxRooms: number;
+  };
+}

--- a/frontend/src/lib/telemetry/schema.ts
+++ b/frontend/src/lib/telemetry/schema.ts
@@ -163,6 +163,8 @@ export type DiagKind =
   | "storage.locked"
   | "storage.quota"
   | "storage.drop"
+  | "runtime.error"
+  | "runtime.resources"
   | "counters"
   | "fault.injected"
   | "meta.suppressed";
@@ -172,7 +174,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 112;
+export const DIAG_KIND_COUNT = 114;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:
@@ -181,11 +183,12 @@ export const DIAG_KIND_COUNT = 112;
  *   `*.drop*`, `*.invalid`, `*.oversize`, plus `storage.locked` (an offline
  *   queue write was silently lost), `sfu.error` and `sfu.ws.error` (both are
  *   failures whose names predate this table), and `ice.turn.unavailable` (no
- *   TURN is a hard failure for a peer behind a symmetric NAT).
+ *   TURN is a hard failure for a peer behind a symmetric NAT), and
+ *   `runtime.error` (an exception nothing in the app caught).
  * - "warn": a degradation that still works - `*.degraded`, `*.stall*`,
  *   `*.retry`, `rv.close`, `peer.disconnect`, `storage.quota`.
  * - "debug": high-rate sampling - `peer.rtt`, `peer.clock`, `counters`,
- *   `sfu.diag`, `voice.ice.state`.
+ *   `sfu.diag`, `voice.ice.state`, `runtime.resources`.
  * - "info": everything else.
  *
  * `sev` decides the order `trimBundleForUpload` sacrifices events in, and it
@@ -314,6 +317,8 @@ export const KIND_SEV = {
   "storage.locked": "error",
   "storage.quota": "warn",
   "storage.drop": "error",
+  "runtime.error": "error",
+  "runtime.resources": "debug",
   counters: "debug",
   "fault.injected": "info",
   "meta.suppressed": "info",
@@ -335,6 +340,11 @@ export const KIND_BUDGET: Readonly<Partial<Record<DiagKind, number>>> = {
   "file.progress": 2,
   "voice.ice.state": 5,
   "peer.rtt": 2,
+  // One broken frame can throw on every animation tick. A storm of the same
+  // error says nothing the first five did not, and it would evict the ring
+  // that explains WHY it started.
+  "runtime.error": 5,
+  "runtime.resources": 2,
 };
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/telemetry/schema.ts
+++ b/frontend/src/lib/telemetry/schema.ts
@@ -134,6 +134,7 @@ export type DiagKind =
   | "voice.teardown"
   | "voice.redial.ask"
   | "voice.redial.serve"
+  | "voice.media.sample"
   | "voice.media.stall"
   | "voice.media.resume"
   // sfu
@@ -174,7 +175,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 114;
+export const DIAG_KIND_COUNT = 115;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:
@@ -188,7 +189,8 @@ export const DIAG_KIND_COUNT = 114;
  * - "warn": a degradation that still works - `*.degraded`, `*.stall*`,
  *   `*.retry`, `rv.close`, `peer.disconnect`, `storage.quota`.
  * - "debug": high-rate sampling - `peer.rtt`, `peer.clock`, `counters`,
- *   `sfu.diag`, `voice.ice.state`, `runtime.resources`.
+ *   `sfu.diag`, `voice.ice.state`, `runtime.resources`,
+ *   `voice.media.sample`.
  * - "info": everything else.
  *
  * `sev` decides the order `trimBundleForUpload` sacrifices events in, and it
@@ -288,6 +290,7 @@ export const KIND_SEV = {
   "voice.teardown": "info",
   "voice.redial.ask": "info",
   "voice.redial.serve": "info",
+  "voice.media.sample": "debug",
   "voice.media.stall": "warn",
   "voice.media.resume": "info",
   // sfu
@@ -343,6 +346,7 @@ export const KIND_BUDGET: Readonly<Partial<Record<DiagKind, number>>> = {
   // One broken frame can throw on every animation tick. A storm of the same
   // error says nothing the first five did not, and it would evict the ring
   // that explains WHY it started.
+  "voice.media.sample": 4,
   "runtime.error": 5,
   "runtime.resources": 2,
 };

--- a/frontend/src/lib/telemetry/store.test.ts
+++ b/frontend/src/lib/telemetry/store.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearStorageCrypto,
+  initStorageCrypto,
+} from "../storage-crypto";
+import {
+  getDiagChunks,
+  listDiagSessions,
+  pruneDiagnostics,
+  putDiagChunk,
+  wipeLocalDatabase,
+  type DiagChunkRecord,
+} from "../storage";
+import {
+  DIAG_KEEP_SESSIONS,
+  clearStoredDiagnostics,
+  flushNow,
+  loadStoredSession,
+  resetDiagStoreForTest,
+  storedDiagSessions,
+} from "./store";
+import { diagPrefs, setDiagPersist } from "./prefs.svelte";
+import { ev } from "./event";
+import { beginSession, rec, resetRecorderForTest } from "./recorder";
+import type { DiagEvent } from "./schema";
+
+const TEST_KEY = new Uint8Array(32).fill(7);
+
+function chunk(
+  sessionId: string,
+  chunkSeq: number,
+  startedAt: number,
+  events: DiagEvent[]
+): DiagChunkRecord {
+  const bytes = new TextEncoder().encode(JSON.stringify(events));
+  return {
+    id: `${sessionId}:${String(chunkSeq).padStart(6, "0")}`,
+    sessionId,
+    startedAt,
+    seqFrom: events[0]?.seq ?? 0,
+    seqTo: events[events.length - 1]?.seq ?? 0,
+    data: bytes.slice().buffer,
+  };
+}
+
+function event(seq: number, kind: DiagEvent["kind"] = "peer.connect"): DiagEvent {
+  return {
+    seq,
+    t: seq * 10,
+    kind,
+    sev: "info",
+    peer: "12D3KooWPEER",
+    room: null,
+  };
+}
+
+beforeEach(async () => {
+  await initStorageCrypto(TEST_KEY);
+  await wipeLocalDatabase();
+  resetRecorderForTest();
+  resetDiagStoreForTest();
+  setDiagPersist(false);
+});
+
+afterEach(() => {
+  clearStorageCrypto();
+});
+
+describe("the diagnostics store", () => {
+  it("round-trips a chunk through the sealed store", async () => {
+    await putDiagChunk(chunk("s1", 0, 1000, [event(1), event(2)]));
+    const rows = await getDiagChunks("s1");
+    expect(rows).toHaveLength(1);
+    const text = new TextDecoder().decode(new Uint8Array(rows[0].data));
+    expect(JSON.parse(text)).toHaveLength(2);
+  });
+
+  it("seals the events rather than storing them readable", async () => {
+    // The events carry peer ids and error strings; a readable diagnostic store
+    // would undo the sealed messages store one field over.
+    await putDiagChunk(chunk("s1", 0, 1000, [event(1)]));
+    const database = await (await import("../storage")).getDB();
+    const raw = await database.get("diagnostics", "s1:000000");
+    const sealed = new TextDecoder().decode(
+      new Uint8Array(raw?.data as ArrayBuffer)
+    );
+    expect(sealed).not.toContain("12D3KooWPEER");
+    expect(sealed).not.toContain("peer.connect");
+  });
+
+  it("keeps the clear fields readable so a prune needs no key", async () => {
+    await putDiagChunk(chunk("s1", 0, 4242, [event(1)]));
+    const sessions = await listDiagSessions();
+    expect(sessions).toEqual([
+      { sessionId: "s1", startedAt: 4242, chunks: 1, bytes: expect.any(Number) },
+    ]);
+  });
+
+  it("returns a session's chunks oldest first, whatever the write order", async () => {
+    await putDiagChunk(chunk("s1", 2, 1000, [event(9)]));
+    await putDiagChunk(chunk("s1", 0, 1000, [event(1)]));
+    await putDiagChunk(chunk("s1", 1, 1000, [event(5)]));
+    const rows = await getDiagChunks("s1");
+    expect(rows.map((r) => r.seqFrom)).toEqual([1, 5, 9]);
+  });
+
+  it("lists sessions newest first", async () => {
+    await putDiagChunk(chunk("old", 0, 1000, [event(1)]));
+    await putDiagChunk(chunk("new", 0, 5000, [event(1)]));
+    expect((await listDiagSessions()).map((s) => s.sessionId)).toEqual([
+      "new",
+      "old",
+    ]);
+  });
+
+  it("keeps exactly the newest N sessions", async () => {
+    for (let i = 1; i <= 6; i++) {
+      await putDiagChunk(chunk(`s${i}`, 0, i * 1000, [event(1)]));
+    }
+    const removed = await pruneDiagnostics(DIAG_KEEP_SESSIONS, 1024 * 1024);
+    expect(removed).toBe(3);
+    const kept = (await listDiagSessions()).map((s) => s.sessionId);
+    expect(kept).toEqual(["s6", "s5", "s4"]);
+  });
+
+  it("drops a whole session, never a partial history", async () => {
+    await putDiagChunk(chunk("s1", 0, 1000, [event(1)]));
+    await putDiagChunk(chunk("s1", 1, 1000, [event(2)]));
+    await putDiagChunk(chunk("s2", 0, 2000, [event(1)]));
+    await pruneDiagnostics(1, 1024 * 1024);
+    expect(await getDiagChunks("s1")).toEqual([]);
+    expect(await getDiagChunks("s2")).toHaveLength(1);
+  });
+
+  it("prunes on total bytes as well as session count", async () => {
+    const big = Array.from({ length: 200 }, (_, i) => event(i + 1));
+    for (let i = 1; i <= 3; i++) {
+      await putDiagChunk(chunk(`s${i}`, 0, i * 1000, big));
+    }
+    const removed = await pruneDiagnostics(DIAG_KEEP_SESSIONS, 100);
+    expect(removed).toBeGreaterThan(0);
+  });
+
+  it("never prunes the session that is still recording", async () => {
+    for (let i = 1; i <= 5; i++) {
+      await putDiagChunk(chunk(`s${i}`, 0, i * 1000, [event(1)]));
+    }
+    await pruneDiagnostics(1, 1, "s1");
+    expect(await getDiagChunks("s1")).toHaveLength(1);
+  });
+});
+
+describe("flush policy", () => {
+  it("writes nothing while the persist switch is off", async () => {
+    beginSession("sess-off", 1000);
+    rec(ev("session.start"));
+    await flushNow();
+    expect(await storedDiagSessions()).toEqual([]);
+  });
+
+  it("writes the ring once the switch is on", async () => {
+    setDiagPersist(true);
+    beginSession("sess-on", 1000);
+    rec(ev("session.start"));
+    rec(ev("peer.connect", { peer: "12D3KooWPEER" }));
+    await flushNow();
+    const sessions = await storedDiagSessions();
+    expect(sessions.map((s) => s.sessionId)).toEqual(["sess-on"]);
+  });
+
+  it("marks the moment persistence became possible", async () => {
+    // Boot, config and relay failures all happen before unlock, so the
+    // persisted stream starts late. `session.unlock` is what says why.
+    setDiagPersist(true);
+    beginSession("sess-unlock", 1000);
+    rec(ev("relay.dial.fail"));
+    await flushNow();
+    const events = await loadStoredSession("sess-unlock");
+    expect(events.map((e) => e.kind)).toEqual([
+      "relay.dial.fail",
+      "session.unlock",
+    ]);
+  });
+
+  it("writes only what is new on a second flush", async () => {
+    setDiagPersist(true);
+    beginSession("sess-inc", 1000);
+    rec(ev("session.start"));
+    await flushNow();
+    rec(ev("peer.connect", { peer: "12D3KooWPEER" }));
+    await flushNow();
+    const chunks = await getDiagChunks("sess-inc");
+    expect(chunks).toHaveLength(2);
+    expect(chunks[1].seqFrom).toBeGreaterThan(chunks[0].seqTo);
+    const events = await loadStoredSession("sess-inc");
+    expect(new Set(events.map((e) => e.seq)).size).toBe(events.length);
+  });
+
+  it("does nothing on a flush with no new events", async () => {
+    setDiagPersist(true);
+    beginSession("sess-idle", 1000);
+    rec(ev("session.start"));
+    await flushNow();
+    await flushNow();
+    expect(await getDiagChunks("sess-idle")).toHaveLength(1);
+  });
+
+  it("starts a new chunk series for a new session", async () => {
+    setDiagPersist(true);
+    beginSession("sess-a", 1000);
+    rec(ev("session.start"));
+    await flushNow();
+    beginSession("sess-b", 2000);
+    rec(ev("session.start"));
+    await flushNow();
+    expect((await getDiagChunks("sess-b"))[0].id).toBe("sess-b:000000");
+  });
+
+  it("survives a write that fails, rather than throwing at the caller", async () => {
+    setDiagPersist(true);
+    beginSession("sess-fail", 1000);
+    rec(ev("session.start"));
+    // Locked storage: `requireKey` throws inside `sealRow`.
+    clearStorageCrypto();
+    await expect(flushNow()).resolves.toBeUndefined();
+    await initStorageCrypto(TEST_KEY);
+  });
+
+  it("retries after unlock what it could not write before", async () => {
+    setDiagPersist(true);
+    beginSession("sess-late", 1000);
+    rec(ev("relay.dial.fail"));
+    clearStorageCrypto();
+    await flushNow();
+    expect(await storedDiagSessions()).toEqual([]);
+
+    await initStorageCrypto(TEST_KEY);
+    rec(ev("relay.dial.ok"));
+    await flushNow();
+    const events = await loadStoredSession("sess-late");
+    expect(events.map((e) => e.kind)).toContain("relay.dial.fail");
+    expect(events.map((e) => e.kind)).toContain("relay.dial.ok");
+  });
+
+  it("clears everything on request", async () => {
+    setDiagPersist(true);
+    beginSession("sess-clear", 1000);
+    rec(ev("session.start"));
+    await flushNow();
+    await clearStoredDiagnostics();
+    expect(await storedDiagSessions()).toEqual([]);
+    expect(diagPrefs.persist).toBe(true);
+  });
+});

--- a/frontend/src/lib/telemetry/store.ts
+++ b/frontend/src/lib/telemetry/store.ts
@@ -1,0 +1,183 @@
+/**
+ * Optional persistence for the flight recorder.
+ *
+ * The recorder itself is always on, in memory. This module is one of its three
+ * gated exits, and it runs ONLY while `diagPrefs.persist` is on.
+ *
+ * Ordering matters here. `blindValue` and `requireKey` throw before unlock, and
+ * boot, config and relay failures happen exactly then - so the earliest and
+ * most valuable events cannot be written when they occur. They stay in the ring
+ * and are flushed on the first tick after unlock, and a `session.unlock` event
+ * marks the moment, so a reader knows why the persisted stream starts late.
+ */
+
+import {
+  deleteDiagnostics,
+  getDiagChunks,
+  listDiagSessions,
+  pruneDiagnostics,
+  putDiagChunk,
+  type DiagChunkRecord,
+  type DiagSessionSummary,
+} from "../storage";
+import { storageCryptoReady } from "../storage-crypto";
+import { errText, ev } from "./event";
+import { diagPrefs } from "./prefs.svelte";
+import { rec, recorderSnapshot } from "./recorder";
+import type { DiagEvent } from "./schema";
+
+/** Sessions kept on disk. Three covers "it broke, I reloaded, it broke again". */
+export const DIAG_KEEP_SESSIONS = 3;
+/** Total sealed bytes kept. Beyond this the oldest session goes, whole. */
+export const DIAG_MAX_BYTES = 8 * 1024 * 1024;
+/** Flush cadence. */
+export const DIAG_FLUSH_MS = 10_000;
+/** Flush early once this many events are unwritten. */
+export const DIAG_FLUSH_EVENTS = 512;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let flushedThrough = 0;
+let chunkSeq = 0;
+let sawUnlock = false;
+let flushing = false;
+let sessionId = "";
+
+/** Idempotent. Safe to call before unlock and before a session exists. */
+export function startDiagPersistence(): void {
+  if (timer !== null) return;
+  timer = setInterval(() => {
+    void maybeFlush();
+  }, DIAG_FLUSH_MS);
+}
+
+export function stopDiagPersistence(): void {
+  if (timer !== null) clearInterval(timer);
+  timer = null;
+}
+
+/** Called by the recorder's own taps whenever the ring grew. */
+export function noteDiagGrowth(): void {
+  const snap = recorderSnapshot();
+  if (snap.nextSeq - flushedThrough > DIAG_FLUSH_EVENTS) void maybeFlush();
+}
+
+/**
+ * Write everything not yet written. Never throws: a storage failure becomes one
+ * `storage.quota` event and one console warning.
+ */
+export async function flushNow(): Promise<void> {
+  await maybeFlush();
+}
+
+async function maybeFlush(): Promise<void> {
+  if (!diagPrefs.persist) return;
+  if (!storageCryptoReady()) return;
+  // One flush at a time. Two overlapping flushes would both read the same
+  // `flushedThrough` and write the same events under two chunk ids.
+  if (flushing) return;
+
+  let snap = recorderSnapshot();
+  if (!snap.sessionId) return;
+
+  if (snap.sessionId !== sessionId) {
+    sessionId = snap.sessionId;
+    flushedThrough = 0;
+    chunkSeq = 0;
+    sawUnlock = false;
+  }
+
+  if (!sawUnlock) {
+    sawUnlock = true;
+    // Recorded, then re-read, so it lands in the FIRST chunk and explains the
+    // gap that precedes it. A snapshot taken before this call would push the
+    // event into the next chunk, and a flush with nothing else to say would
+    // write a chunk holding only this one event.
+    rec(ev("session.unlock"));
+    snap = recorderSnapshot();
+  }
+
+  const pending = snap.events.filter((e) => e.seq > flushedThrough);
+  if (pending.length === 0) return;
+
+  flushing = true;
+  try {
+    const record: DiagChunkRecord = {
+      id: `${snap.sessionId}:${String(chunkSeq).padStart(6, "0")}`,
+      sessionId: snap.sessionId,
+      startedAt: snap.startedAt,
+      seqFrom: pending[0].seq,
+      seqTo: pending[pending.length - 1].seq,
+      data: encodeEvents(pending),
+    };
+    await putDiagChunk(record);
+    chunkSeq++;
+    flushedThrough = record.seqTo;
+    await pruneDiagnostics(
+      DIAG_KEEP_SESSIONS,
+      DIAG_MAX_BYTES,
+      snap.sessionId
+    );
+  } catch (err) {
+    rec(ev("storage.quota", { d: { err: errText(err), what: "diag-chunk" } }));
+    console.warn("[diag] chunk not persisted:", err);
+  } finally {
+    flushing = false;
+  }
+}
+
+function encodeEvents(events: DiagEvent[]): ArrayBuffer {
+  const bytes = new TextEncoder().encode(JSON.stringify(events));
+  // A fresh, exactly sized buffer: a TextEncoder result can be a view into a
+  // larger pool, and IndexedDB would store the whole pool.
+  return bytes.slice().buffer;
+}
+
+
+/** Every stored session, newest first. For the Diagnostics pane. */
+export async function storedDiagSessions(): Promise<DiagSessionSummary[]> {
+  try {
+    return await listDiagSessions();
+  } catch (err) {
+    console.warn("[diag] could not list stored sessions:", err);
+    return [];
+  }
+}
+
+/** One stored session's events, oldest first, gaps and all. */
+export async function loadStoredSession(id: string): Promise<DiagEvent[]> {
+  try {
+    const chunks = await getDiagChunks(id);
+    const out: DiagEvent[] = [];
+    for (const chunk of chunks) {
+      const text = new TextDecoder().decode(new Uint8Array(chunk.data));
+      const parsed: unknown = JSON.parse(text);
+      if (Array.isArray(parsed)) out.push(...(parsed as DiagEvent[]));
+    }
+    out.sort((a, b) => a.seq - b.seq);
+    return out;
+  } catch (err) {
+    console.warn("[diag] could not read stored session:", err);
+    return [];
+  }
+}
+
+/** Drop every stored chunk. The pane's "Clear stored diagnostics" action. */
+export async function clearStoredDiagnostics(): Promise<void> {
+  try {
+    await deleteDiagnostics();
+    flushedThrough = 0;
+    chunkSeq = 0;
+    sessionId = "";
+  } catch (err) {
+    console.warn("[diag] could not clear stored diagnostics:", err);
+  }
+}
+
+export function resetDiagStoreForTest(): void {
+  stopDiagPersistence();
+  flushedThrough = 0;
+  chunkSeq = 0;
+  sawUnlock = false;
+  flushing = false;
+  sessionId = "";
+}

--- a/frontend/src/lib/telemetry/taps.test.ts
+++ b/frontend/src/lib/telemetry/taps.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
+  censusEvent,
   counterEvents,
+  errorEvent,
   diffCounters,
   flattenBags,
   statusEvent,
@@ -280,5 +282,82 @@ describe("counter sampling", () => {
     expect(Object.keys(events[2].d ?? {})).toHaveLength(1);
     const seen = events.flatMap((e) => Object.keys(e.d ?? {}));
     expect(new Set(seen).size).toBe(25);
+  });
+});
+
+describe("uncaught failures", () => {
+  beforeEach(() => {
+    resetRecorderForTest();
+    beginSession("s1", 0);
+  });
+
+  it("records a thrown DOMException with its name and message", () => {
+    // The two that actually reached users, verbatim from the console.
+    const body = errorEvent(
+      "uncaught",
+      new DOMException(
+        "Failed to construct 'RTCPeerConnection': Cannot create so many PeerConnections",
+        "UnknownError"
+      )
+    );
+    expect(body.kind).toBe("runtime.error");
+    expect(body.sev).toBe("error");
+    expect(body.d?.source).toBe("uncaught");
+    expect(String(body.d?.err)).toContain("so many PeerConnections");
+  });
+
+  it("records a rejection whose reason is not an Error", () => {
+    const body = errorEvent("rejection", "duplicated a=msid detected");
+    expect(String(body.d?.err)).toContain("duplicated a=msid");
+  });
+
+  it("scrubs a room code the platform quoted back at us", () => {
+    const code = "a1b2c3d4e5f60718";
+    const ref = refs().roomRef(code);
+    // A real message from a real failure path: the URL carries the code.
+    const body = errorEvent(
+      "uncaught",
+      new TypeError(`Failed to fetch https://relay.example/invite/${code}`)
+    );
+    const text = String(body.d?.err);
+    expect(text).not.toContain(code);
+    expect(text).toContain("<url>");
+    // And outside a URL, where the ordinal is the useful replacement.
+    const bare = errorEvent("uncaught", new Error(`room ${code} is wedged`));
+    expect(String(bare.d?.err)).not.toContain(code);
+    expect(String(bare.d?.err)).toContain(ref);
+  });
+
+  it("scrubs a did:key even when this session never bound it", () => {
+    const body = errorEvent(
+      "rejection",
+      new Error(
+        "no route to did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"
+      )
+    );
+    expect(String(body.d?.err)).not.toContain("z6Mkjchh");
+    expect(String(body.d?.err)).toContain("<did>");
+  });
+
+  it("never throws, whatever was thrown at it", () => {
+    const hostile = {
+      get message() {
+        throw new Error("nope");
+      },
+      toString() {
+        throw new Error("nope");
+      },
+    };
+    expect(() => errorEvent("uncaught", hostile)).not.toThrow();
+    expect(() => errorEvent("rejection", undefined)).not.toThrow();
+  });
+});
+
+describe("the resource gauge", () => {
+  it("says nothing while the gauge is not installed", () => {
+    // jsdom has no RTCPeerConnection, so the census never installs here -
+    // and a sampler with nothing to sample must stay quiet rather than
+    // record a misleading zero.
+    expect(censusEvent()).toBeNull();
   });
 });

--- a/frontend/src/lib/telemetry/taps.test.ts
+++ b/frontend/src/lib/telemetry/taps.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  counterEvents,
+  diffCounters,
+  flattenBags,
+  statusEvent,
+  transportEvent,
+  videoEvent,
+  voiceEvent,
+} from "./taps";
+import { beginSession, refs, resetRecorderForTest } from "./recorder";
+import { KIND_SEV, type DiagKind } from "./schema";
+import type { TransportStatus } from "../transport/types";
+
+/** A human-facing banner string. It must never reach a bundle. */
+const SENTINEL = "zzUserFacingBannerTextzz";
+
+/** Every member of the `TransportStatus` union, in declaration order. */
+const ALL_STATUSES: TransportStatus[] = [
+  { type: "app-warning", message: SENTINEL },
+  { type: "relay-connected", message: SENTINEL },
+  { type: "relay-disconnected", message: SENTINEL },
+  { type: "relay-dial-retry", message: SENTINEL },
+  { type: "relay-dial-failed", message: SENTINEL },
+  { type: "relay-reconnect-failed", message: SENTINEL },
+  { type: "relay-reconnecting", message: SENTINEL },
+  { type: "stream-open-failed", peerId: "12D3KooWAAA", message: SENTINEL },
+  { type: "rendezvous-failed", message: SENTINEL },
+  { type: "rendezvous-reconnecting", message: SENTINEL },
+  { type: "reservation-timeout", message: SENTINEL },
+  { type: "voice-dial-failed", peerId: "12D3KooWAAA", message: SENTINEL },
+  { type: "voice-peer-left", peerId: "12D3KooWAAA", message: SENTINEL },
+  { type: "peer-dial-failed", peerId: "12D3KooWAAA", message: SENTINEL },
+  { type: "voice-connection-failed", peerId: "12D3KooWAAA", message: SENTINEL },
+  {
+    type: "voice-ice-connected",
+    peerId: "12D3KooWAAA",
+    relayed: true,
+    message: SENTINEL,
+  },
+  { type: "voice-degraded", peerId: "12D3KooWAAA", message: SENTINEL },
+];
+
+describe("statusEvent", () => {
+  it("covers all 17 TransportStatus variants", () => {
+    // Nine of these are emitted today and read by nothing. If a variant is
+    // added to the union and not to the table, `statusEvent` stops compiling -
+    // this asserts the other direction, that the fixture is complete.
+    expect(ALL_STATUSES).toHaveLength(17);
+    const types = new Set(ALL_STATUSES.map((s) => s.type));
+    expect(types.size).toBe(17);
+  });
+
+  it("maps each variant to its documented kind", () => {
+    const expected: Record<string, DiagKind> = {
+      "app-warning": "session.config",
+      "relay-connected": "relay.dial.ok",
+      "relay-disconnected": "relay.disconnect",
+      "relay-dial-retry": "relay.dial.attempt",
+      "relay-dial-failed": "relay.dial.fail",
+      "relay-reconnecting": "relay.reconnect.schedule",
+      "relay-reconnect-failed": "relay.reconnect.fail",
+      "reservation-timeout": "relay.reservation.timeout",
+      "rendezvous-failed": "rv.open.fail",
+      "rendezvous-reconnecting": "rv.open",
+      "stream-open-failed": "stream.open.fail",
+      "peer-dial-failed": "peer.dial.fail",
+      "voice-dial-failed": "voice.pc.new",
+      "voice-peer-left": "voice.teardown",
+      "voice-connection-failed": "voice.failed",
+      "voice-ice-connected": "voice.ice.connected",
+      "voice-degraded": "voice.degraded",
+    };
+    for (const status of ALL_STATUSES) {
+      expect(statusEvent(status).kind).toBe(expected[status.type]);
+    }
+  });
+
+  it("carries the full peerId for every peer-naming variant", () => {
+    for (const status of ALL_STATUSES) {
+      if (!("peerId" in status)) continue;
+      expect(statusEvent(status).peer).toBe("12D3KooWAAA");
+    }
+  });
+
+  it("escalates the two variants whose default severity is too low", () => {
+    // `app-warning` is a real app problem and `rendezvous-reconnecting` means
+    // the room membership channel is down, but their kinds are shared with
+    // ordinary info events.
+    expect(statusEvent({ type: "app-warning", message: SENTINEL }).sev).toBe("warn");
+    expect(
+      statusEvent({ type: "rendezvous-reconnecting", message: SENTINEL }).sev
+    ).toBe("warn");
+  });
+
+  it("records a voice dial failure as an error even though its kind is info", () => {
+    const body = statusEvent({
+      type: "voice-dial-failed",
+      peerId: "12D3KooWAAA",
+      message: SENTINEL,
+    });
+    expect(body.sev).toBe("error");
+    expect(KIND_SEV["voice.pc.new"]).toBe("info");
+  });
+
+  it("keeps the relayed flag, which decides voice-relayed-only", () => {
+    const body = statusEvent({
+      type: "voice-ice-connected",
+      peerId: "12D3KooWAAA",
+      relayed: true,
+      message: SENTINEL,
+    });
+    expect(body.d).toEqual({ relayed: true });
+  });
+
+  it("never copies a status message into the event", () => {
+    for (const status of ALL_STATUSES) {
+      const body = statusEvent(status);
+      expect(JSON.stringify(body)).not.toContain(SENTINEL);
+    }
+  });
+});
+
+describe("transportEvent", () => {
+  beforeEach(() => {
+    resetRecorderForTest();
+    beginSession("s", 0);
+  });
+
+  it("maps the connection lifecycle", () => {
+    expect(transportEvent("connect", ["p1"])).toMatchObject({
+      kind: "peer.connect",
+      peer: "p1",
+    });
+    expect(transportEvent("disconnect", ["p1"])?.kind).toBe("peer.disconnect");
+    expect(transportEvent("streamProven", ["p1"])?.kind).toBe("stream.proven");
+    expect(transportEvent("streamLost", ["p1"])?.kind).toBe("stream.lost");
+  });
+
+  it("splits relayChanged into two kinds", () => {
+    expect(transportEvent("relayChanged", ["p1", true])?.kind).toBe(
+      "peer.relayed"
+    );
+    expect(transportEvent("relayChanged", ["p1", false])?.kind).toBe(
+      "peer.direct"
+    );
+  });
+
+  it("replaces a room code with an ordinal", () => {
+    const code = "0123456789abcdef";
+    const body = transportEvent("roomPeers", [code, ["p1", "p2"]]);
+    expect(body).toMatchObject({ kind: "rv.peers", room: "r1" });
+    expect(body?.d).toEqual({ count: 2 });
+    expect(JSON.stringify(body)).not.toContain(code);
+  });
+
+  it("reduces a message to its byte length", () => {
+    const payload = new Uint8Array([1, 2, 3, 4, 5]);
+    const body = transportEvent("message", ["p1", payload, "roomcode1234"]);
+    expect(body).toMatchObject({ kind: "app.msg.in", peer: "p1", room: "r1" });
+    expect(body?.d).toEqual({ bytes: 5 });
+    expect(JSON.stringify(body)).not.toContain("roomcode1234");
+  });
+
+  it("keeps a null room null rather than minting an ordinal", () => {
+    const body = transportEvent("message", ["p1", new Uint8Array(0), null]);
+    expect(body?.room).toBeNull();
+    expect(refs().rooms()).toEqual([]);
+  });
+
+  it("labels the device-sync bus so its events are distinguishable", () => {
+    const body = transportEvent("connect", ["p1"], "sync");
+    expect(body?.d).toEqual({ bus: "sync" });
+  });
+
+  it("does not label the main bus", () => {
+    expect(transportEvent("connect", ["p1"], "main")?.d).toBeUndefined();
+  });
+
+  it("returns null for an event with no diagnostic content", () => {
+    expect(transportEvent("somethingElse", [])).toBeNull();
+    expect(transportEvent("status", [])).toBeNull();
+  });
+});
+
+describe("voiceEvent", () => {
+  it("maps the voice roster and media flow", () => {
+    expect(voiceEvent("peerJoined", ["p1"])?.kind).toBe("voice.join");
+    expect(voiceEvent("peerLeft", ["p1"])?.kind).toBe("voice.leave");
+    expect(voiceEvent("trackAdded", ["p1", {}])?.kind).toBe(
+      "voice.media.resume"
+    );
+    expect(voiceEvent("trackRemoved", ["p1"])?.kind).toBe("voice.teardown");
+  });
+
+  it("records the device class but never the deviceId", () => {
+    const body = voiceEvent("deviceChanged", ["input", "hw:deadbeef"]);
+    expect(body?.d).toEqual({ audioDevice: "input" });
+    expect(JSON.stringify(body)).not.toContain("hw:deadbeef");
+  });
+
+  it("reduces an error to a name and message", () => {
+    const body = voiceEvent("error", [new TypeError("boom")]);
+    expect(body).toMatchObject({ kind: "voice.failed" });
+    expect(body?.d).toEqual({ message: "TypeError: boom" });
+  });
+
+  it("reuses the status table", () => {
+    expect(voiceEvent("status", [{ type: "voice-degraded", peerId: "p1", message: SENTINEL }])?.kind).toBe(
+      "voice.degraded"
+    );
+  });
+});
+
+describe("videoEvent", () => {
+  it("maps the SFU track lifecycle", () => {
+    expect(videoEvent("trackAdded", ["p1", {}, "camera"])).toMatchObject({
+      kind: "sfu.track.added",
+      peer: "p1",
+      d: { source: "camera" },
+    });
+    expect(videoEvent("trackStalled", ["p1", "screen"])).toMatchObject({
+      kind: "sfu.track.stalled",
+      d: { source: "screen" },
+    });
+  });
+
+  it("discriminates the four transmission events by phase", () => {
+    const phases = [
+      ["transmissionAvailable", "available"],
+      ["transmissionEnded", "ended"],
+      ["transmissionWatched", "watched"],
+      ["transmissionWatchEnded", "watch-ended"],
+    ] as const;
+    for (const [event, phase] of phases) {
+      expect(videoEvent(event, ["p1"])).toMatchObject({
+        kind: "sfu.consume",
+        d: { phase },
+      });
+    }
+  });
+
+  it("skips the events the SFU snapshot already covers", () => {
+    // The SFU's own roster arrives with far higher fidelity in an `sfu.diag`
+    // snapshot, which is what the sfu-room-split rule reads.
+    expect(videoEvent("peerJoined", ["p1"])).toBeNull();
+    expect(videoEvent("peerLeft", ["p1"])).toBeNull();
+    expect(videoEvent("outputVolumeChanged", [0.5])).toBeNull();
+  });
+});
+
+describe("counter sampling", () => {
+  it("flattens bags with a prefix so three bags cannot collide", () => {
+    expect(
+      flattenBags({ t: { connects: 1 }, a: { connects: 9 }, f: {} })
+    ).toEqual({ "t.connects": 1, "a.connects": 9 });
+  });
+
+  it("reports only what changed", () => {
+    expect(
+      diffCounters({ "t.a": 5, "t.b": 1 }, { "t.a": 7, "t.b": 1 })
+    ).toEqual({ "t.a": 2 });
+  });
+
+  it("treats a missing key as zero", () => {
+    expect(diffCounters({}, { "t.a": 3 })).toEqual({ "t.a": 3 });
+  });
+
+  it("emits nothing when nothing moved", () => {
+    expect(counterEvents(diffCounters({ "t.a": 1 }, { "t.a": 1 }))).toEqual([]);
+  });
+
+  it("chunks a wide delta rather than losing the overflow", () => {
+    // Three bags carry 24 counters and a detail bag holds 12 keys.
+    const delta: Record<string, number> = {};
+    for (let i = 0; i < 25; i++) delta[`t.k${i}`] = 1;
+    const events = counterEvents(delta);
+    expect(events).toHaveLength(3);
+    expect(Object.keys(events[0].d ?? {})).toHaveLength(12);
+    expect(Object.keys(events[2].d ?? {})).toHaveLength(1);
+    const seen = events.flatMap((e) => Object.keys(e.d ?? {}));
+    expect(new Set(seen).size).toBe(25);
+  });
+});

--- a/frontend/src/lib/telemetry/taps.test.ts
+++ b/frontend/src/lib/telemetry/taps.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   censusEvent,
+  probeTurn,
+  resetTurnProbeForTest,
+  TURN_PROBE_MIN_INTERVAL_MS,
   counterEvents,
   errorEvent,
   diffCounters,
@@ -10,7 +13,12 @@ import {
   videoEvent,
   voiceEvent,
 } from "./taps";
-import { beginSession, refs, resetRecorderForTest } from "./recorder";
+import {
+  beginSession,
+  recorderSnapshot,
+  refs,
+  resetRecorderForTest,
+} from "./recorder";
 import { KIND_SEV, type DiagKind } from "./schema";
 import type { TransportStatus } from "../transport/types";
 
@@ -359,5 +367,61 @@ describe("the resource gauge", () => {
     // and a sampler with nothing to sample must stay quiet rather than
     // record a misleading zero.
     expect(censusEvent()).toBeNull();
+  });
+});
+
+describe("the TURN reachability probe", () => {
+  beforeEach(() => {
+    resetRecorderForTest();
+    beginSession("s1", 0);
+    resetTurnProbeForTest();
+  });
+
+  const TURN = { urls: "turn:t.example:3478", username: "u", credential: "c" };
+
+  it("records nothing when there is no TURN to ask", async () => {
+    await probeTurn([{ urls: "stun:s.example:19302" }]);
+    const kinds = recorderSnapshot().events.map((e) => e.kind);
+    // The credential path already reports a missing credential; a second
+    // report would double-count it in every rule that reads these.
+    expect(kinds).not.toContain("ice.turn.fail");
+    expect(kinds).not.toContain("ice.turn.ok");
+  });
+
+  it("records a failure when no allocation is possible", async () => {
+    // jsdom has no RTCPeerConnection, so the probe cannot build one and
+    // returns null - the same "nothing to say" path. Assert the shape that
+    // matters instead: it must never throw into its caller.
+    await expect(probeTurn([TURN])).resolves.toBeUndefined();
+  });
+
+  it("asks at most once a minute, however many links fail", async () => {
+    // A room where every link fails at once must not mean one allocation per
+    // link: the probe builds a connection of its own, and a storm of them is
+    // the very budget problem it exists to help diagnose.
+    let built = 0;
+    (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection =
+      class {
+        constructor() {
+          built++;
+          throw new Error("stub");
+        }
+      };
+    try {
+      await probeTurn([TURN], 1_000_000);
+      expect(built).toBe(1);
+      await probeTurn([TURN], 1_000_000 + TURN_PROBE_MIN_INTERVAL_MS - 1);
+      expect(built).toBe(1);
+      await probeTurn([TURN], 1_000_000 + TURN_PROBE_MIN_INTERVAL_MS);
+      expect(built).toBe(2);
+      // Both attempts are on the record as failures, with the branch that
+      // says an allocation was tried rather than a credential missed.
+      const fails = recorderSnapshot().events.filter(
+        (e) => e.kind === "ice.turn.fail" && e.d?.branch === "allocate"
+      );
+      expect(fails).toHaveLength(2);
+    } finally {
+      delete (globalThis as { RTCPeerConnection?: unknown }).RTCPeerConnection;
+    }
   });
 });

--- a/frontend/src/lib/telemetry/taps.ts
+++ b/frontend/src/lib/telemetry/taps.ts
@@ -15,6 +15,7 @@
 
 import { errText, ev, MAX_DETAIL_KEYS } from "./event";
 import { installPcCensus, pcCensus } from "./pc-census";
+import { probeTurnAllocation } from "./net-probe";
 import {
   initRecorder,
   rec,
@@ -347,6 +348,55 @@ export function censusEvent(): Body | null {
   return ev("runtime.resources", {
     d: { pcLive: c.live, pcCreated: c.created, pcPeak: c.peak },
   });
+}
+
+/**
+ * Not more often than this, however many links fail at once: one allocation
+ * per minute is enough to date a TURN outage, and the probe builds a
+ * connection of its own.
+ */
+export const TURN_PROBE_MIN_INTERVAL_MS = 60_000;
+
+let lastTurnProbeAt = -Infinity;
+
+/**
+ * Ask the network directly, and record the answer next to the app's own.
+ *
+ * Called at the two moments the answer is worth having: when credentials
+ * first land, and when a voice link gives up. The second is the one that
+ * matters - a probe taken at the instant the app failed is what separates
+ * "TURN was down for this user" from "the app never used it".
+ */
+export async function probeTurn(
+  servers: readonly RTCIceServer[],
+  now: number = Date.now()
+): Promise<void> {
+  try {
+    if (now - lastTurnProbeAt < TURN_PROBE_MIN_INTERVAL_MS) return;
+    lastTurnProbeAt = now;
+    const res = await probeTurnAllocation(servers);
+    // Nothing to ask: the credential path reports that on its own.
+    if (!res) return;
+    rec(
+      res.ok
+        ? ev("ice.turn.ok", { d: { branch: "allocate", ms: res.ms } })
+        : ev("ice.turn.fail", {
+            d: {
+              branch: "allocate",
+              ms: res.ms,
+              outcome: res.outcome,
+              err: res.err ?? null,
+            },
+          })
+    );
+  } catch {
+    // A sampler never breaks the app.
+  }
+}
+
+/** The rate limiter is module state; a test needs to clear it. */
+export function resetTurnProbeForTest(): void {
+  lastTurnProbeAt = -Infinity;
 }
 
 function onWindowError(e: ErrorEvent): void {

--- a/frontend/src/lib/telemetry/taps.ts
+++ b/frontend/src/lib/telemetry/taps.ts
@@ -14,6 +14,7 @@
  */
 
 import { errText, ev, MAX_DETAIL_KEYS } from "./event";
+import { installPcCensus, pcCensus } from "./pc-census";
 import {
   initRecorder,
   rec,
@@ -303,6 +304,60 @@ export function counterEvents(delta: Record<string, number>): Body[] {
 }
 
 // ---------------------------------------------------------------------------
+// Uncaught failures and the resource gauge
+// ---------------------------------------------------------------------------
+
+/**
+ * An exception nothing in the app caught.
+ *
+ * Every other probe here records a decision the code made ON PURPOSE. This one
+ * records the ones it did not: a `DOMException` from `setRemoteDescription`, a
+ * constructor refusing because a browser budget is spent, a rejection in a
+ * `void`-ed promise. Those are exactly the failures with no handler to tap,
+ * which is why they are also the ones that reach a user with nothing written
+ * down anywhere.
+ *
+ * The message is SCRUBBED, not merely truncated: an error composed by the
+ * platform quotes whatever the app passed it, and a failed fetch quotes its
+ * URL - which is how a room code gets into text that has no field for one.
+ */
+export function errorEvent(source: "uncaught" | "rejection", value: unknown): Body {
+  return ev("runtime.error", {
+    d: { source, err: refs().scrub(errText(value)) },
+  });
+}
+
+let lastCensus = "";
+
+/**
+ * The `RTCPeerConnection` gauge, on change only.
+ *
+ * A silent gauge means a steady one: at four connections per peer this would
+ * otherwise repeat the same three numbers every tick for the whole session,
+ * and the ring is the scarce thing here. What matters is the shape over time -
+ * `live` that only ever climbs is a leak, and `created` climbing while `live`
+ * holds is a rebuild loop.
+ */
+export function censusEvent(): Body | null {
+  const c = pcCensus();
+  if (!c.installed) return null;
+  const key = `${c.live}/${c.created}`;
+  if (key === lastCensus) return null;
+  lastCensus = key;
+  return ev("runtime.resources", {
+    d: { pcLive: c.live, pcCreated: c.created, pcPeak: c.peak },
+  });
+}
+
+function onWindowError(e: ErrorEvent): void {
+  rec(errorEvent("uncaught", e.error ?? e.message));
+}
+
+function onRejection(e: PromiseRejectionEvent): void {
+  rec(errorEvent("rejection", e.reason));
+}
+
+// ---------------------------------------------------------------------------
 // Installation
 // ---------------------------------------------------------------------------
 
@@ -336,6 +391,14 @@ export function installTelemetryTaps(opts: TelemetryTapOptions): void {
   stopTelemetryTaps();
   initRecorder(opts);
   lastCounters = {};
+  lastCensus = "";
+  // Before the first dial: a connection built earlier than this is invisible
+  // to the gauge for the rest of the session.
+  installPcCensus();
+  if (typeof window !== "undefined") {
+    window.addEventListener("error", onWindowError);
+    window.addEventListener("unhandledrejection", onRejection);
+  }
 
   counterTimer = setInterval(() => {
     try {
@@ -348,6 +411,8 @@ export function installTelemetryTaps(opts: TelemetryTapOptions): void {
       lastCounters = now;
       recordCounters(now);
       for (const body of counterEvents(delta)) rec(body);
+      const census = censusEvent();
+      if (census) rec(census);
     } catch {
       // A sampler never breaks the app.
     }
@@ -386,6 +451,10 @@ export async function sampleSfu(
 }
 
 export function stopTelemetryTaps(): void {
+  if (typeof window !== "undefined") {
+    window.removeEventListener("error", onWindowError);
+    window.removeEventListener("unhandledrejection", onRejection);
+  }
   if (counterTimer !== null) clearInterval(counterTimer);
   if (sfuTimer !== null) clearInterval(sfuTimer);
   counterTimer = null;
@@ -416,4 +485,6 @@ export const TAP_KINDS: readonly DiagKind[] = [
   "counters",
   "sfu.diag",
   "fault.injected",
+  "runtime.error",
+  "runtime.resources",
 ];

--- a/frontend/src/lib/telemetry/taps.ts
+++ b/frontend/src/lib/telemetry/taps.ts
@@ -1,0 +1,419 @@
+/**
+ * Bus taps and samplers - the pure translation layer between the three event
+ * buses and `DiagKind`.
+ *
+ * Every function that maps an event name plus its arguments to an event body
+ * is pure and exported, so it can be tested without a transport. That matters
+ * more than it looks: `transport.svelte.ts` builds a libp2p node at import
+ * time and cannot load under vitest (see `transport/call-error.ts`), so a
+ * translator living next to the emitter would be untestable.
+ *
+ * REDACTION: a translator receives room CODES and message BYTES. It must
+ * convert a code through `refs().roomRef()` and reduce a payload to a length.
+ * `taps.test.ts` asserts that no translator ever copies either into `d`.
+ */
+
+import { errText, ev, MAX_DETAIL_KEYS } from "./event";
+import {
+  initRecorder,
+  rec,
+  recordCounters,
+  recordSfuSnapshot,
+  refs,
+  type RecorderContext,
+} from "./recorder";
+import type { DiagEvent, DiagKind, SfuSnapshot } from "./schema";
+import type { TransportStatus } from "../transport/types";
+
+/** How often the counter bags are diffed. */
+export const COUNTER_SAMPLE_MS = 5000;
+/** How often an SFU snapshot is requested while in a call. */
+export const SFU_DIAG_SAMPLE_MS = 30_000;
+
+type Body = Omit<DiagEvent, "seq" | "t">;
+
+// ---------------------------------------------------------------------------
+// TransportStatus - all 17 variants
+// ---------------------------------------------------------------------------
+
+/**
+ * Nine of these variants are emitted today and read by NOTHING:
+ * `TransportStatus.svelte` deletes each toast on a 10 s timer and
+ * `transport.svelte.ts` switches on five. This table is where they stop being
+ * discarded.
+ */
+export function statusEvent(status: TransportStatus): Body {
+  const peer = "peerId" in status ? status.peerId : null;
+  switch (status.type) {
+    case "app-warning":
+      return ev("session.config", { sev: "warn", d: { warning: true } });
+    case "relay-connected":
+      return ev("relay.dial.ok");
+    case "relay-disconnected":
+      return ev("relay.disconnect");
+    case "relay-dial-retry":
+      return ev("relay.dial.attempt");
+    case "relay-dial-failed":
+      return ev("relay.dial.fail");
+    case "relay-reconnecting":
+      return ev("relay.reconnect.schedule");
+    case "relay-reconnect-failed":
+      return ev("relay.reconnect.fail");
+    case "reservation-timeout":
+      return ev("relay.reservation.timeout");
+    case "rendezvous-failed":
+      return ev("rv.open.fail");
+    case "rendezvous-reconnecting":
+      return ev("rv.open", { sev: "warn", d: { reconnecting: true } });
+    case "stream-open-failed":
+      return ev("stream.open.fail", { peer });
+    case "peer-dial-failed":
+      return ev("peer.dial.fail", { peer });
+    case "voice-dial-failed":
+      return ev("voice.pc.new", { peer, sev: "error", d: { failed: true } });
+    case "voice-peer-left":
+      return ev("voice.teardown", { peer });
+    case "voice-connection-failed":
+      return ev("voice.failed", { peer });
+    case "voice-ice-connected":
+      return ev("voice.ice.connected", {
+        peer,
+        d: { relayed: status.relayed },
+      });
+    case "voice-degraded":
+      return ev("voice.degraded", { peer });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bus translators
+// ---------------------------------------------------------------------------
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+/**
+ * `TransportEvents` -> an event body, or null for an event with no diagnostic
+ * content.
+ *
+ * @param bus "sync" for the SECOND `LibP2PTransport` that device sync builds.
+ *   Without the label its events are indistinguishable from the chat bus's.
+ */
+export function transportEvent(
+  event: string,
+  args: unknown[],
+  bus?: string
+): Body | null {
+  const body = translateTransport(event, args);
+  if (!body) return null;
+  if (bus && bus !== "main") {
+    body.d = { ...(body.d ?? {}), bus };
+  }
+  return body;
+}
+
+function translateTransport(event: string, args: unknown[]): Body | null {
+  const peer = asString(args[0]);
+  switch (event) {
+    case "connect":
+      return ev("peer.connect", { peer });
+    case "disconnect":
+      return ev("peer.disconnect", { peer });
+    case "streamProven":
+      return ev("stream.proven", { peer });
+    case "streamLost":
+      return ev("stream.lost", { peer });
+    case "relayChanged":
+      return args[1] === true
+        ? ev("peer.relayed", { peer })
+        : ev("peer.direct", { peer });
+    case "roomPeers": {
+      const room = asString(args[0]);
+      const list = Array.isArray(args[1]) ? args[1] : [];
+      return ev("rv.peers", {
+        room: room ? refs().roomRef(room) : null,
+        d: { count: list.length },
+      });
+    }
+    case "message": {
+      // The payload NEVER enters an event. Its length is the diagnostic fact.
+      const data = args[1] as { byteLength?: number } | undefined;
+      const room = asString(args[2]);
+      return ev("app.msg.in", {
+        peer,
+        room: room ? refs().roomRef(room) : null,
+        d: { bytes: typeof data?.byteLength === "number" ? data.byteLength : 0 },
+      });
+    }
+    case "status":
+      return args[0] ? statusEvent(args[0] as TransportStatus) : null;
+    default:
+      return null;
+  }
+}
+
+/** Record one chat-bus event. Called from inside `LibP2PTransport.emit`. */
+export function recTransportEvent(
+  event: string,
+  args: unknown[],
+  suppressed: boolean,
+  bus?: string
+): void {
+  const body = transportEvent(event, args, bus);
+  if (body) rec(body);
+  // Recorded AFTER the translated event and BEFORE the early return, so a
+  // reader sees both what was emitted and that it was then swallowed.
+  if (suppressed) rec(ev("fault.injected", { d: { event } }));
+}
+
+/**
+ * `VoiceEvents` -> an event body.
+ *
+ * `deviceChanged` records only the device CLASS, never the deviceId: a
+ * deviceId is a stable per-browser fingerprint.
+ */
+export function voiceEvent(event: string, args: unknown[]): Body | null {
+  const peer = asString(args[0]);
+  switch (event) {
+    case "peerJoined":
+      return ev("voice.join", { peer });
+    case "peerLeft":
+      return ev("voice.leave", { peer });
+    case "trackAdded":
+      // A remote track arriving IS media starting to flow, which is what
+      // `voice.media.resume` means to the rule engine.
+      return ev("voice.media.resume", { peer, d: { via: "trackAdded" } });
+    case "trackRemoved":
+      return ev("voice.teardown", { peer, d: { via: "trackRemoved" } });
+    case "deviceChanged":
+      return ev("session.config", { d: { audioDevice: asString(args[0]) } });
+    case "error":
+      return ev("voice.failed", { d: { message: errText(args[0]) } });
+    case "status":
+      return args[0] ? statusEvent(args[0] as TransportStatus) : null;
+    default:
+      return null;
+  }
+}
+
+export function recVoiceEvent(event: string, args: unknown[]): void {
+  const body = voiceEvent(event, args);
+  if (body) rec(body);
+}
+
+/**
+ * `VideoEvents` -> an event body.
+ *
+ * `peerJoined`, `peerLeft` and `outputVolumeChanged` are deliberately NOT
+ * translated. The first two duplicate the voice roster, and the SFU's own view
+ * of the roster is captured authoritatively by an `sfu.diag` snapshot
+ * (`roomPeerCount` plus `room[]`) - which is what the `sfu-room-split` rule
+ * reads, and is better evidence than an event pair that can be missed.
+ */
+export function videoEvent(event: string, args: unknown[]): Body | null {
+  const peer = asString(args[0]);
+  switch (event) {
+    case "trackAdded":
+      return ev("sfu.track.added", { peer, d: { source: asString(args[2]) } });
+    case "trackRemoved":
+      return ev("sfu.consume", {
+        peer,
+        d: {
+          phase: "track-removed",
+          source: asString(args[1]),
+          mediaKind: asString(args[2]),
+        },
+      });
+    case "trackStalled":
+      return ev("sfu.track.stalled", { peer, d: { source: asString(args[1]) } });
+    case "error":
+      return ev("sfu.error", { d: { message: errText(args[0]) } });
+    case "healed":
+      return ev("sfu.join", { d: { phase: "healed" } });
+    case "transmissionAvailable":
+      return ev("sfu.consume", { peer, d: { phase: "available" } });
+    case "transmissionEnded":
+      return ev("sfu.consume", { peer, d: { phase: "ended" } });
+    case "transmissionWatched":
+      return ev("sfu.consume", { peer, d: { phase: "watched" } });
+    case "transmissionWatchEnded":
+      return ev("sfu.consume", { peer, d: { phase: "watch-ended" } });
+    default:
+      return null;
+  }
+}
+
+export function recVideoEvent(event: string, args: unknown[]): void {
+  const body = videoEvent(event, args);
+  if (body) rec(body);
+}
+
+// ---------------------------------------------------------------------------
+// Counter sampler
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff two flat counter snapshots.
+ *
+ * Keys are already bag-prefixed (`t.connects`, `a.profilesRejected`,
+ * `f.droppedFrames`) so three bags with a `connects` each cannot collide.
+ */
+export function diffCounters(
+  before: Record<string, number>,
+  after: Record<string, number>
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const key in after) {
+    const delta = after[key] - (before[key] ?? 0);
+    if (delta !== 0) out[key] = delta;
+  }
+  return out;
+}
+
+/** Flatten `{ t: {a: 1}, f: {b: 2} }` to `{ "t.a": 1, "f.b": 2 }`. */
+export function flattenBags(
+  bags: Record<string, Record<string, number>>
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const prefix in bags) {
+    const bag = bags[prefix];
+    for (const key in bag) {
+      const value = bag[key];
+      if (typeof value === "number") out[`${prefix}.${key}`] = value;
+    }
+  }
+  return out;
+}
+
+/**
+ * Split a delta into `counters` events. A `d` bag holds 12 keys, and three
+ * bags carry 24 counters, so a busy tick needs more than one event - dropping
+ * the overflow would silently lose exactly the counter that moved.
+ */
+export function counterEvents(delta: Record<string, number>): Body[] {
+  const keys = Object.keys(delta);
+  const out: Body[] = [];
+  for (let i = 0; i < keys.length; i += MAX_DETAIL_KEYS) {
+    const d: Record<string, number> = {};
+    for (const key of keys.slice(i, i + MAX_DETAIL_KEYS)) d[key] = delta[key];
+    out.push(ev("counters", { d }));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Installation
+// ---------------------------------------------------------------------------
+
+export interface TelemetryTapOptions extends RecorderContext {
+  /**
+   * Counter bags by prefix. Passed in rather than imported: `_stats` is module
+   * private to `transport.svelte.ts`, and importing that module here would be
+   * a cycle through a libp2p node built at import time.
+   */
+  counterBags(): Record<string, Record<string, number>>;
+  /** True while an SFU snapshot is worth asking for. */
+  inCall(): boolean;
+  /** `document.hidden`, injected so a test needs no DOM. */
+  hidden(): boolean;
+  /** Resolves null when the SFU refuses, times out, or is not connected. */
+  requestSfuDiag(): Promise<SfuSnapshot | null>;
+}
+
+let counterTimer: ReturnType<typeof setInterval> | null = null;
+let sfuTimer: ReturnType<typeof setInterval> | null = null;
+let lastCounters: Record<string, number> = {};
+
+/**
+ * Wire the recorder to its context and start the samplers. Called once, from
+ * `transport.svelte.ts`, immediately after the three singletons exist.
+ *
+ * Idempotent - a second call replaces the timers rather than doubling the
+ * sample rate.
+ */
+export function installTelemetryTaps(opts: TelemetryTapOptions): void {
+  stopTelemetryTaps();
+  initRecorder(opts);
+  lastCounters = {};
+
+  counterTimer = setInterval(() => {
+    try {
+      // The same guard the presence reconcile loop uses: a hidden tab is
+      // throttled to the point where a sample says more about the browser's
+      // timer policy than about the app.
+      if (opts.hidden()) return;
+      const now = flattenBags(opts.counterBags());
+      const delta = diffCounters(lastCounters, now);
+      lastCounters = now;
+      recordCounters(now);
+      for (const body of counterEvents(delta)) rec(body);
+    } catch {
+      // A sampler never breaks the app.
+    }
+  }, COUNTER_SAMPLE_MS);
+
+  sfuTimer = setInterval(() => {
+    if (!opts.inCall()) return;
+    void sampleSfu(opts);
+  }, SFU_DIAG_SAMPLE_MS);
+}
+
+/** Take one SFU snapshot now. Also called once during an export. */
+export async function sampleSfu(
+  opts: Pick<TelemetryTapOptions, "requestSfuDiag">
+): Promise<void> {
+  try {
+    const snapshot = await opts.requestSfuDiag();
+    if (!snapshot) return;
+    recordSfuSnapshot(snapshot);
+    const send = snapshot.self.transports.find((t) => t.dir === "send");
+    const recv = snapshot.self.transports.find((t) => t.dir === "recv");
+    rec(
+      ev("sfu.diag", {
+        d: {
+          producers: snapshot.self.producers.length,
+          consumers: snapshot.self.consumers.length,
+          roomPeers: snapshot.roomPeerCount,
+          iceSend: send ? send.iceState : null,
+          iceRecv: recv ? recv.iceState : null,
+        },
+      })
+    );
+  } catch {
+    // A sampler never breaks the app.
+  }
+}
+
+export function stopTelemetryTaps(): void {
+  if (counterTimer !== null) clearInterval(counterTimer);
+  if (sfuTimer !== null) clearInterval(sfuTimer);
+  counterTimer = null;
+  sfuTimer = null;
+}
+
+/** Exported for the exhaustiveness test: every kind a tap can produce. */
+export const TAP_KINDS: readonly DiagKind[] = [
+  "peer.connect",
+  "peer.disconnect",
+  "stream.proven",
+  "stream.lost",
+  "peer.relayed",
+  "peer.direct",
+  "rv.peers",
+  "app.msg.in",
+  "voice.join",
+  "voice.leave",
+  "voice.media.resume",
+  "voice.teardown",
+  "session.config",
+  "voice.failed",
+  "sfu.track.added",
+  "sfu.consume",
+  "sfu.track.stalled",
+  "sfu.error",
+  "sfu.join",
+  "counters",
+  "sfu.diag",
+  "fault.injected",
+];

--- a/frontend/src/lib/telemetry/upload.test.ts
+++ b/frontend/src/lib/telemetry/upload.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  UPLOAD_MAX_CHARS,
+  collectorAvailable,
+  hexSha256,
+  resetUploadStateForTest,
+  signedContent,
+  uploadBundle,
+} from "./upload";
+import { buildClientBundle } from "./bundle";
+import { setDiagUpload } from "./prefs.svelte";
+import {
+  beginSession,
+  initRecorder,
+  rec,
+  recorderSnapshot,
+  resetRecorderForTest,
+} from "./recorder";
+import { ev } from "./event";
+import { setRuntimeConfig } from "../runtime-config";
+import type { ClientBundle } from "./schema";
+
+const CTX = {
+  version: "1.0.0",
+  commit: "deadbee",
+  ua: "test",
+  now: 1_750_000_000_000,
+  randomHex: (bytes: number) => "a".repeat(bytes * 2),
+};
+
+function bundle(): ClientBundle {
+  resetRecorderForTest();
+  initRecorder({
+    selfPeerId: () => "12D3KooWSELF",
+    runtime: () => ({
+      apiHost: "relay.example.org",
+      relayPeerId: "12D3KooWRELAY",
+      sfuHosts: [],
+      configured: true,
+    }),
+    faultsActive: () => false,
+  });
+  beginSession("sess", 1_749_999_000_000);
+  rec(ev("session.start"));
+  return buildClientBundle(recorderSnapshot(), CTX);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetUploadStateForTest();
+  setDiagUpload(true);
+  setRuntimeConfig({ apiUrl: "https://relay.example.org" });
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  // `btoa` exists in node 25, but the module must not depend on that.
+  if (typeof globalThis.btoa !== "function") {
+    vi.stubGlobal("btoa", (s: string) =>
+      Buffer.from(s, "binary").toString("base64")
+    );
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function reply(status: number, body: unknown = {}): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("signedContent", () => {
+  it("is exactly the documented string", () => {
+    // The relay's `verifyTelemetryAuth` builds the same string. A drift here is
+    // a silent 401 on every upload, so the literal is pinned on both sides.
+    expect(signedContent(1750000000000, "abc123")).toBe(
+      "awful-telemetry:1750000000000:abc123"
+    );
+  });
+
+  it("uses a prefix that is not the mailbox prefix", () => {
+    // Domain separation: a shared prefix would make one signature valid on
+    // both surfaces.
+    expect(signedContent(1, "x")).not.toContain("awful-mailbox:");
+  });
+});
+
+describe("hexSha256", () => {
+  it("hashes the body to lowercase hex", () => {
+    expect(hexSha256("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+});
+
+describe("uploadBundle", () => {
+  it("refuses before any fetch when the switch is off", async () => {
+    setDiagUpload(false);
+    expect(await uploadBundle(bundle())).toEqual({ ok: false, reason: "off" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses when this build knows no relay", async () => {
+    setRuntimeConfig({ apiUrl: "" });
+    expect(await uploadBundle(bundle())).toEqual({
+      ok: false,
+      reason: "disabled",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts to the relay the app already knows, with no new config key", async () => {
+    fetchMock.mockResolvedValue(reply(200, { bundleId: "b1" }));
+    expect(await uploadBundle(bundle())).toEqual({ ok: true, bundleId: "b1" });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://relay.example.org/telemetry");
+    expect(init.method).toBe("POST");
+  });
+
+  it("signs the body it actually sends", async () => {
+    fetchMock.mockResolvedValue(reply(200, { bundleId: "b1" }));
+    await uploadBundle(bundle());
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-awful-peer"]).toBe("12D3KooWSELF");
+    expect(Number(headers["x-awful-ts"])).toBeGreaterThan(0);
+    expect(headers["x-awful-sig"]).toMatch(/^[A-Za-z0-9+/=]+$/);
+    // The relay hashes the bytes it reads, so the hash must cover this body.
+    expect(typeof init.body).toBe("string");
+  });
+
+  it("maps 204 to disabled and memoizes it", async () => {
+    fetchMock.mockResolvedValue(reply(204));
+    expect(await uploadBundle(bundle())).toEqual({
+      ok: false,
+      reason: "disabled",
+    });
+    // The Upload button hides from this, with no second request.
+    expect(await collectorAvailable()).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps 401 to unauthorized", async () => {
+    fetchMock.mockResolvedValue(reply(401));
+    expect(await uploadBundle(bundle())).toEqual({
+      ok: false,
+      reason: "unauthorized",
+    });
+  });
+
+  it("maps 429 to rate-limited", async () => {
+    fetchMock.mockResolvedValue(reply(429));
+    expect(await uploadBundle(bundle())).toEqual({
+      ok: false,
+      reason: "rate-limited",
+    });
+  });
+
+  it("maps a thrown fetch to network", async () => {
+    fetchMock.mockRejectedValue(new TypeError("offline"));
+    expect(await uploadBundle(bundle())).toEqual({
+      ok: false,
+      reason: "network",
+    });
+  });
+
+  it("maps a 200 with no bundleId to network", async () => {
+    fetchMock.mockResolvedValue(reply(200, { nope: true }));
+    expect(await uploadBundle(bundle())).toEqual({
+      ok: false,
+      reason: "network",
+    });
+  });
+
+  it("trims a bundle to fit the collector's body limit", async () => {
+    fetchMock.mockResolvedValue(reply(200, { bundleId: "b1" }));
+    const big = bundle();
+    big.events = Array.from({ length: 20_000 }, (_, i) => ({
+      seq: i + 1,
+      t: i,
+      kind: "peer.rtt" as const,
+      sev: "debug" as const,
+      peer: "12D3KooWPEER",
+      room: null,
+      d: { pad: "x".repeat(180) },
+    }));
+    await uploadBundle(big);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.body as string).length).toBeLessThanOrEqual(UPLOAD_MAX_CHARS);
+  });
+});
+
+describe("collectorAvailable", () => {
+  it("treats any non-204 answer as a live route", async () => {
+    fetchMock.mockResolvedValue(reply(400));
+    expect(await collectorAvailable()).toBe(true);
+  });
+
+  it("does not memoize a network failure", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("offline"));
+    expect(await collectorAvailable()).toBe(false);
+    fetchMock.mockResolvedValue(reply(400));
+    expect(await collectorAvailable()).toBe(true);
+  });
+});

--- a/frontend/src/lib/telemetry/upload.ts
+++ b/frontend/src/lib/telemetry/upload.ts
@@ -1,0 +1,157 @@
+/**
+ * Upload a bundle to this instance's collector.
+ *
+ * The collector is the relay the app already talks to, so there is NO new
+ * runtime-config key. Without `TELEMETRY_ENABLED=1` the relay answers 204 and
+ * nothing happens; that answer is memoized and the Upload button is hidden.
+ *
+ * AUTH: signed with the DEVICE libp2p key, never the identity key.
+ * The peerId of an Ed25519 libp2p key is an identity multihash - the public key
+ * is INSIDE it - so a signature checked against the key extracted from the
+ * claimed peerId proves the uploader owns that peerId, and the relay already
+ * knows every peerId it has seen. A signature by the identity key would instead
+ * hand the collector a `did:key` -> peerId binding it must never learn.
+ */
+
+import { keys } from "@libp2p/crypto";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { apiUrl } from "../runtime-config";
+import { deviceKeySeed } from "../transport/device-key";
+import { trimBundleForUpload } from "./bundle";
+import { diagPrefs } from "./prefs.svelte";
+import type { ClientBundle } from "./schema";
+
+/**
+ * Headroom under the relay's `telemetryMaxBody` (2 MiB). `JSON.stringify`
+ * length counts characters, and a multi-byte character costs more than one
+ * byte, so the trim target must sit below the real limit.
+ */
+export const UPLOAD_MAX_CHARS = 1_800_000;
+
+/** Mandatory domain separation. Reusing the mailbox prefix would make one
+ *  signature valid on both surfaces. */
+const SIGN_PREFIX = "awful-telemetry:";
+
+export type UploadResult =
+  | { ok: true; bundleId: string }
+  | {
+      ok: false;
+      reason:
+        | "disabled"
+        | "off"
+        | "too-large"
+        | "unauthorized"
+        | "rate-limited"
+        | "network";
+    };
+
+/** Memoized: 204 means the operator never set the collector up. */
+let collectorKnown: boolean | null = null;
+
+export function resetUploadStateForTest(): void {
+  collectorKnown = null;
+}
+
+/**
+ * The exact string that is signed. Exported so the relay's own test and this
+ * module cannot drift apart silently.
+ */
+export function signedContent(ts: number, bodySha256Hex: string): string {
+  return `${SIGN_PREFIX}${ts}:${bodySha256Hex}`;
+}
+
+export function hexSha256(body: string): string {
+  const digest = sha256(new TextEncoder().encode(body));
+  return [...digest].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Send a bundle. Never throws; every failure is a `reason` plus one warning.
+ */
+export async function uploadBundle(b: ClientBundle): Promise<UploadResult> {
+  if (!diagPrefs.upload) return { ok: false, reason: "off" };
+
+  const base = apiUrl();
+  if (!base) return { ok: false, reason: "disabled" };
+
+  try {
+    const trimmed = trimBundleForUpload(b, UPLOAD_MAX_CHARS);
+    const body = JSON.stringify(trimmed);
+    if (body.length > UPLOAD_MAX_CHARS) return { ok: false, reason: "too-large" };
+
+    const ts = Date.now();
+    const digest = hexSha256(body);
+    const key = await keys.generateKeyPairFromSeed("Ed25519", deviceKeySeed());
+    const sig = await key.sign(new TextEncoder().encode(signedContent(ts, digest)));
+
+    const res = await fetch(`${base}/telemetry`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-awful-peer": b.self.peerId,
+        "x-awful-ts": String(ts),
+        "x-awful-sig": base64(sig),
+      },
+      body,
+    });
+
+    if (res.status === 204) {
+      collectorKnown = false;
+      return { ok: false, reason: "disabled" };
+    }
+    collectorKnown = true;
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, reason: "unauthorized" };
+    }
+    if (res.status === 429) return { ok: false, reason: "rate-limited" };
+    // The relay answers 413 once the body passed `telemetryMaxBody`, which
+    // means the trim above left too little headroom.
+    if (res.status === 413) return { ok: false, reason: "too-large" };
+    if (!res.ok) {
+      console.warn("[diag] upload failed:", res.status);
+      return { ok: false, reason: "network" };
+    }
+
+    const parsed = (await res.json()) as { bundleId?: unknown };
+    return typeof parsed.bundleId === "string"
+      ? { ok: true, bundleId: parsed.bundleId }
+      : { ok: false, reason: "network" };
+  } catch (err) {
+    console.warn("[diag] upload failed:", err);
+    return { ok: false, reason: "network" };
+  }
+}
+
+/**
+ * Whether the collector exists. A HEAD is not used: the ingest route is
+ * POST-only, so an empty POST is the only probe, and the relay meters it.
+ */
+export async function collectorAvailable(): Promise<boolean> {
+  if (collectorKnown !== null) return collectorKnown;
+  const base = apiUrl();
+  if (!base) {
+    collectorKnown = false;
+    return false;
+  }
+  try {
+    const res = await fetch(`${base}/telemetry`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    // 204 is "not set up". Anything else - including a 400 or a 401 - means the
+    // route is live and only the request was wrong.
+    collectorKnown = res.status !== 204;
+    return collectorKnown;
+  } catch {
+    // A network failure says nothing about the operator's configuration, so it
+    // is NOT memoized.
+    return false;
+  }
+}
+
+function base64(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += String.fromCharCode(b);
+  return btoa(out);
+}

--- a/frontend/src/lib/transport/dm.svelte.ts
+++ b/frontend/src/lib/transport/dm.svelte.ts
@@ -59,6 +59,8 @@ import {
   storageCryptoReady,
   type StoreCryptoSpec,
 } from "$lib/storage-crypto";
+import { ev, errText } from "$lib/telemetry/event";
+import { rec } from "$lib/telemetry/recorder";
 
 interface QueuedMessage {
   to: string;
@@ -140,6 +142,7 @@ async function saveQueuedDmMessages(queue: QueuedMessage[]): Promise<void> {
     // and to allocate a lamport out of IndexedDB, so the key is armed by the
     // time anything can be queued.
     console.warn("[dm] storage locked: offline queue not persisted");
+    rec(ev("storage.locked", { d: { what: "dm-queue" } }));
     return;
   }
   try {
@@ -151,9 +154,10 @@ async function saveQueuedDmMessages(queue: QueuedMessage[]): Promise<void> {
         ct: bytesToBase64(new Uint8Array(sealed._enc.ct)),
       })
     );
-  } catch {
+  } catch (err) {
     // Storage full or blocked: the message still sent or sits in memory;
     // a quota error must not blow up out of sendDirectMessage.
+    rec(ev("storage.quota", { d: { err: errText(err) } }));
   }
 }
 
@@ -441,6 +445,7 @@ export async function sendDirectMessage(
   let delivered = false;
   if (isOnline) {
     delivered = await _transport.send(resolvedPeerId!, envelope);
+    rec(ev("dm.send", { peer: resolvedPeerId, d: { delivered } }));
   }
   // STARTED here, awaited after the local echo. The queue write is now a
   // sealed read-modify-write of the whole queue (AES-GCM both ways), and
@@ -449,6 +454,15 @@ export async function sendDirectMessage(
   let queued: Promise<void> | null = null;
   if (!delivered) {
     queued = queueDmMessage(peerDid, envelope, id);
+    rec(
+      ev("dm.queue", {
+        peer:
+          resolvedPeerId && !looksLikeDid(resolvedPeerId)
+            ? resolvedPeerId
+            : null,
+        d: { delivered: false },
+      })
+    );
     // Opt-in relay mailbox: a sealed copy waits for the offline peer so
     // delivery does not require both of you online at once. Best-effort -
     // the queue keeps retrying P2P either way.
@@ -567,6 +581,7 @@ async function _flushQueuedDmForPeer(peerId: string): Promise<void> {
   await mutateDmQueue((queue) =>
     queue.filter((e) => !sent.has(queueEntryKey(e)))
   );
+  rec(ev("dm.flush", { peer: peerId, d: { removed: sent.size } }));
 }
 
 /**

--- a/frontend/src/lib/transport/file/webtorrent.ts
+++ b/frontend/src/lib/transport/file/webtorrent.ts
@@ -11,6 +11,8 @@ import type {
   FileTransferTransport,
 } from "../types";
 import { getIceServers } from "../ice-server-list";
+import { ev, errText } from "../../telemetry/event";
+import { rec, refs } from "../../telemetry/recorder";
 
 type TorrentLike = {
   infoHash: string;
@@ -301,6 +303,14 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     });
 
     const seeders = this.seedersByHash.get(file.infoHash);
+    rec(
+      ev("file.request", {
+        d: {
+          peers: seeders?.size ?? 0,
+          fileRef: refs().fileRef(file.infoHash),
+        },
+      })
+    );
     if (!seeders || seeders.size === 0) return;
 
     for (const peerId of seeders) {
@@ -463,6 +473,11 @@ export class WebTorrentFileTransport implements FileTransferTransport {
             peers: created.numPeers ?? 0,
             seeders: this.seedersByHash.get(descriptor.infoHash)?.size ?? 1,
           });
+          rec(
+            ev("file.announce", {
+              d: { fileRef: refs().fileRef(descriptor.infoHash) },
+            })
+          );
 
           resolve(descriptor);
         }
@@ -674,6 +689,11 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     torrent.on("error", (...args: unknown[]) => {
       const err = args[0] as Error;
       const prev = this.transfers.get(infoHash);
+      rec(
+        ev("file.fail", {
+          d: { err: errText(err), fileRef: refs().fileRef(infoHash) },
+        })
+      );
       // If currently seeding, keep it as seeding and just log the error
       if (prev?.seeding || prev?.status === "seeding") {
         console.error(`Transient error on seeded torrent ${infoHash}:`, err.message);

--- a/frontend/src/lib/transport/ice-server-list.ts
+++ b/frontend/src/lib/transport/ice-server-list.ts
@@ -1,4 +1,6 @@
 import { apiUrl } from "$lib/runtime-config";
+import { ev, errText } from "$lib/telemetry/event";
+import { rec } from "$lib/telemetry/recorder";
 // STUN servers - safe to ship, no credentials.
 //
 // Two, not seven. Gathering does not finish until every entry has answered or
@@ -123,13 +125,17 @@ export async function refreshTurnCredentials(): Promise<void> {
     const base = apiUrl();
     const res = await fetch(`${base}/turn-credentials`);
     if (!res.ok) {
+      rec(ev("ice.turn.fail", { d: { branch: "not-ok", status: res.status } }));
       _scheduleRetry(); // transient server trouble: keep trying
       return;
     }
     // 204 is the relay saying TURN_SECRET is unset. It is a documented,
     // supported state, not a fault - and it is `ok`, so it has to be caught
     // here or it falls through to a JSON parse of an empty body.
-    if (res.status === 204) return;
+    if (res.status === 204) {
+      rec(ev("ice.turn.unavailable", { d: { branch: "no-secret", status: 204 } }));
+      return;
+    }
     // A host that answers an unrouted path with index.html returns 200 too, so
     // res.ok is not enough on its own: the JSON parse below would throw into
     // the silent catch and leave the list STUN-only with nothing logged. That
@@ -138,6 +144,7 @@ export async function refreshTurnCredentials(): Promise<void> {
       console.warn(
         "[ice] /turn-credentials did not return JSON - no TURN available, relayed peers will not connect"
       );
+      rec(ev("ice.turn.fail", { d: { branch: "not-json", status: res.status } }));
       _scheduleRetry();
       return;
     }
@@ -154,6 +161,7 @@ export async function refreshTurnCredentials(): Promise<void> {
       d.urls.length === 0 ||
       !d.urls.every((u) => typeof u === "string")
     ) {
+      rec(ev("ice.turn.fail", { d: { branch: "malformed" } }));
       _scheduleRetry();
       return;
     }
@@ -163,6 +171,14 @@ export async function refreshTurnCredentials(): Promise<void> {
       credential: d.credential,
     });
     _notifyChanged();
+    rec(
+      ev("ice.turn.ok", {
+        d: {
+          ttl: typeof d.ttl === "number" && Number.isFinite(d.ttl) ? d.ttl : null,
+          urlCount: d.urls.length,
+        },
+      })
+    );
     // ttl is in seconds (relay/turn.go). A missing or unusable ttl leaves
     // this credential unrefreshed until the next connect() - the same
     // fallback the old, never-refreshed code had - rather than guessing a
@@ -173,8 +189,9 @@ export async function refreshTurnCredentials(): Promise<void> {
         (d.ttl * 1000) / 2
       );
     }
-  } catch {
+  } catch (err) {
     // Stay STUN-only for now, but keep trying - see RETRY_MS.
+    rec(ev("ice.turn.fail", { d: { branch: "threw", err: errText(err) } }));
     _scheduleRetry();
   }
 }

--- a/frontend/src/lib/transport/ice-server-list.ts
+++ b/frontend/src/lib/transport/ice-server-list.ts
@@ -1,6 +1,7 @@
 import { apiUrl } from "$lib/runtime-config";
 import { ev, errText } from "$lib/telemetry/event";
 import { rec } from "$lib/telemetry/recorder";
+import { probeTurn } from "$lib/telemetry/taps";
 // STUN servers - safe to ship, no credentials.
 //
 // Two, not seven. Gathering does not finish until every entry has answered or
@@ -171,6 +172,9 @@ export async function refreshTurnCredentials(): Promise<void> {
       credential: d.credential,
     });
     _notifyChanged();
+    // Credentials are not reachability: a mint that succeeds says nothing
+    // about whether coturn will actually allocate from this network. Ask it.
+    void probeTurn(cached);
     rec(
       ev("ice.turn.ok", {
         d: {

--- a/frontend/src/lib/transport/ice-stats.test.ts
+++ b/frontend/src/lib/transport/ice-stats.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { succeededPair } from "./ice-stats";
+
+/** Chrome: the pair carries ids, and the types live on separate entries. */
+const chrome = [
+  { id: "I-local", type: "local-candidate", candidateType: "relay", protocol: "udp" },
+  { id: "I-remote", type: "remote-candidate", candidateType: "srflx", protocol: "udp" },
+  {
+    id: "CP1",
+    type: "candidate-pair",
+    state: "succeeded",
+    nominated: true,
+    localCandidateId: "I-local",
+    remoteCandidateId: "I-remote",
+    currentRoundTripTime: 0.042,
+  },
+];
+
+/** Firefox: the types are on the pair itself. */
+const firefox = [
+  {
+    id: "CP1",
+    type: "candidate-pair",
+    state: "succeeded",
+    nominated: true,
+    localCandidateType: "host",
+    remoteCandidateType: "host",
+    currentRoundTripTime: 0.002,
+  },
+];
+
+describe("succeededPair", () => {
+  it("dereferences the candidate ids Chrome reports", () => {
+    // The bug this exists to kill: reading pair.localCandidateType here gives
+    // undefined, so a call relayed through TURN reported itself as direct.
+    expect(succeededPair(chrome)).toEqual({
+      local: "relay",
+      remote: "srflx",
+      relayed: true,
+      rttMs: 42,
+    });
+  });
+
+  it("reads the inline types Firefox reports", () => {
+    expect(succeededPair(firefox)).toEqual({
+      local: "host",
+      remote: "host",
+      relayed: false,
+      rttMs: 2,
+    });
+  });
+
+  it("prefers the nominated pair when several have succeeded", () => {
+    const rows = [
+      { id: "A", type: "candidate-pair", state: "succeeded", localCandidateType: "host", remoteCandidateType: "host" },
+      { id: "B", type: "candidate-pair", state: "succeeded", nominated: true, localCandidateType: "relay", remoteCandidateType: "relay" },
+    ];
+    expect(succeededPair(rows)?.relayed).toBe(true);
+  });
+
+  it("returns null when nothing has succeeded", () => {
+    // Not the same as "types unknown": no pair at all is the answer to why
+    // there is no audio, and the caller must be able to tell them apart.
+    const rows = [{ id: "CP1", type: "candidate-pair", state: "in-progress" }];
+    expect(succeededPair(rows)).toBeNull();
+  });
+
+  it("accepts a real RTCStatsReport, which is a Map", () => {
+    const report = new Map(chrome.map((r) => [r.id, r]));
+    expect(succeededPair(report)?.relayed).toBe(true);
+  });
+
+  it("survives a report with no types anywhere", () => {
+    const rows = [
+      { id: "CP1", type: "candidate-pair", state: "succeeded", localCandidateId: "gone" },
+    ];
+    expect(succeededPair(rows)).toEqual({
+      local: null,
+      remote: null,
+      relayed: false,
+      rttMs: null,
+    });
+  });
+});

--- a/frontend/src/lib/transport/ice-stats.ts
+++ b/frontend/src/lib/transport/ice-stats.ts
@@ -1,0 +1,75 @@
+/**
+ * Which candidate pair actually carried the media, and whether it was relayed.
+ *
+ * `RTCIceCandidatePairStats` has no candidate TYPE in Chrome. It carries
+ * `localCandidateId` and `remoteCandidateId`, and the types live on the
+ * separate `local-candidate` / `remote-candidate` entries those ids point at.
+ * Reading `pair.localCandidateType` therefore yields `undefined` on every
+ * Chromium browser - which silently made "is this call relayed?" answer NO for
+ * every Chrome user, including the ones whose audio was going through TURN.
+ *
+ * Firefox does expose the types on the pair, so both shapes are read: the
+ * inline value first, the dereferenced one second.
+ */
+
+export interface SucceededPair {
+  /** "host" | "srflx" | "prflx" | "relay", or null when unreported. */
+  local: string | null;
+  remote: string | null;
+  /** Either end via TURN. The question every "is it my network" answer needs. */
+  relayed: boolean;
+  /** Round trip time in milliseconds, or null. */
+  rttMs: number | null;
+}
+
+type Row = Record<string, unknown> & { type?: string };
+
+/**
+ * The nominated succeeded pair, or the first succeeded one. Returns null when
+ * no pair has succeeded yet, which is itself the answer to "why is there no
+ * audio" and must not be confused with a pair whose types are unknown.
+ */
+export function succeededPair(
+  stats: Iterable<unknown> | { values(): Iterable<unknown> }
+): SucceededPair | null {
+  const rows: Row[] = [];
+  const iterable =
+    typeof (stats as { values?: unknown }).values === "function"
+      ? (stats as { values(): Iterable<unknown> }).values()
+      : (stats as Iterable<unknown>);
+  for (const row of iterable) {
+    if (row && typeof row === "object") rows.push(row as Row);
+  }
+
+  const candidates = new Map<string, Row>();
+  let best: Row | null = null;
+  for (const row of rows) {
+    if (row.type === "local-candidate" || row.type === "remote-candidate") {
+      const id = row.id;
+      if (typeof id === "string") candidates.set(id, row);
+      continue;
+    }
+    if (row.type !== "candidate-pair" || row.state !== "succeeded") continue;
+    // A nominated pair beats a merely succeeded one; ICE can hold several.
+    if (!best || row.nominated === true) best = row;
+  }
+  if (!best) return null;
+
+  const typeOf = (inline: unknown, id: unknown): string | null => {
+    if (typeof inline === "string") return inline;
+    if (typeof id !== "string") return null;
+    const found = candidates.get(id)?.candidateType;
+    return typeof found === "string" ? found : null;
+  };
+
+  const local = typeOf(best.localCandidateType, best.localCandidateId);
+  const remote = typeOf(best.remoteCandidateType, best.remoteCandidateId);
+  const rtt = best.currentRoundTripTime;
+
+  return {
+    local,
+    remote,
+    relayed: local === "relay" || remote === "relay",
+    rttMs: typeof rtt === "number" ? Math.round(rtt * 1000) : null,
+  };
+}

--- a/frontend/src/lib/transport/libp2p/transport.ts
+++ b/frontend/src/lib/transport/libp2p/transport.ts
@@ -1,4 +1,4 @@
-import { relayMultiaddr } from "$lib/runtime-config";
+import { isConfigured, relayMultiaddr } from "$lib/runtime-config";
 import { createLibp2p, type Libp2p } from "libp2p";
 import { webRTC } from "@libp2p/webrtc";
 import { webSockets } from "@libp2p/websockets";
@@ -12,6 +12,9 @@ import { peerIdFromString } from "@libp2p/peer-id";
 import { multiaddr, type Multiaddr } from "@multiformats/multiaddr";
 import type { Connection, Stream } from "@libp2p/interface";
 import type { StreamMessageEvent, StreamCloseEvent } from "@libp2p/interface";
+import { errText, ev } from "$lib/telemetry/event";
+import { beginSession, rec, refs } from "$lib/telemetry/recorder";
+import { recTransportEvent } from "$lib/telemetry/taps";
 
 // js-libp2p exposes no public "reserve a relay slot now" API. Listening on a
 // `<relay>/p2p-circuit` address is what triggers a reservation, and we need to
@@ -319,9 +322,15 @@ export class LibP2PTransport implements PeerTransport {
   private relayReconnectTimer: TimerHandle | null = null;
   private reconcileTimer: TimerHandle | null = null;
   private privateKeyBytes: Uint8Array | null = null;
+  /** Distinguishes chat-session events from a device-sync instance's. Only
+   *  the main bus may call `beginSession`, or a sync session erases the
+   *  chat session's history. */
+  private readonly diagBus: string;
+  private diagSessionId: string | null = null;
 
-  constructor() {
+  constructor(opts?: { diagBus?: string }) {
     installFaultHook();
+    this.diagBus = opts?.diagBus ?? "main";
   }
 
   get p2pNode(): Libp2p<AppServices> | null {
@@ -345,6 +354,11 @@ export class LibP2PTransport implements PeerTransport {
         /stream that is closed/i.test(r?.message ?? "")
       ) {
         this.debugStats.suppressedStreamErrors++;
+        rec(
+          ev("stream.reset", {
+            d: { suppressed: true, err: errText(e.reason) },
+          })
+        );
         e.preventDefault();
       }
     });
@@ -354,6 +368,18 @@ export class LibP2PTransport implements PeerTransport {
   async connect(privateKeyBytes?: Uint8Array | null): Promise<void> {
     this.installStreamNoiseFilter();
     this.intentionalDisconnect = false;
+
+    // Minted once per connect(); a reconnect keeps the session so a bundle
+    // tells the whole story. Only main resets the ring - a sync instance
+    // must never erase the chat session's history.
+    this.diagSessionId = Array.from(
+      crypto.getRandomValues(new Uint8Array(16)),
+      (b) => b.toString(16).padStart(2, "0")
+    ).join("");
+    if (this.diagBus === "main") {
+      beginSession(this.diagSessionId, Date.now());
+    }
+    rec(ev("session.start", { d: { bus: this.diagBus } }));
 
     // A reconnect used to leak the previous node's timers: reconcileTimer was
     // overwritten (leaving an interval running against a dead node forever)
@@ -469,6 +495,15 @@ export class LibP2PTransport implements PeerTransport {
 
     const myId = this.node.peerId.toString();
     console.log("[LibP2PTransport] node started, selfId:", myId);
+    rec(
+      ev("session.config", {
+        d: {
+          selfId: myId,
+          relayPeerId: this.relayPeerId ?? "",
+          configured: isConfigured(),
+        },
+      })
+    );
 
     // These MUST be attached before the relay dial. waitForRelayReservation()
     // can block for seconds while the node is already reachable, and any peer
@@ -973,7 +1008,15 @@ export class LibP2PTransport implements PeerTransport {
         if (misses < PING_MISSES_ALLOWED) return;
         console.log("[Transport] peer stopped answering:", peerId.slice(-8));
         this.debugStats.livenessDrops++;
-        this.pingMisses.delete(peerId);
+        rec(
+          ev("peer.drop.liveness", {
+            peer: peerId,
+            d: {
+              misses,
+              silentMs: Date.now() - (this.lastInbound.get(peerId) ?? askedAt),
+            },
+          })
+        );
         this.dropPeer(peerId);
       }, PEER_PROBE_RELEASE_MS);
     }
@@ -997,7 +1040,7 @@ export class LibP2PTransport implements PeerTransport {
         done = true;
         clearTimeout(timer);
         this.rttProbes.delete(nonce);
-        resolve(rtt);
+        rec(ev("peer.rtt", { peer: peerId, d: { ms: rtt } }));
       };
       const timer = setTimeout(() => settle(null), timeoutMs);
       // sentAt is recorded as late as possible - after the frame is built,
@@ -1034,7 +1077,14 @@ export class LibP2PTransport implements PeerTransport {
         done = true;
         clearTimeout(timer);
         this.rttProbes.delete(nonce);
-        resolve(sample);
+        if (sample) {
+          rec(
+            ev("peer.clock", {
+              peer: peerId,
+              d: { t0: sample.t0, t1: sample.t1, t2: sample.t2, t3: sample.t3 },
+            })
+          );
+        }
       };
       const timer = setTimeout(() => finish(null), timeoutMs);
       const sentWallAt = Date.now();
@@ -1111,6 +1161,15 @@ export class LibP2PTransport implements PeerTransport {
       console.warn(
         `[Transport] high connection count: ${connections.length} ` +
           `(${this.connectedPeers.size} peers)`
+      );
+      rec(
+        ev("session.config", {
+          sev: "warn",
+          d: {
+            connections: connections.length,
+            peers: this.connectedPeers.size,
+          },
+        })
       );
     }
     const byPeer = new Map<string, Connection[]>();
@@ -1201,18 +1260,23 @@ export class LibP2PTransport implements PeerTransport {
     if (this.dialingPeers.has(peerId)) return;
     this.dialingPeers.add(peerId);
     this.debugStats.relayUpgradeAttempts++;
+    rec(ev("peer.upgrade.attempt", { peer: peerId }));
     try {
       if (shouldBlockWebrtcDial()) throw new Error("webrtc dial blocked");
       const relayAddr = relayMultiaddr();
       await this.node.dial(
         multiaddr(`${relayAddr}/p2p-circuit/webrtc/p2p/${peerId}`)
       );
-    } catch {
+    } catch (err) {
+      rec(
+        ev("peer.upgrade.fail", { peer: peerId, d: { reason: errText(err) } })
+      );
       return; // still relayed; the backoff decides when to try again
     } finally {
       this.dialingPeers.delete(peerId);
     }
 
+    rec(ev("peer.upgrade.ok", { peer: peerId }));
     this.updateRelayedStatus(peerId);
     // The dial can resolve while still handing back something relayed.
     if (this.relayedPeers.has(peerId)) return;
@@ -1325,6 +1389,11 @@ export class LibP2PTransport implements PeerTransport {
           type: "relay-dial-retry",
           message: `Relay unreachable - retrying (${attempt + 1}/${RELAY_DIAL_ATTEMPTS})`,
         });
+        rec(
+          ev("relay.dial.attempt", {
+            d: { attempt: attempt + 1, delayMs: Math.round(delay) },
+          })
+        );
         await new Promise((r) => setTimeout(r, delay));
       }
     }
@@ -1351,6 +1420,7 @@ export class LibP2PTransport implements PeerTransport {
 
   private async requestRelayReservation(): Promise<void> {
     if (!this.node) return;
+    rec(ev("relay.reservation.request"));
     const relayMa = relayMultiaddr();
     const circuitListenAddr = multiaddr(`${relayMa}/p2p-circuit`);
     try {
@@ -1360,6 +1430,7 @@ export class LibP2PTransport implements PeerTransport {
       await transportManager.listen([circuitListenAddr]);
     } catch (err) {
       console.warn("[Transport] reservation request failed:", err);
+      rec(ev("relay.reservation.timeout", { d: { err: errText(err) } }));
     }
   }
 
@@ -1511,6 +1582,7 @@ export class LibP2PTransport implements PeerTransport {
         }
         console.log("[Transport] stream never confirmed for", peerId.slice(-8));
         this.debugStats.confirmFailures++;
+        rec(ev("stream.confirm.fail", { peer: peerId, d: { attempts } }));
         this.cleanupPeerStream(peerId);
         if (openedOn && this.liveConnections.get(peerId) === openedOn) {
           // Stop preferring the connection that just failed us.
@@ -1581,6 +1653,12 @@ export class LibP2PTransport implements PeerTransport {
       );
     } catch (err) {
       console.warn(`[LibP2PTransport] write failed for ${peerId}:`, err);
+      rec(
+        ev("stream.write.fail", {
+          peer: peerId,
+          d: { err: errText(err), bytes: data.byteLength },
+        })
+      );
       this.cleanupPeerStream(peerId);
       return false;
     }
@@ -1625,6 +1703,7 @@ export class LibP2PTransport implements PeerTransport {
           console.warn(
             `[LibP2PTransport] oversized direct frame (${len}b) from ${fromId.slice(-8)}, aborting stream`
           );
+          rec(ev("rv.frame.oversize", { peer: fromId, d: { bytes: len } }));
           this.cleanupPeerStream(fromId);
           stream.abort(new Error("frame too large"));
           return;
@@ -1706,6 +1785,7 @@ export class LibP2PTransport implements PeerTransport {
     const stream = this.peerStreams.get(peerId);
     if (!stream) return;
     this.debugStats.outboundResets++;
+    rec(ev("stream.reset", { peer: peerId }));
     const wasProven = this.confirmedStreams.has(stream);
     this.peerStreams.delete(peerId);
     this.confirmNonces.delete(peerId);
@@ -1830,6 +1910,11 @@ export class LibP2PTransport implements PeerTransport {
             "[Rendezvous] failed to process frame, aborting stream:",
             err
           );
+          rec(
+            ev("rv.send.fail", {
+              d: { phase: "inbound", err: errText(err) },
+            })
+          );
           this.rendezvousReadBuf = new Uint8Array(0);
           stream.abort(
             err instanceof Error
@@ -1849,6 +1934,7 @@ export class LibP2PTransport implements PeerTransport {
       // then silently no-opped, so a leaveRoom UNREGISTER was lost with no
       // retry and the relay kept telling peers we were still in the room.
       if (this.rendezvousStream !== stream) return;
+      rec(ev("rv.close"));
       this.stopRendezvousPing();
       this.rendezvousStream = null;
       if (!this.intentionalDisconnect && this.node) {
@@ -1888,6 +1974,13 @@ export class LibP2PTransport implements PeerTransport {
 
   private rendezvousSend(msg: RendezvousClientMsg): void {
     if (!this.rendezvousStream) return;
+    if (msg.type === "REGISTER" || msg.type === "UNREGISTER") {
+      rec(
+        ev(msg.type === "REGISTER" ? "rv.register" : "rv.unregister", {
+          room: refs().roomRef(msg.room),
+        })
+      );
+    }
     const payload = new TextEncoder().encode(JSON.stringify(msg));
     const frame = new Uint8Array(4 + payload.byteLength);
     new DataView(frame.buffer).setUint32(0, payload.byteLength, false);
@@ -1896,6 +1989,7 @@ export class LibP2PTransport implements PeerTransport {
       this.rendezvousStream.send(frame);
     } catch (err) {
       console.warn("[Rendezvous] send failed:", err);
+      rec(ev("rv.send.fail", { d: { err: errText(err) } }));
     }
   }
 
@@ -1904,6 +1998,9 @@ export class LibP2PTransport implements PeerTransport {
     if (shouldBlockDial(peerId)) return;
     if (this.dialingPeers.has(peerId)) return;
     this.dialingPeers.add(peerId);
+    rec(
+      ev("peer.dial.start", { peer: peerId, d: { attempt, viaWebrtc: true } })
+    );
 
     try {
       const relayAddr = relayMultiaddr();
@@ -1916,7 +2013,14 @@ export class LibP2PTransport implements PeerTransport {
         if (shouldBlockWebrtcDial()) throw new Error("webrtc dial blocked");
         await this.node.dial(withWebRTC);
         return;
-      } catch {}
+      } catch (err) {
+        rec(
+          ev("peer.dial.fail", {
+            peer: peerId,
+            d: { form: "webrtc", err: errText(err) },
+          })
+        );
+      }
 
       try {
         await this.node.dial(withoutWebRTC);
@@ -2022,6 +2126,7 @@ export class LibP2PTransport implements PeerTransport {
         });
         if (circuit) {
           console.log("[Transport] relay reservation ok:", circuit.toString());
+          rec(ev("relay.reservation.ok", { d: { circuit: true } }));
           clearTimeout(deadline);
           node.removeEventListener("self:peer:update", check);
           resolve(true);
@@ -2080,7 +2185,9 @@ export class LibP2PTransport implements PeerTransport {
   ): void {
     // Suppressing "connect" reproduces the case where one side reloads and the
     // other never notices, so it never re-sends anything about itself.
-    if (shouldSuppressEvent(event as string)) return;
+    const suppressed = shouldSuppressEvent(event as string);
+    recTransportEvent(event as string, args, suppressed, this.diagBus);
+    if (suppressed) return;
     this.handlers.get(event)?.forEach((h) => (h as Function)(...args));
   }
 }

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -166,6 +166,8 @@ interface RemotePeer {
   /** Whether the succeeded candidate pair went via TURN, remembered from the
    *  connected probe so the stall-recovery emit reports the same path. */
   relayed: boolean;
+  /** Polls taken; only every third one is recorded. */
+  sampleTick?: number;
 }
 
 export class LibP2PVoice implements VoiceTransport {
@@ -713,15 +715,55 @@ export class LibP2PVoice implements VoiceTransport {
     } catch {
       return;
     }
+    // `getStats` yields loosely typed rows; only these fields are read.
+    type Row = Record<string, unknown> & { type?: string; kind?: string };
+    let inbound: Row | null = null;
+    let pair: Row | null = null;
     for (const report of stats.values()) {
-      if (report.type !== "inbound-rtp" || report.kind !== "audio") continue;
-      const bytes = report.bytesReceived as number;
-      if (remote.lastBytesReceived === null || bytes > remote.lastBytesReceived) {
-        remote.lastBytesReceivedAt = now;
+      const row = report as Row;
+      if (row.type === "inbound-rtp" && row.kind === "audio") {
+        inbound = row;
+      } else if (row.type === "candidate-pair" && row.state === "succeeded") {
+        pair = row;
       }
-      remote.lastBytesReceived = bytes;
-      return;
     }
+    if (!inbound) return;
+    const bytes = Number(inbound.bytesReceived) || 0;
+    const previous = remote.lastBytesReceived;
+    if (previous === null || bytes > previous) remote.lastBytesReceivedAt = now;
+    remote.lastBytesReceived = bytes;
+
+    // The watchdog above turns all of this into one verdict after 8s of
+    // silence. The verdict is what repairs the link; the samples are what
+    // explain it afterwards - they show WHEN audio thinned out, and whether
+    // the path was relayed and losing packets while it happened, which a
+    // single "stalled" event at the end cannot.
+    //
+    // Every third poll, so a timeline costs about one event per peer per
+    // 12s rather than a third of the ring.
+    remote.sampleTick = (remote.sampleTick ?? 0) + 1;
+    if (remote.sampleTick % 3 !== 0) return;
+    rec(
+      ev("voice.media.sample", {
+        peer: remote.peerId,
+        d: {
+          bytes,
+          delta: previous === null ? 0 : bytes - previous,
+          jitter: typeof inbound.jitter === "number" ? inbound.jitter : null,
+          lost:
+            typeof inbound.packetsLost === "number" ? inbound.packetsLost : null,
+          // The path itself: "relay" next to loss is the network, and the
+          // same loss on a direct pair is a different conversation.
+          path: pair
+            ? `${String(pair.localCandidateType ?? "?")}/${String(pair.remoteCandidateType ?? "?")}`
+            : null,
+          rtt:
+            typeof pair?.currentRoundTripTime === "number"
+              ? Math.round(pair.currentRoundTripTime * 1000)
+              : null,
+        },
+      })
+    );
   }
 
   leave(): void {

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -6,6 +6,9 @@ import { getIceServers, onIceServersChanged } from "../ice-server-list";
 import { MessageType } from "$lib/types/message";
 import { encode } from "$lib/utils";
 import { CallAudioMixer } from "$lib/audio/call-audio-mixer";
+import { ev } from "$lib/telemetry/event";
+import { rec } from "$lib/telemetry/recorder";
+import { recVoiceEvent } from "$lib/telemetry/taps";
 
 /** Same ceiling as the output slider in audio settings. */
 export const MAX_PEER_VOLUME = 2.5;
@@ -366,6 +369,7 @@ export class LibP2PVoice implements VoiceTransport {
   handleWireSignal(peerId: string, signal: unknown): void {
     if (!isVoiceSignal(signal)) {
       this.debugStats.signalsInvalid++;
+      rec(ev("voice.signal.invalid", { peer: peerId }));
       return;
     }
     // Same default-deny the /voice/1.0.0 inbound handler enforced: an offer
@@ -532,6 +536,7 @@ export class LibP2PVoice implements VoiceTransport {
     if (now - (this.lastRedialAsk.get(peerId) ?? 0) < VOICE_REDIAL_ASK_MS) return;
     this.lastRedialAsk.set(peerId, now);
     this.debugStats.redialsAsked++;
+    rec(ev("voice.redial.ask", { peer: peerId }));
     void this.transport
       .send(peerId, encode({ type: MessageType.VoiceRedial }))
       .catch(() => {});
@@ -539,14 +544,23 @@ export class LibP2PVoice implements VoiceTransport {
 
   /** The other side says its voice link to us is dead. Rebuild it now. */
   handleRedialRequest(peerId: string): void {
-    if (!this.node || !this.callPeers.has(peerId)) return;
-    if (peerId > this.transport.selfId()) return; // we are not their dialer
+    // Each return below refuses the redial ask. This probe names the
+    // reason. No reason had a name before this probe.
+    if (!this.node || !this.callPeers.has(peerId)) {
+      rec(ev("voice.redial.serve", { peer: peerId, d: { refused: "inactive" } }));
+      return;
+    }
+    if (peerId > this.transport.selfId()) {
+      rec(ev("voice.redial.serve", { peer: peerId, d: { refused: "not-dialer" } }));
+      return; // we are not their dialer
+    }
     // Rate limit the RECEIVING side too. The sender's limit is no protection
     // at all: a peer stuck in a redial loop (or one that simply means us harm)
     // would otherwise tear our link down on every message, and since only the
     // rebuild was rate limited, a healthy call could be flapped from outside.
     const now = Date.now();
     if (now - (this.lastRedialServed.get(peerId) ?? 0) < VOICE_REDIAL_ASK_MS) {
+      rec(ev("voice.redial.serve", { peer: peerId, d: { refused: "rate-limited" } }));
       return;
     }
     const remote = this.remotePeers.get(peerId);
@@ -577,6 +591,7 @@ export class LibP2PVoice implements VoiceTransport {
       ) &&
       this.linkIsHealthy(remote, now)
     ) {
+      rec(ev("voice.redial.serve", { peer: peerId, d: { refused: "mid-handshake" } }));
       return;
     }
     // An ESTABLISHED link that has merely blipped: their ask must beat our
@@ -591,6 +606,7 @@ export class LibP2PVoice implements VoiceTransport {
       remote.pc.connectionState !== "connected" &&
       now - remote.okAt < VOICE_BLIP_GRACE_MS
     ) {
+      rec(ev("voice.redial.serve", { peer: peerId, d: { refused: "blip-grace" } }));
       return;
     }
     // Stamped only once we act, so a refused ask does not spend the slot the
@@ -598,6 +614,7 @@ export class LibP2PVoice implements VoiceTransport {
     // and that is still one per interval however often they ask.
     this.lastRedialServed.set(peerId, now);
     this.debugStats.redialsServed++;
+    rec(ev("voice.redial.serve", { peer: peerId, d: { refused: false } }));
     if (remote) {
       this.teardownRemotePeer(peerId);
       this.emit("peerLeft", peerId);
@@ -634,6 +651,7 @@ export class LibP2PVoice implements VoiceTransport {
         remote.okAt = now;
         if (remote.stallSignaled) {
           remote.stallSignaled = false;
+          rec(ev("voice.media.resume", { peer: remote.peerId }));
           // Audio resumed WITHOUT a rebuild, so no connectionstatechange
           // will ever fire - without this emit the degraded verdict (amber
           // tile ring) latches until the next reconnect.
@@ -655,6 +673,7 @@ export class LibP2PVoice implements VoiceTransport {
       // instead of showing a healthy pair that cannot hear each other.
       if (!remote.stallSignaled) {
         remote.stallSignaled = true;
+        rec(ev("voice.media.stall", { peer: remote.peerId, d: { silentMs: now - remote.lastBytesReceivedAt } }));
         this.emit("status", {
           type: "voice-degraded",
           peerId: remote.peerId,
@@ -1121,6 +1140,7 @@ export class LibP2PVoice implements VoiceTransport {
     if (!sdp) return;
 
     this.debugStats.offersSent++;
+    rec(ev("voice.offer.out", { peer: peerId, d: { via: "dial" } }));
     const ok = await this.sendSignal(peerId, { type: "offer", sdp });
     if (!ok) {
       // send() resolving false means the app stream to this peer is provably
@@ -1158,6 +1178,7 @@ export class LibP2PVoice implements VoiceTransport {
     const pc = new RTCPeerConnection({
       iceServers: getIceServers(),
     });
+    rec(ev("voice.pc.new", { peer: peerId }));
 
     if (this.processedStream) {
       for (const track of this.processedStream.getAudioTracks()) {
@@ -1195,6 +1216,7 @@ export class LibP2PVoice implements VoiceTransport {
           if (pc.signalingState !== "stable") return;
           await pc.setLocalDescription(offer);
           this.debugStats.offersSent++;
+          rec(ev("voice.offer.out", { peer: peerId, d: { via: "renegotiate" } }));
           void this.sendSignal(peerId, { type: "offer", sdp: offer.sdp! });
         } catch (err) {
           console.warn(`[LibP2PVoice] renegotiation failed for ${peerId}:`, err);
@@ -1206,6 +1228,7 @@ export class LibP2PVoice implements VoiceTransport {
     // the wedge check counts from before the dial even started.
     pc.oniceconnectionstatechange = () => {
       const st = pc.iceConnectionState;
+      rec(ev("voice.ice.state", { peer: peerId, d: { state: st } }));
       if (st === "checking" || st === "connected" || st === "completed") {
         this.touchLink(peerId);
       }
@@ -1213,6 +1236,7 @@ export class LibP2PVoice implements VoiceTransport {
 
     pc.onconnectionstatechange = () => {
       const state = pc.connectionState;
+      rec(ev("voice.pc.state", { peer: peerId, d: { state } }));
       if (state === "connected") {
         // check if relayed via TURN
         pc.getStats()
@@ -1258,14 +1282,16 @@ export class LibP2PVoice implements VoiceTransport {
         // attempt ICE restart; signalling rides the app transport, which
         // queues and confirms delivery itself
         if (remote.pc.signalingState === "stable") {
+          rec(ev("voice.restart", { peer: peerId }));
           remote.pc.restartIce();
           remote.pc
             .createOffer({ iceRestart: true })
-            .then((offer) =>
-              remote.pc.setLocalDescription(offer).then(() =>
+            .then((offer) => {
+              rec(ev("voice.offer.out", { peer: peerId, d: { via: "ice-restart" } }));
+              return remote.pc.setLocalDescription(offer).then(() =>
                 this.sendSignal(peerId, { type: "offer", sdp: offer.sdp! })
-              )
-            )
+              );
+            })
             .then((sent) => {
               // A restart offer lost to a transport hiccup is otherwise
               // unrecoverable until the 5s blip ask - unlike the initial
@@ -1355,6 +1381,7 @@ export class LibP2PVoice implements VoiceTransport {
     const remote = this.remotePeers.get(peerId);
     if (!remote) return;
     this.debugStats.teardowns++;
+    rec(ev("voice.teardown", { peer: peerId }));
 
     remote.sourceNode?.disconnect();
     remote.gainNode?.disconnect();
@@ -1387,6 +1414,7 @@ export class LibP2PVoice implements VoiceTransport {
     switch (signal.type) {
       case "offer": {
         this.debugStats.offersIn++;
+        rec(ev("voice.offer.in", { peer: peerId }));
         const state = remote.pc.signalingState;
 
         if (state === "have-local-offer") {
@@ -1433,6 +1461,7 @@ export class LibP2PVoice implements VoiceTransport {
 
       case "answer": {
         this.debugStats.answersIn++;
+        rec(ev("voice.answer.in", { peer: peerId }));
         await remote.pc.setRemoteDescription({
           type: "answer",
           sdp: signal.sdp,
@@ -1476,6 +1505,7 @@ export class LibP2PVoice implements VoiceTransport {
     event: K,
     ...args: Parameters<VoiceEvents[K]>
   ): void {
+    recVoiceEvent(event as string, args);
     this.handlers.get(event)?.forEach((h) => (h as Function)(...args));
   }
 }

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -8,6 +8,7 @@ import { encode } from "$lib/utils";
 import { CallAudioMixer } from "$lib/audio/call-audio-mixer";
 import { ev } from "$lib/telemetry/event";
 import { rec } from "$lib/telemetry/recorder";
+import { probeTurn } from "$lib/telemetry/taps";
 import { recVoiceEvent } from "$lib/telemetry/taps";
 
 /** Same ceiling as the output slider in audio settings. */
@@ -1270,6 +1271,13 @@ export class LibP2PVoice implements VoiceTransport {
           peerId,
           message: `Voice connection failed for ${peerId.slice(-8)}`,
         });
+        // Ask the network at the instant the app gave up. A TURN allocation
+        // taken now is what separates "TURN was down for this user" from "the
+        // app never used it" - the two look identical in every other event,
+        // and they are the two halves of "is it my internet or your code".
+        // Rate-limited inside probeTurn, so a room full of failing links
+        // still costs one allocation a minute.
+        void probeTurn(getIceServers());
         this.debugStats.tdPcFailed++;
         this.teardownRemotePeer(peerId);
         this.emit("peerLeft", peerId);

--- a/frontend/src/lib/transport/libp2p/voice.ts
+++ b/frontend/src/lib/transport/libp2p/voice.ts
@@ -3,6 +3,7 @@ import type { VoiceTransport, VoiceEvents } from "../types";
 import type { AppServices, LibP2PTransport } from "./transport";
 import type { DtlnProcessor } from "$lib/audio/dtln-processor";
 import { getIceServers, onIceServersChanged } from "../ice-server-list";
+import { succeededPair } from "../ice-stats";
 import { MessageType } from "$lib/types/message";
 import { encode } from "$lib/utils";
 import { CallAudioMixer } from "$lib/audio/call-audio-mixer";
@@ -718,15 +719,11 @@ export class LibP2PVoice implements VoiceTransport {
     // `getStats` yields loosely typed rows; only these fields are read.
     type Row = Record<string, unknown> & { type?: string; kind?: string };
     let inbound: Row | null = null;
-    let pair: Row | null = null;
     for (const report of stats.values()) {
       const row = report as Row;
-      if (row.type === "inbound-rtp" && row.kind === "audio") {
-        inbound = row;
-      } else if (row.type === "candidate-pair" && row.state === "succeeded") {
-        pair = row;
-      }
+      if (row.type === "inbound-rtp" && row.kind === "audio") inbound = row;
     }
+    const pair = succeededPair(stats);
     if (!inbound) return;
     const bytes = Number(inbound.bytesReceived) || 0;
     const previous = remote.lastBytesReceived;
@@ -754,13 +751,8 @@ export class LibP2PVoice implements VoiceTransport {
             typeof inbound.packetsLost === "number" ? inbound.packetsLost : null,
           // The path itself: "relay" next to loss is the network, and the
           // same loss on a direct pair is a different conversation.
-          path: pair
-            ? `${String(pair.localCandidateType ?? "?")}/${String(pair.remoteCandidateType ?? "?")}`
-            : null,
-          rtt:
-            typeof pair?.currentRoundTripTime === "number"
-              ? Math.round(pair.currentRoundTripTime * 1000)
-              : null,
+          path: pair ? `${pair.local ?? "?"}/${pair.remote ?? "?"}` : null,
+          rtt: pair?.rttMs ?? null,
         },
       })
     );
@@ -1284,27 +1276,23 @@ export class LibP2PVoice implements VoiceTransport {
         // check if relayed via TURN
         pc.getStats()
           .then((stats) => {
-            for (const report of stats.values()) {
-              if (
-                report.type === "candidate-pair" &&
-                report.state === "succeeded"
-              ) {
-                const isRelay =
-                  report.localCandidateType === "relay" ||
-                  report.remoteCandidateType === "relay";
-                remote.relayed = isRelay;
-                this.emit("status", {
-                  type: "voice-ice-connected",
-                  // Full id: consumers match tiles against it; the human-
-                  // readable part is the message.
-                  peerId,
-                  relayed: isRelay,
-                  message: isRelay
-                    ? "Voice connected via relay (TURN)"
-                    : "Voice connected directly (P2P)",
-                });
-              }
-            }
+            // Chrome puts no candidate TYPE on a candidate-pair - only ids
+            // pointing at separate entries - so the old inline read was
+            // `undefined === "relay"` for every Chromium user, and every
+            // relayed call told them it was direct. See ice-stats.ts.
+            const pair = succeededPair(stats);
+            if (!pair) return;
+            remote.relayed = pair.relayed;
+            this.emit("status", {
+              type: "voice-ice-connected",
+              // Full id: consumers match tiles against it; the human-
+              // readable part is the message.
+              peerId,
+              relayed: pair.relayed,
+              message: pair.relayed
+                ? "Voice connected via relay (TURN)"
+                : "Voice connected directly (P2P)",
+            });
           })
           .catch(() => {});
       } else if (state === "failed") {

--- a/frontend/src/lib/transport/mailbox.svelte.ts
+++ b/frontend/src/lib/transport/mailbox.svelte.ts
@@ -17,6 +17,8 @@ import {
 import { parseDmEnvelope } from "./dm-codec";
 import { deliverMailboxDm } from "./transport.svelte";
 import { apiUrl } from "$lib/runtime-config";
+import { ev, errText } from "$lib/telemetry/event";
+import { rec } from "$lib/telemetry/recorder";
 
 const OPTIN_KEY = "awful:mailbox-optin:v1";
 // A call, not a const: this module is imported while the app is still
@@ -72,8 +74,9 @@ export async function depositDmToMailbox(
         blob: b64(blob),
       }),
     });
-  } catch {
+  } catch (err) {
     // Relay down or box full: nothing lost, only slower.
+    rec(ev("dm.mailbox.deposit", { d: { err: errText(err) } }));
   }
 }
 
@@ -123,6 +126,7 @@ export async function collectMailbox(): Promise<void> {
           job = { senderDid, payload: parsed.payload };
       } catch (err) {
         console.warn("[mailbox] dropped blob:", err);
+        rec(ev("dm.mailbox.drop", { d: { err: errText(err) } }));
         done.push(entry.id);
         continue;
       }
@@ -135,6 +139,7 @@ export async function collectMailbox(): Promise<void> {
         done.push(entry.id);
       } catch (err) {
         console.warn("[mailbox] delivery failed, keeping blob:", err);
+        rec(ev("dm.mailbox.collect", { d: { err: errText(err), delivered: false } }));
       }
     }
     if (done.length > 0) {
@@ -144,6 +149,7 @@ export async function collectMailbox(): Promise<void> {
         body: JSON.stringify({ ...authFields(), ids: done }),
       });
       console.log(`[mailbox] collected ${done.length} offline DM(s)`);
+      rec(ev("dm.mailbox.collect", { d: { count: done.length } }));
     }
   } catch {
     // Offline or relay down: the next tick retries.

--- a/frontend/src/lib/transport/mediasoup.ts
+++ b/frontend/src/lib/transport/mediasoup.ts
@@ -3,9 +3,13 @@
 // turn a camera on.
 import type * as mediasoupClient from "mediasoup-client";
 import type { VideoTransport, VideoEvents, VideoSource } from "./types";
-import { sfuForRoom } from "./sfu-pool";
+import { sfuForRoom, sfuPool } from "./sfu-pool";
 import { shouldBlockSfu } from "./faults";
 import { getIceServers } from "./ice-server-list";
+import { errText, ev } from "$lib/telemetry/event";
+import { rec } from "$lib/telemetry/recorder";
+import { recVideoEvent } from "$lib/telemetry/taps";
+import type { SfuSnapshot } from "$lib/telemetry/schema";
 
 /**
  * Reaches the user verbatim - transmission.svelte assigns an error event's
@@ -151,6 +155,32 @@ interface MSError {
   direction?: "send" | "recv";
 }
 
+/**
+ * `ms:diag` request/reply pair for a live SFU snapshot. Mirrored in
+ * `sfu/index.ts` and `frontend/src/lib/telemetry/schema.ts` - change all
+ * three together.
+ */
+interface MSDiag {
+  type: "ms:diag";
+  requestId: string;
+} // client -> server
+interface MSDiagReply {
+  type: "ms:diag";
+  requestId: string;
+  snapshot: SfuSnapshot;
+} // server -> client
+/**
+ * The SFU refuses a diag request with THIS frame, never with `ms:error`.
+ * An `ms:error` with no `direction` latches `this.refusal` and ends the
+ * whole session (see `failSession`). A refused session is the one most
+ * worth inspecting, so a diag refusal must not also kill the session.
+ */
+interface MSDiagUnavailable {
+  type: "ms:diag-unavailable";
+  requestId: string;
+  reason: "disabled" | "rate-limited";
+}
+
 type MSMessage =
   | MSGetCapabilities
   | MSCapabilities
@@ -170,7 +200,10 @@ type MSMessage =
   | MSCloseConsumer
   | MSCloseProducer
   | MSResumeConsumer
-  | MSError;
+  | MSError
+  | MSDiag
+  | MSDiagReply
+  | MSDiagUnavailable;
 
 /**
  * Turns an SFU refusal into a sentence for the person in the call. It reaches
@@ -309,12 +342,14 @@ export class MediasoupVideo implements VideoTransport {
       this.currentRoomCode = roomCode;
       this.currentPeerId = peerId;
       await this.connectSfu(roomCode, peerId);
+      rec(ev("sfu.join", { peer: peerId }));
 
       const capMsg = await this.request<MSCapabilities>(
         { type: "ms:get-capabilities", requestId: this.nextRequestId() },
         "ms:capabilities"
       );
       this.lastRoomPeerCount = capMsg.roomPeerCount;
+      rec(ev("sfu.caps", { d: { roomPeerCount: capMsg.roomPeerCount } }));
 
       const { Device } = await import("mediasoup-client");
       this.device = new Device();
@@ -546,6 +581,13 @@ export class MediasoupVideo implements VideoTransport {
       const sfuUrl =
         sfuForRoom(roomCode) ??
         `${location.origin.replace(/^http/, "ws")}/sfu`;
+      let sfuHost: string | null;
+      try {
+        sfuHost = new URL(sfuUrl).host;
+      } catch {
+        sfuHost = null;
+      }
+      rec(ev("sfu.pick", { d: { host: sfuHost, poolSize: sfuPool().length } }));
 
       // A fresh socket starts clean: the previous session's refusal must not
       // fail the requests this one is about to make.
@@ -555,6 +597,7 @@ export class MediasoupVideo implements VideoTransport {
       this.sfuWs = ws;
 
       ws.onopen = () => {
+        rec(ev("sfu.ws.open"));
         // Identify ourselves to the SFU with a stable anonymous peer id.
         // We reuse a per-page session id so the SFU can correlate transports.
         ws.send(
@@ -568,6 +611,7 @@ export class MediasoupVideo implements VideoTransport {
       };
 
       ws.onerror = () => {
+        rec(ev("sfu.ws.error"));
         reject(new Error(SFU_UNREACHABLE));
       };
 
@@ -580,14 +624,34 @@ export class MediasoupVideo implements VideoTransport {
         }
       };
 
-      ws.onclose = () => {
+      ws.onclose = (closeEvent: CloseEvent) => {
         // Only the CURRENT socket's close means anything. A rebuild closes the
         // old socket and opens a new one, and the old close event lands after
         // that - rejecting the fresh socket's in-flight requests (they share
         // one pendingById map) and scheduling a rejoin behind a session that is
         // already healthy. That is a join failing with "SFU connection closed"
         // for no reason anyone can see.
-        if (this.sfuWs !== ws) return;
+        //
+        // The probe obeys the same rule and tags the superseded case, because
+        // an untagged sfu.ws.close folds into the topology as a disconnected
+        // SFU sitting behind a session that is actually fine.
+        if (this.sfuWs !== ws) {
+          rec(
+            ev("sfu.ws.close", {
+              d: {
+                code: closeEvent.code,
+                reason: closeEvent.reason,
+                stale: true,
+              },
+            })
+          );
+          return;
+        }
+        rec(
+          ev("sfu.ws.close", {
+            d: { code: closeEvent.code, reason: closeEvent.reason },
+          })
+        );
         const wasJoined = this.device !== null;
 
         // Reject all pending requests when connection drops
@@ -629,6 +693,7 @@ export class MediasoupVideo implements VideoTransport {
     // Chrome caps a page at 500 live ones; that is the "Cannot create so many
     // PeerConnections" that eventually takes voice, video and libp2p's own
     // WebRTC dials down together.
+    rec(ev("sfu.rejoin", { d: { attempt, delayMs: delay } }));
     if (this.rejoinTimer) clearTimeout(this.rejoinTimer);
     this.rejoinTimer = setTimeout(() => {
       this.rejoinTimer = null;
@@ -783,6 +848,7 @@ export class MediasoupVideo implements VideoTransport {
    * direction instead of the whole session.
    */
   private handleTransportTimeout(direction: "send" | "recv" | undefined): void {
+    rec(ev("sfu.transport.timeout", { d: { direction: direction ?? "unknown" } }));
     this.emit(
       "error",
       new Error(
@@ -923,6 +989,7 @@ export class MediasoupVideo implements VideoTransport {
               }
             : {}),
         });
+        rec(ev("sfu.produce", { d: { source, kind: track.kind } }));
 
         const entry: Producer = { producer, source, stream };
         produced.push(entry);
@@ -1013,6 +1080,7 @@ export class MediasoupVideo implements VideoTransport {
       // libp2p/voice.ts) worked and video silently never did (finding 7).
       iceServers: getIceServers(),
     });
+    rec(ev("sfu.transport.create", { d: { direction: "send" } }));
 
     this.sendTransport.on(
       "connect",
@@ -1049,6 +1117,7 @@ export class MediasoupVideo implements VideoTransport {
     );
 
     this.sendTransport.on("connectionstatechange", (state: string) => {
+      rec(ev("sfu.transport.state", { d: { direction: "send", state } }));
       if (state === "failed" || state === "closed") {
         this.emit("error", new Error("Send transport connection failed"));
         this.scheduleRejoin(this.joinGeneration);
@@ -1072,6 +1141,7 @@ export class MediasoupVideo implements VideoTransport {
       // (finding 7).
       iceServers: getIceServers(),
     });
+    rec(ev("sfu.transport.create", { d: { direction: "recv" } }));
 
     this.recvTransport.on(
       "connect",
@@ -1086,6 +1156,7 @@ export class MediasoupVideo implements VideoTransport {
     );
 
     this.recvTransport.on("connectionstatechange", (state: string) => {
+      rec(ev("sfu.transport.state", { d: { direction: "recv", state } }));
       if (state === "failed" || state === "closed") {
         this.emit("error", new Error("Receive transport connection failed"));
         this.scheduleRejoin(this.joinGeneration);
@@ -1112,6 +1183,15 @@ export class MediasoupVideo implements VideoTransport {
     // pending lookup: every reason the SFU sends lands during the join
     // handshake, where a request is waiting for a frame that is never coming.
     if (msg.type === "ms:error") {
+      rec(
+        ev("sfu.error", {
+          d: {
+            reason: msg.reason,
+            direction: msg.direction ?? null,
+            latched: msg.reason !== "transport-timeout",
+          },
+        })
+      );
       if (msg.reason === "transport-timeout") {
         this.handleTransportTimeout(msg.direction);
       } else {
@@ -1387,11 +1467,13 @@ export class MediasoupVideo implements VideoTransport {
   ): Promise<void> {
     try {
       await this.consumeProducer(peerId, producerId, source);
-    } catch {
+    } catch (err) {
+      rec(ev("sfu.consume.failed", { peer: peerId, d: { err: errText(err), attempt: 1 } }));
       await new Promise((resolve) => setTimeout(resolve, 3_000));
       try {
         await this.consumeProducer(peerId, producerId, source);
       } catch (err) {
+        rec(ev("sfu.consume.failed", { peer: peerId, d: { err: errText(err), attempt: 2 } }));
         this.emit(
           "error",
           err instanceof Error ? err : new Error(String(err))
@@ -1416,12 +1498,23 @@ export class MediasoupVideo implements VideoTransport {
     this.emit("error", err);
   }
 
-  private request<T>(msg: MSMessage, responseType: string): Promise<T> {
+  /**
+   * `opts.ignoreRefusal` skips the refusal check below: a refused session
+   * is exactly the one `requestDiag` needs to inspect. `opts.alsoAccept`
+   * documents a second acceptable response type; it needs no extra check
+   * here, because resolution below matches a response by its `requestId`
+   * alone, never by `responseType`.
+   */
+  private request<T>(
+    msg: MSMessage,
+    responseType: string,
+    opts?: { alsoAccept?: string; ignoreRefusal?: boolean }
+  ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       // A refused session never answers anything: the SFU closed the socket
       // right after its ms:error, so signal() below would drop this frame
       // and the caller would wait out the full timeout for nothing.
-      if (this.refusal) {
+      if (this.refusal && !opts?.ignoreRefusal) {
         reject(this.refusal);
         return;
       }
@@ -1448,6 +1541,25 @@ export class MediasoupVideo implements VideoTransport {
 
       this.signal(msg);
     });
+  }
+
+  /**
+   * One `ms:diag` snapshot, or null. Never throws: a refused session, a
+   * timeout, and `ms:diag-unavailable` all resolve to null, so a caller on
+   * a periodic tick needs no try/catch of its own.
+   */
+  async requestDiag(): Promise<SfuSnapshot | null> {
+    try {
+      const msg = await this.request<MSDiagReply | MSDiagUnavailable>(
+        { type: "ms:diag", requestId: this.nextRequestId() },
+        "ms:diag",
+        { alsoAccept: "ms:diag-unavailable", ignoreRefusal: true }
+      );
+      if (msg.type === "ms:diag-unavailable") return null;
+      return msg.snapshot;
+    } catch {
+      return null;
+    }
   }
 
   /** Start the getStats() sweep (finding 5). Idempotent - join() calls this
@@ -1538,6 +1650,7 @@ export class MediasoupVideo implements VideoTransport {
     event: K,
     ...args: Parameters<VideoEvents[K]>
   ): void {
+    recVideoEvent(event as string, args);
     this.handlers.get(event)?.forEach((h) => (h as Function)(...args));
   }
 }

--- a/frontend/src/lib/transport/mediasoup.ts
+++ b/frontend/src/lib/transport/mediasoup.ts
@@ -1217,6 +1217,20 @@ export class MediasoupVideo implements VideoTransport {
 
     switch (msg.type) {
       case "ms:new-producer":
+        // Recorded BEFORE the queue check, so an announcement that arrives
+        // early is still half of the pair a reader needs: every producer
+        // announced to us should end in a consumer, and the gap between the
+        // two is where a wedged recv transport hides.
+        rec(
+          ev("sfu.consume", {
+            peer: msg.peerId,
+            d: {
+              phase: "announced",
+              producer: msg.producerId,
+              source: msg.source,
+            },
+          })
+        );
         // Not joined yet (no device): queue and process after join() completes.
         if (!this.device) {
           this.queuedProducers.push(msg);
@@ -1362,7 +1376,20 @@ export class MediasoupVideo implements VideoTransport {
     source: VideoSource
   ): Promise<void> {
     const inflight = this.inflightConsumes.get(producerId);
-    if (inflight) return inflight;
+    if (inflight) {
+      // Two consumes for one producer are not merely wasteful: the SFU answers
+      // the second with the SAME consumer id and mid, and the duplicate media
+      // section makes the browser reject the whole offer permanently. This
+      // event is how a reader knows the guard held rather than that the race
+      // never happened.
+      rec(
+        ev("sfu.consume", {
+          peer: peerId,
+          d: { phase: "dedup", producer: producerId, source },
+        })
+      );
+      return inflight;
+    }
     const p = this.consumeProducerInner(peerId, producerId, source).finally(
       () => {
         // Identity-checked: a rebuild may have already replaced this entry
@@ -1432,6 +1459,18 @@ export class MediasoupVideo implements VideoTransport {
     // arbitrary point in a GOP the client never asked for (finding 3).
     this.signal({ type: "ms:resume-consumer", producerId });
 
+    rec(
+      ev("sfu.consume", {
+        peer: peerId,
+        d: {
+          phase: "ok",
+          producer: producerId,
+          source,
+          kind: consumer.kind,
+        },
+      })
+    );
+
     if (!this.consumers.has(peerId)) this.consumers.set(peerId, []);
     this.consumers.get(peerId)!.push({ consumer, source });
 
@@ -1468,12 +1507,22 @@ export class MediasoupVideo implements VideoTransport {
     try {
       await this.consumeProducer(peerId, producerId, source);
     } catch (err) {
-      rec(ev("sfu.consume.failed", { peer: peerId, d: { err: errText(err), attempt: 1 } }));
+      rec(
+        ev("sfu.consume.failed", {
+          peer: peerId,
+          d: { err: errText(err), attempt: 1, producer: producerId },
+        })
+      );
       await new Promise((resolve) => setTimeout(resolve, 3_000));
       try {
         await this.consumeProducer(peerId, producerId, source);
       } catch (err) {
-        rec(ev("sfu.consume.failed", { peer: peerId, d: { err: errText(err), attempt: 2 } }));
+        rec(
+          ev("sfu.consume.failed", {
+            peer: peerId,
+            d: { err: errText(err), attempt: 2, producer: producerId },
+          })
+        );
         this.emit(
           "error",
           err instanceof Error ? err : new Error(String(err))

--- a/frontend/src/lib/transport/sync.svelte.ts
+++ b/frontend/src/lib/transport/sync.svelte.ts
@@ -479,7 +479,7 @@ async function startSyncServer(): Promise<void> {
 
   console.log("[Sync][Source] Starting sync server for room:", _syncRoomCode);
 
-  _transport = new LibP2PTransport();
+  _transport = new LibP2PTransport({ diagBus: "sync" });
 
   // Set up handlers
   _transport.on("connect", (peerId: string) => {
@@ -759,7 +759,7 @@ export async function connectAsTarget(payload: SyncPayload): Promise<void> {
     _syncRoomCode = payload.roomCode;
     _isSourceDevice = false;
 
-    _transport = new LibP2PTransport();
+    _transport = new LibP2PTransport({ diagBus: "sync" });
 
     let receivedIdentity: DatabaseExport["identity"] | null = null;
     const receivedData: Partial<DatabaseExport> = {};

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -149,6 +149,11 @@ import {
   withFileTransfer,
 } from "./files.svelte";
 import { initVoice } from "./voice.svelte";
+import { installTelemetryTaps, stopTelemetryTaps } from "../telemetry/taps";
+import { ev } from "../telemetry/event";
+import { noteIdentity, rec, recorderSnapshot, refs } from "../telemetry/recorder";
+import { apiUrl, isConfigured, relayMultiaddr, sfuUrls } from "../runtime-config";
+import { faultStats, faultsActive } from "./faults";
 import { initTransmission } from "./transmission.svelte";
 
 const MSG_ORDER = (a: Message, b: Message) =>
@@ -529,6 +534,7 @@ if (import.meta.env.DEV && typeof window !== "undefined") {
     sendFiles,
     sendMessage,
     _handleCallPresence,
+    diag: () => recorderSnapshot(),
   };
 }
 
@@ -596,6 +602,56 @@ export const _fileTransport = new WebTorrentFileTransport(() =>
 initVoice(_voice, _dtln);
 initTransmission(_video);
 initFiles(_fileTransport);
+
+/** Resolve the SFU host list once per call; each entry may be unparseable. */
+function _diagSfuHosts(): string[] {
+  const hosts: string[] = [];
+  for (const url of sfuUrls()) {
+    try {
+      hosts.push(new URL(url).host);
+    } catch {
+      // An unparseable configured URL is dropped, not fatal to the sample.
+    }
+  }
+  return hosts;
+}
+
+/** The HOST only, never a URL with a path or query. */
+function _diagApiHost(): string {
+  const url = apiUrl();
+  if (!url) return "";
+  try {
+    return new URL(url).host;
+  } catch {
+    return "";
+  }
+}
+
+/** The trailing `/p2p/<id>` segment of the relay multiaddr, id only. */
+function _diagRelayPeerId(): string {
+  const marker = "/p2p/";
+  const addr = relayMultiaddr();
+  const at = addr.lastIndexOf(marker);
+  if (at === -1) return "";
+  const rest = addr.slice(at + marker.length);
+  const nextSlash = rest.indexOf("/");
+  return nextSlash === -1 ? rest : rest.slice(0, nextSlash);
+}
+
+installTelemetryTaps({
+  selfPeerId: () => _transport.selfId(),
+  runtime: () => ({
+    apiHost: _diagApiHost(),
+    relayPeerId: _diagRelayPeerId(),
+    sfuHosts: _diagSfuHosts(),
+    configured: isConfigured(),
+  }),
+  faultsActive,
+  counterBags: () => ({ t: _transport.debugStats, a: _stats, f: faultStats }),
+  inCall: () => transportState.inCall,
+  hidden: () => typeof document !== "undefined" && document.hidden,
+  requestSfuDiag: () => _video.requestDiag(),
+});
 
 // Stored peer profile metadata is invisible until the peer re-broadcasts:
 // the reactive map only ever filled from live messages, so a reload emptied
@@ -1032,10 +1088,12 @@ if (typeof document !== "undefined") {
   document.addEventListener("visibilitychange", () => {
     if (document.hidden) {
       _hiddenSince = Date.now();
+      rec(ev("session.visibility", { d: { hidden: true } }));
       return;
     }
     const away = _hiddenSince ? Date.now() - _hiddenSince : 0;
     _hiddenSince = 0;
+    rec(ev("session.visibility", { d: { hidden: false, hiddenMs: away } }));
     // A glance away only needs history reconciled. A long absence means the
     // connections themselves may be stale, so re-announce and re-dial too.
     if (away > AWAY_FULL_RESYNC_MS) _resyncEverything();
@@ -1043,7 +1101,10 @@ if (typeof document !== "undefined") {
   });
 }
 if (typeof window !== "undefined") {
-  window.addEventListener("online", () => _resyncEverything());
+  window.addEventListener("online", () => {
+    rec(ev("session.online"));
+    _resyncEverything();
+  });
 }
 
 async function _sendDigest(peerId: string): Promise<void> {
@@ -1075,6 +1136,13 @@ async function _sendDigestForRoom(
     await getWatermarksForRoom(roomCode)
   );
   _stats.digestsOut++;
+  rec(
+    ev("app.digest.out", {
+      peer: peerId,
+      room: refs().roomRef(roomCode),
+      d: { watermarks: Object.keys(watermarks).length },
+    })
+  );
   await _transport.send(
     peerId,
     encode({ type: MessageType.SyncDigest, roomCode, watermarks })
@@ -1145,6 +1213,13 @@ async function _handleDigest(
   // merely named, and never fall back to whatever room the UI has open.
   _stats.digestsIn++;
   if (!roomCode || !_transport.rooms().includes(roomCode)) return;
+  rec(
+    ev("app.digest.in", {
+      peer: peerId,
+      room: refs().roomRef(roomCode),
+      d: { watermarks: Object.keys(theirWatermarks).length },
+    })
+  );
   // Senders in a digest are peer-chosen strings, and every entry costs a
   // blindValue plus map work downstream. A room never accumulates anywhere
   // near this many senders honestly; a digest that does is dropped whole.
@@ -1378,10 +1453,22 @@ async function _handleSyncBatch(
       _verifyIncoming(m, { room: roomCode, allowUnsigned: allowUnsignedFor(m) })
     )
   );
-  const verified = messages.filter((_, i) => verdicts[i]);
+  const verified = messages.filter((_, i) => verdicts[i].ok);
   if (verified.length < messages.length) {
+    const reasons: Record<string, number> = {};
+    for (const v of verdicts) {
+      if (!v.ok) reasons[v.reason] = (reasons[v.reason] ?? 0) + 1;
+    }
     console.warn(
-      `[sync] dropped ${messages.length - verified.length} message(s) with invalid signatures`
+      `[sync] dropped ${messages.length - verified.length} message(s) with invalid signatures`,
+      reasons
+    );
+    rec(
+      ev("app.sync.drop", {
+        peer: fromPeerId ?? null,
+        room: refs().roomRef(roomCode),
+        d: { count: messages.length - verified.length, reason: "bad-signature" },
+      })
     );
   }
   // Two kinds of rejection. A SIGNED (v2/v3) message that failed verify is
@@ -1414,7 +1501,7 @@ async function _handleSyncBatch(
   const rejectedFloor = new Map<string, number>();
   const permanentMax = new Map<string, number>();
   messages.forEach((m, i) => {
-    if (verdicts[i]) return;
+    if (verdicts[i].ok) return;
     if (typeof m.senderId !== "string" || !m.senderId) return;
     if (!Number.isSafeInteger(m.lamport) || m.lamport < 0) return;
     // v2 joined v1 as a DETERMINISTIC reject at the 2026-08-28 sunset. This
@@ -1545,6 +1632,13 @@ async function _handleSyncBatch(
   if (hijacks.length) {
     console.warn(
       `[sync] refused ${hijacks.length} message(s) reusing the id of one we already hold`
+    );
+    rec(
+      ev("app.sync.drop", {
+        peer: fromPeerId ?? null,
+        room: refs().roomRef(roomCode),
+        d: { count: hijacks.length, reason: "id-reuse" },
+      })
     );
     const refused = new Set(hijacks.map((w) => w.id));
     usable = usable.filter((w) => !refused.has(w.id));
@@ -1747,9 +1841,14 @@ async function _handleProfile(peerId: string, msg: WireProfile): Promise<void> {
     (await verifyPeerBinding(claimed, peerId, msg.bindingSig));
   if (!proven) {
     _stats.profilesRejected++;
+    rec(ev("app.profile.reject", { peer: peerId, d: { reason: "binding" } }));
     return;
   }
   const did = claimed as string;
+  rec(ev("app.profile.in", { peer: peerId }));
+  // A proven peerId->DID binding is the only thing allowed to group two
+  // peerIds under one identity ordinal - see the recorder's own warning.
+  noteIdentity(peerId, did);
   const isNewMapping = _peerIdToDid.get(peerId) !== did;
   _setPeerDid(peerId, did);
 
@@ -2121,6 +2220,12 @@ function _handleRoomUsersSync(
   const valid = participants.filter(
     (p) => typeof p === "string" && (looksLikeDid(p) || looksLikePeerId(p))
   );
+  rec(
+    ev("app.roomusers", {
+      room: refs().roomRef(roomCode),
+      d: { count: valid.length },
+    })
+  );
   if (roomCode !== transportState.roomCode) {
     // A list for a room we are subscribed to but not looking at. Persist it,
     // but leave the on-screen member list alone - merging it in was how one
@@ -2149,19 +2254,23 @@ function _handleRoomUsersSync(
 
 function _broadcastJoinRoom(): void {
   const selfDid = identityStore.did ?? _transport.selfId();
-  if (!selfDid || !transportState.roomCode) return;
+  const roomCode = transportState.roomCode;
+  if (!selfDid || !roomCode) return;
   _transport.broadcast(
     encode({ type: MessageType.JoinRoom, peerId: selfDid }),
-    transportState.roomCode
+    roomCode
   );
+  rec(ev("app.join", { room: refs().roomRef(roomCode) }));
 }
 
 function _broadcastLeaveRoom(): Promise<void> {
   const selfDid = identityStore.did ?? _transport.selfId();
-  if (!selfDid || !transportState.roomCode) return Promise.resolve();
+  const roomCode = transportState.roomCode;
+  if (!selfDid || !roomCode) return Promise.resolve();
+  rec(ev("app.leave", { room: refs().roomRef(roomCode) }));
   return _transport.broadcast(
     encode({ type: MessageType.LeaveRoom, peerId: selfDid }),
-    transportState.roomCode
+    roomCode
   );
 }
 
@@ -2834,11 +2943,17 @@ _transport.on("message", (peerId, data, room) => {
         // No watermark, lamport, or storage side effects.
         const ephemeralMsg = msg as WirePluginEphemeral;
         _verifyIncoming(ephemeralMsg as unknown as WireChatMessage, { room })
-          .then((ok) => {
-            if (!ok) {
+          .then((v) => {
+            if (!v.ok) {
               console.warn(
                 "[app] dropped ephemeral plugin message with invalid signature from",
                 ephemeralMsg.senderId
+              );
+              rec(
+                ev("app.msg.reject", {
+                  peer: peerId,
+                  d: { reason: v.reason, wire: "plugin_ephemeral" },
+                })
               );
               return;
             }
@@ -2928,13 +3043,21 @@ _transport.on("message", (peerId, data, room) => {
           break;
         }
         _verifyIncoming(msg, { room })
-          .then((ok) => {
-            if (ok) _handleChatMessage(msg, room, peerId).catch(() => {});
-            else
-              console.warn(
-                "[app] dropped message with invalid signature from",
-                msg.senderId
-              );
+          .then((v) => {
+            if (v.ok) {
+              _handleChatMessage(msg, room, peerId).catch(() => {});
+              return;
+            }
+            console.warn(
+              "[app] dropped message with invalid signature from",
+              msg.senderId
+            );
+            rec(
+              ev("app.msg.reject", {
+                peer: peerId,
+                d: { reason: v.reason, wire: msg.type },
+              })
+            );
           })
           .catch(() => {});
         break;
@@ -3206,6 +3329,7 @@ export function disconnectTransport(): void {
 }
 
 function _disconnectWithoutBroadcasting(): void {
+  rec(ev("session.end"));
   for (const transfer of transportState.fileTransfers.values()) {
     if (transfer.blobURL) URL.revokeObjectURL(transfer.blobURL);
   }
@@ -3215,6 +3339,7 @@ function _disconnectWithoutBroadcasting(): void {
   _fileTransport.resetTransfers();
   leaveCall();
   _transport.disconnect();
+  stopTelemetryTaps();
   _peerIdToDid.clear();
   clearCardStates();
   // The search corpus is decrypted message text; it dies with the session
@@ -3269,7 +3394,14 @@ function _disconnectWithoutBroadcasting(): void {
  * peer gets no copy - gossip and sync still cover them.
  */
 function _broadcastChatWire(wire: WireChatMessage, roomCode: string): void {
-  _transport.broadcast(encode(wire), roomCode);
+  const payload = encode(wire);
+  _transport.broadcast(payload, roomCode);
+  rec(
+    ev("app.msg.out", {
+      room: refs().roomRef(roomCode),
+      d: { bytes: payload.byteLength },
+    })
+  );
   const batch = encode({
     type: MessageType.SyncBatch,
     roomCode,

--- a/frontend/src/lib/transport/verify-incoming.test.ts
+++ b/frontend/src/lib/transport/verify-incoming.test.ts
@@ -46,7 +46,7 @@ describe("verifyIncoming", () => {
       wire({ senderId: alice.did, senderDid: alice.did }),
       alice.priv
     );
-    expect(await verifyIncoming(w, { room: ROOM })).toBe(true);
+    expect(await verifyIncoming(w, { room: ROOM })).toEqual({ ok: true });
   });
 
   it("rejects a signature over a DIFFERENT room (v3 binds the room)", async () => {
@@ -55,7 +55,10 @@ describe("verifyIncoming", () => {
       alice.priv,
       "other-room"
     );
-    expect(await verifyIncoming(w, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "bad-signature",
+    });
   });
 
   it("rejects a flipped type on a valid signature (v3 binds the type)", async () => {
@@ -67,7 +70,10 @@ describe("verifyIncoming", () => {
       ...w,
       type: MessageType.PluginUpdate,
     } as WireChatMessage;
-    expect(await verifyIncoming(flipped, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(flipped, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "bad-signature",
+    });
   });
 
   // The forgery this module exists for: a senderId that is NOT in did:key
@@ -79,7 +85,10 @@ describe("verifyIncoming", () => {
       wire({ senderId: alicePeerId, senderDid: mallory.did }),
       mallory.priv
     );
-    expect(await verifyIncoming(w, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "did-mismatch",
+    });
   });
 
   it("rejects any mismatch between senderDid and senderId", async () => {
@@ -87,14 +96,20 @@ describe("verifyIncoming", () => {
       wire({ senderId: alice.did, senderDid: mallory.did }),
       mallory.priv
     );
-    expect(await verifyIncoming(w, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "did-mismatch",
+    });
   });
 
   it("rejects every signature version but 3", async () => {
     const base = wire({ senderId: alice.did, senderDid: alice.did });
     for (const sigV of [undefined, 1, 2, 4, 99]) {
       const w = { ...base, sig: "00".repeat(64), sigV } as WireChatMessage;
-      expect(await verifyIncoming(w, { room: ROOM })).toBe(false);
+      expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+        ok: false,
+        reason: "sig-version",
+      });
     }
   });
 
@@ -106,7 +121,10 @@ describe("verifyIncoming", () => {
     const w = wire({ senderId: alice.did, senderDid: alice.did });
     const sig = ed25519.sign(utf8(canonicalContentV2(w as never)), alice.priv);
     const signed = { ...w, sig: hex(sig), sigV: 2 } as WireChatMessage;
-    expect(await verifyIncoming(signed, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(signed, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "sig-version",
+    });
   });
 
   it("rejects content over the size cap, even genuinely signed", async () => {
@@ -118,7 +136,10 @@ describe("verifyIncoming", () => {
       }),
       alice.priv
     );
-    expect(await verifyIncoming(w, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "content-oversize",
+    });
   });
 
   it("rejects a non-string content field", async () => {
@@ -126,7 +147,10 @@ describe("verifyIncoming", () => {
       ...signV3(wire({ senderId: alice.did, senderDid: alice.did }), alice.priv),
       content: 12345,
     } as unknown as WireChatMessage;
-    expect(await verifyIncoming(w, { room: ROOM })).toBe(false);
+    expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "content-type",
+    });
   });
 
   it("needs an authenticated room for v3 - never trusts the wire for it", async () => {
@@ -134,20 +158,39 @@ describe("verifyIncoming", () => {
       wire({ senderId: alice.did, senderDid: alice.did }),
       alice.priv
     );
-    expect(await verifyIncoming(w, {})).toBe(false);
+    expect(await verifyIncoming(w, {})).toMatchObject({
+      ok: false,
+      reason: "no-room",
+    });
+  });
+
+  it("rejects a message with no senderDid at all", async () => {
+    const base = wire({ senderId: alice.did });
+    const sig = ed25519.sign(
+      utf8(canonicalContentV3({ ...base, roomCode: ROOM } as never)),
+      alice.priv
+    );
+    const w = { ...base, sig: hex(sig), sigV: 3 } as WireChatMessage;
+    expect(await verifyIncoming(w, { room: ROOM })).toMatchObject({
+      ok: false,
+      reason: "no-did",
+    });
   });
 
   describe("unsigned rows", () => {
     const unsigned = wire({ senderId: alice.did, senderDid: alice.did });
 
     it("are rejected by default", async () => {
-      expect(await verifyIncoming(unsigned, { room: ROOM })).toBe(false);
+      expect(await verifyIncoming(unsigned, { room: ROOM })).toMatchObject({
+        ok: false,
+        reason: "unsigned",
+      });
     });
 
     it("are allowed only where the caller opts in (DM sync)", async () => {
       expect(
         await verifyIncoming(unsigned, { room: ROOM, allowUnsigned: true })
-      ).toBe(true);
+      ).toEqual({ ok: true });
     });
   });
 });

--- a/frontend/src/lib/transport/verify-incoming.ts
+++ b/frontend/src/lib/transport/verify-incoming.ts
@@ -26,20 +26,36 @@ export interface VerifyOpts {
   allowUnsigned?: boolean;
 }
 
+export type VerifyReason =
+  | "content-type"
+  | "content-oversize"
+  | "unsigned"
+  | "sig-version"
+  | "no-did"
+  | "did-mismatch"
+  | "no-room"
+  | "bad-signature";
+
+export type VerifyVerdict = { ok: true } | { ok: false; reason: VerifyReason };
+
 export async function verifyIncoming(
   wire: WireChatMessage,
   opts: VerifyOpts = {}
-): Promise<boolean> {
+): Promise<VerifyVerdict> {
   // Ahead of everything else, signed or not: a valid signature (or an
   // allowUnsigned sync batch from a trusted counterparty) only proves who
   // sent it, never that it is a reasonable size to store and render.
-  if (
-    typeof wire.content !== "string" ||
-    wire.content.length > MAX_CHAT_CONTENT_LENGTH
-  ) {
-    return false;
+  if (typeof wire.content !== "string") {
+    return { ok: false, reason: "content-type" };
   }
-  if (!wire.sig) return opts.allowUnsigned === true;
+  if (wire.content.length > MAX_CHAT_CONTENT_LENGTH) {
+    return { ok: false, reason: "content-oversize" };
+  }
+  if (!wire.sig) {
+    return opts.allowUnsigned === true
+      ? { ok: true }
+      : { ok: false, reason: "unsigned" };
+  }
   // v3 ONLY, as of the 2026-08-28 sunset.
   //
   // v1's canonical left reaction/reply/file fields unsigned, so a relay could
@@ -55,8 +71,8 @@ export async function verifyIncoming(
   // sync transfers the database wholesale rather than re-verifying it, so
   // nothing already on a device is lost - a peer simply cannot backfill a
   // room's pre-v3 past to a device that never had it.
-  if (wire.sigV !== 3) return false;
-  if (!wire.senderDid) return false;
+  if (wire.sigV !== 3) return { ok: false, reason: "sig-version" };
+  if (!wire.senderDid) return { ok: false, reason: "no-did" };
   // The signing DID must BE the claimed sender, always. This was once checked
   // only when senderId was already in did:key form, so a senderId in any
   // other shape - notably a libp2p peerId, which every peer in the mesh can
@@ -67,15 +83,18 @@ export async function verifyIncoming(
   // signer is the author. Every validly signed message carries
   // senderDid === senderId: signMessage() needs an unlocked session and sets
   // both from it.
-  if (wire.senderDid !== wire.senderId) return false;
+  if (wire.senderDid !== wire.senderId) {
+    return { ok: false, reason: "did-mismatch" };
+  }
   // v3 binds type and room. The wire carries no roomCode, so the canonical is
   // reconstructed with the AUTHENTICATED room this message is being filed
   // under - a message signed for another room (or with its type flipped in
   // transit) fails verification here.
-  if (!opts.room) return false;
-  return verifySignature(
+  if (!opts.room) return { ok: false, reason: "no-room" };
+  const valid = await verifySignature(
     wire.senderDid,
     wire.sig,
     canonicalContentV3({ ...wire, roomCode: opts.room })
   );
+  return valid ? { ok: true } : { ok: false, reason: "bad-signature" };
 }

--- a/relay/cors.go
+++ b/relay/cors.go
@@ -61,8 +61,18 @@ func corsHeaders(r *http.Request) http.Header {
 
 	headers := http.Header{}
 	headers.Set("Access-Control-Allow-Origin", allowOrigin)
-	headers.Set("Access-Control-Allow-Methods", "GET,OPTIONS")
-	headers.Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	// POST is here for the routes that take a body - the mailbox pair and the
+	// telemetry ingest. A preflight that omits the method blocks the request
+	// before the handler ever runs.
+	headers.Set("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+	// X-Awful-Peer/Ts/Sig are the telemetry upload's auth triple. A browser
+	// preflights any request that carries a non-simple header, so an upload from
+	// an app on another origin fails outright when they are missing here - not
+	// with a 401, but with a blocked fetch that reports only "Failed to fetch".
+	headers.Set(
+		"Access-Control-Allow-Headers",
+		"Content-Type, Authorization, X-Awful-Peer, X-Awful-Ts, X-Awful-Sig",
+	)
 	headers.Set("Access-Control-Max-Age", "86400")
 	headers.Set("Vary", "Origin")
 	return headers

--- a/relay/main.go
+++ b/relay/main.go
@@ -236,6 +236,19 @@ type connectedClient struct {
 	// membershipOps in readLoop - it needs no lock of its own even though
 	// register() happens to touch it while holding registry.mu.
 	emptyRegisters opBudget
+
+	// Telemetry-only bookkeeping (relay/telemetry.go), guarded by
+	// registry.mu exactly like roomCapLogged and joinLeaveLog above - written
+	// by register/unregister, read by relayViewFor. Cheap to maintain
+	// unconditionally: none of it changes any wire-visible or logged
+	// behavior when TELEMETRY_ENABLED is unset, so the "inert by default"
+	// contract holds without gating these increments.
+	diagRef            string
+	diagOpenedAt       time.Time
+	diagRegisters      int
+	diagUnregisters    int
+	diagCapped         int
+	diagOracleSilenced int
 }
 
 // newConnectedClient starts the client's writer goroutine. The client must
@@ -243,11 +256,13 @@ type connectedClient struct {
 // stays alive for the life of the process.
 func newConnectedClient(peerId string, s rvStream) *connectedClient {
 	c := &connectedClient{
-		peerId: peerId,
-		stream: s,
-		rooms:  make(map[string]struct{}),
-		out:    make(chan []byte, sendQueueDepth),
-		done:   make(chan struct{}),
+		peerId:       peerId,
+		stream:       s,
+		rooms:        make(map[string]struct{}),
+		out:          make(chan []byte, sendQueueDepth),
+		done:         make(chan struct{}),
+		diagRef:      fmt.Sprintf("s%x", time.Now().UnixNano()),
+		diagOpenedAt: time.Now(),
 	}
 	go c.writeLoop()
 	return c
@@ -583,6 +598,7 @@ func (r *registry) sendTo(c *connectedClient, msg serverMsg) {
 		// will not complete, which is how one dead tab stalled a whole room.
 		// It has missed frames either way, so it has to reconnect to resync.
 		log.Printf("[rv] %s is not reading its stream, dropping it", short(c.peerId))
+		diagRecord(c.peerId, relayDiagEvent{Kind: "rv.close", D: map[string]any{"reason": relayCloseOutboxFull}})
 		c.shutdown()
 	}
 }
@@ -664,6 +680,7 @@ func (r *registry) sendPeers(c *connectedClient, room string, others []string) {
 // already indistinguishable from success to the client.
 func (r *registry) register(c *connectedClient, room string) registerOutcome {
 	r.mu.Lock()
+	c.diagRegisters++
 
 	// A stream the registry has already let go of - its read loop ended, or the
 	// peer's last connection dropped and the libp2p backup cleaned up after it -
@@ -687,20 +704,24 @@ func (r *registry) register(c *connectedClient, room string) registerOutcome {
 		others := peersExcept(r.rooms[room], c.peerId)
 		r.mu.Unlock()
 		r.sendPeers(c, room, others)
+		diagRecord(c.peerId, relayDiagEvent{Kind: "rv.register", Room: diagRoomRef(room)})
 		return registerJoined
 	}
 	if r.total >= maxTotalRegistrations {
 		sayCapped := !r.totalCapLogged
 		r.totalCapLogged = true
+		c.diagCapped++
 		r.mu.Unlock()
 		if sayCapped {
 			log.Printf("[rv] registry is at its %d-registration ceiling, ignoring further REGISTERs", maxTotalRegistrations)
 		}
+		diagRecord(c.peerId, relayDiagEvent{Kind: "rv.register", Room: diagRoomRef(room), D: map[string]any{"refused": "capped"}})
 		return registerCapped
 	}
 	if r.roomsHeldByPeer(c.peerId) >= maxRoomsPerPeer {
 		sayCapped := !c.roomCapLogged
 		c.roomCapLogged = true
+		c.diagCapped++
 		r.mu.Unlock()
 		// Every line the registry writes is emitted with the lock released.
 		// log.Printf takes its own mutex and then writes to stderr
@@ -710,6 +731,7 @@ func (r *registry) register(c *connectedClient, room string) registerOutcome {
 		if sayCapped {
 			log.Printf("[rv] %s hit the %d-room cap, ignoring further REGISTERs", short(c.peerId), maxRoomsPerPeer)
 		}
+		diagRecord(c.peerId, relayDiagEvent{Kind: "rv.register", Room: diagRoomRef(room), D: map[string]any{"refused": "capped"}})
 		return registerCapped
 	}
 
@@ -721,7 +743,9 @@ func (r *registry) register(c *connectedClient, room string) registerOutcome {
 	// code guesser is fishing for, so only THAT case spends the budget; a
 	// REGISTER into a room that already has somebody else in it is free.
 	if len(members) == 0 && !c.emptyRegisters.allow(time.Now()) {
+		c.diagOracleSilenced++
 		r.mu.Unlock()
+		diagRecord(c.peerId, relayDiagEvent{Kind: "rv.register", Room: diagRoomRef(room), D: map[string]any{"refused": "oracle"}})
 		return registerOracleSilenced
 	}
 	if members == nil {
@@ -771,6 +795,7 @@ func (r *registry) register(c *connectedClient, room string) registerOutcome {
 	// it is the frame that answers the REGISTER, and queuing it behind a
 	// broadcast to everyone else only delays the join for no reason.
 	r.sendPeers(c, room, others)
+	diagRecord(c.peerId, relayDiagEvent{Kind: "rv.register", Room: diagRoomRef(room)})
 	if !announce {
 		return registerJoined
 	}
@@ -786,6 +811,7 @@ func (r *registry) register(c *connectedClient, room string) registerOutcome {
 
 func (r *registry) unregister(c *connectedClient, room string) {
 	r.mu.Lock()
+	c.diagUnregisters++
 	// Same guard as register: a stream the registry has let go of no longer
 	// speaks for anyone.
 	if !r.isLive(c) {
@@ -796,6 +822,7 @@ func (r *registry) unregister(c *connectedClient, room string) {
 	r.mu.Unlock()
 
 	line.emit()
+	diagRecord(c.peerId, relayDiagEvent{Kind: "rv.unregister", Room: diagRoomRef(room)})
 
 	// Send notifications outside the lock
 	for _, tc := range targets {
@@ -966,6 +993,14 @@ func (r *registry) disconnectPeer(peerId string) {
 		l.emit()
 	}
 	lifecycleLogf("[rv] %s disconnected", short(peerId))
+	// One rv.close per evicted stream, plus one peer.disconnect for the
+	// libp2p-level event itself: this is the ONE case where a stream's
+	// rooms are torn down before its own readLoop had a chance to notice
+	// and record its own close reason - "evicted" names exactly that.
+	for range doomed {
+		diagRecord(peerId, relayDiagEvent{Kind: "rv.close", D: map[string]any{"reason": relayCloseEvicted}})
+	}
+	diagRecord(peerId, relayDiagEvent{Kind: "peer.disconnect"})
 
 	// Stop the writer goroutines, otherwise they outlive the session for as
 	// long as the process runs.
@@ -999,6 +1034,7 @@ type rvReadStream interface {
 func (r *registry) handleStream(s network.Stream) {
 	peerId := s.Conn().RemotePeer().String()
 	lifecycleLogf("[rv] %s opened rendezvous stream", short(peerId))
+	diagRecord(peerId, relayDiagEvent{Kind: "rv.open"})
 
 	// Every stream stands on its own; an earlier stream from the same peerId is
 	// left alone. Two tabs of the app share a peerId (the libp2p key lives in
@@ -1010,17 +1046,18 @@ func (r *registry) handleStream(s network.Stream) {
 	c := r.addStream(peerId, s)
 	if c == nil {
 		lifecycleLogf("[rv] %s already holds %d rendezvous streams, refusing another", short(peerId), maxStreamsPerPeer)
+		diagRecord(peerId, relayDiagEvent{Kind: "rv.close", D: map[string]any{"reason": relayCloseStreamCap}})
 		s.Reset()
 		return
 	}
 
-	r.readLoop(s, peerId, c)
+	reason := r.readLoop(s, peerId, c)
 
 	// The count matters now that a peerId can hold several streams: "stream
 	// closed" alone no longer means the peer is gone. removeClient is also
 	// what tears the stream down (via c.shutdown) - the idle-timeout case
 	// above ends up here exactly like any other read error.
-	lifecycleLogf("[rv] %s stream closed (%d still open)", short(peerId), r.removeClient(c))
+	lifecycleLogf("[rv] %s stream closed (%d still open, reason=%s)", short(peerId), r.removeClient(c), reason)
 }
 
 // readLoop reassembles length-prefixed frames from a rendezvous stream and
@@ -1028,7 +1065,7 @@ func (r *registry) handleStream(s network.Stream) {
 // timeout, see rendezvousIdleTimeout and rendezvousLivenessTimeout. Split
 // out of handleStream so a fake satisfying only rvReadStream can exercise
 // it in tests.
-func (r *registry) readLoop(s rvReadStream, peerId string, c *connectedClient) {
+func (r *registry) readLoop(s rvReadStream, peerId string, c *connectedClient) string {
 	// Read loop - reassemble length-prefixed frames
 	buf := make([]byte, 0, 512)
 	tmp := make([]byte, 4096)
@@ -1051,6 +1088,10 @@ func (r *registry) readLoop(s rvReadStream, peerId string, c *connectedClient) {
 	// Set once the stream has registered a room; from then on it gets
 	// rendezvousLivenessTimeout instead of rendezvousIdleTimeout.
 	registered := false
+	// The reason this loop eventually exits with, recorded once below as one
+	// rv.close event - see readLoopCloseReason (telemetry.go) and
+	// relayCloseGraceful and its siblings for the vocabulary.
+	reason := relayCloseGraceful
 
 readLoop:
 	for {
@@ -1065,6 +1106,7 @@ readLoop:
 		}
 		n, err := s.Read(tmp)
 		if err != nil {
+			reason = readLoopCloseReason(err, registered)
 			break
 		}
 		buf = append(buf, tmp[:n]...)
@@ -1076,7 +1118,9 @@ readLoop:
 			// buf and re-trip on every subsequent read while buf grows unbounded.
 			if msgLen > maxMsgLen {
 				warn("[rv] message too large from %s: %d bytes, closing stream", short(peerId), msgLen)
+				diagRecord(peerId, relayDiagEvent{Kind: "rv.frame.oversize", D: map[string]any{"bytes": msgLen}})
 				s.Reset()
+				reason = relayCloseFrameOversize
 				break readLoop
 			}
 			if len(buf) < 4+msgLen {
@@ -1088,12 +1132,14 @@ readLoop:
 			var msg clientMsg
 			if err := json.Unmarshal(payload, &msg); err != nil {
 				warn("[rv] bad message from %s: %v", short(peerId), err)
+				diagRecord(peerId, relayDiagEvent{Kind: "rv.send.fail", D: map[string]any{"reason": "malformed"}})
 				continue
 			}
 
 			if msg.Type == "REGISTER" || msg.Type == "UNREGISTER" {
 				if !validRoom(msg.Room) {
 					warn("[rv] %s sent an unusable room id (%d bytes), ignoring", short(peerId), len(msg.Room))
+					diagRecord(peerId, relayDiagEvent{Kind: "rv.send.fail", D: map[string]any{"reason": "bad-room"}})
 					if msg.Type == "REGISTER" {
 						r.sendTo(c, serverMsg{Type: "REGISTER_FAILED", Room: msg.Room})
 					}
@@ -1112,6 +1158,7 @@ readLoop:
 				// registers each room once per connection.
 				if !membershipOps.allow(time.Now()) {
 					warn("[rv] %s is changing rooms faster than %d/%s, ignoring", short(peerId), maxMembershipOps, membershipOpWindow)
+					diagRecord(peerId, relayDiagEvent{Kind: "rv.send.fail", Room: diagRoomRef(msg.Room), D: map[string]any{"reason": "rate-limited"}})
 					if msg.Type == "REGISTER" {
 						r.sendTo(c, serverMsg{Type: "REGISTER_FAILED", Room: msg.Room})
 					}
@@ -1146,9 +1193,13 @@ readLoop:
 				// finding 5).
 			default:
 				warn("[rv] unknown type from %s: %s", short(peerId), logSafe(msg.Type))
+				diagRecord(peerId, relayDiagEvent{Kind: "rv.send.fail", D: map[string]any{"reason": "unknown-type"}})
 			}
 		}
 	}
+
+	diagRecord(peerId, relayDiagEvent{Kind: "rv.close", D: map[string]any{"reason": reason}})
+	return reason
 }
 
 // Connection ceiling for the whole relay. The low mark is where the connection
@@ -1310,6 +1361,7 @@ func main() {
 
 	reg := newRegistry()
 	h.SetStreamHandler(RendezvousProtocol, reg.handleStream)
+	relaySelfPeerId = h.ID().String()
 
 	// HTTP server for OG and Klipy endpoints (run on separate internal port)
 	apiPort := "8081"
@@ -1328,6 +1380,10 @@ func main() {
 		mux.HandleFunc("/mailbox/collect", handleMailboxCollect)
 		mux.HandleFunc("/mailbox/ack", handleMailboxAck)
 		startMailboxSweeper()
+		mux.HandleFunc("/telemetry", postOnly(handleTelemetryIngest(reg)))
+		mux.HandleFunc("/telemetry/list", handleTelemetryList)
+		mux.HandleFunc("/telemetry/get", handleTelemetryGet)
+		startTelemetrySweeper()
 		log.Printf("[http] Starting API server on port %s", apiPort)
 		server := &http.Server{
 			Addr:              ":" + apiPort,

--- a/relay/telemetry.go
+++ b/relay/telemetry.go
@@ -1,0 +1,901 @@
+package main
+
+// Relay-side diagnostic vantage: an OPT-IN, per-peer ring of structured
+// events plus an HTTP surface to receive a client's own bundle and read it
+// back, with this relay's view stapled onto it. Wire schema mirrored in
+// frontend/src/lib/telemetry/schema.ts (DiagEvent, RelayVantage,
+// RelayCloseReason) - a change to an event's shape or to that reason
+// vocabulary must be made in both places, in the same commit.
+//
+// What the relay already knows about a peer (docs/spec.md "Server
+// Privacy") - its own peerId, dial/reservation outcomes, timings and error
+// codes - is exactly what this file may record and serve back. It must
+// NEVER learn or emit a room CODE (rooms travel as diagRoomRef, an HMAC
+// keyed by a boot-only secret - see telemetryBootSecret), a did:key, or
+// message/file content, none of which this relay ever sees in the first
+// place.
+//
+// Everything here is inert unless TELEMETRY_ENABLED=1: diagRecord no-ops,
+// and the HTTP endpoints answer 204/404 without doing any of the work
+// below. Every diagRecord call site in this package is OUTSIDE
+// registry.mu - TestRegistryNeverLogsUnderItsLock's reasoning for
+// log.Printf applies identically to a mutex-taking recorder: called under
+// the registry's single global lock, it would serialize every join and
+// leave in the process behind it.
+//
+// POST /telemetry wire contract (frontend/src/lib/telemetry/upload.ts):
+// headers X-Awful-Peer (full peerId), X-Awful-Ts (unix ms, decimal
+// string), X-Awful-Sig (base64 Ed25519 signature); body is the bundle JSON
+// verbatim. The signed content is exactly
+// "awful-telemetry:" + <X-Awful-Ts verbatim> + ":" + hex(sha256(body)).
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// relaySelfPeerId is this relay's own libp2p peerId, set once in main()
+// right after the host is built and never written again - every request
+// handler only reads it.
+var relaySelfPeerId string
+
+// telemetryEnabled gates the entire surface: with it unset, /telemetry
+// answers 204 and writes nothing, the admin routes 404, and diagRecord
+// never allocates a ring. A package var, not a const, read once at init
+// like every other operator flag here, but reassignable so tests can flip
+// it without an os.Setenv/re-init dance.
+var telemetryEnabled = os.Getenv("TELEMETRY_ENABLED") == "1"
+
+// telemetryAdminToken gates the two operator read routes. Empty means "not
+// configured", and those routes must then behave as if they do not exist
+// (404, not 401/403) so an unconfigured instance never advertises a console
+// nobody can reach.
+var telemetryAdminToken = os.Getenv("TELEMETRY_ADMIN_TOKEN")
+
+var telemetryDir = func() string {
+	if d := os.Getenv("TELEMETRY_DIR"); d != "" {
+		return d
+	}
+	return "/app/data/telemetry"
+}()
+
+// telemetryBootSecret keys diagRoomRef's HMAC. Generated fresh every start
+// and NEVER written to disk: a room ref must not be invertible back to a
+// room code after the process exits, which persisting this secret would
+// undo. A package var (not const) so a test can swap it to prove two boot
+// secrets yield different refs for the same room code.
+var telemetryBootSecret = func() []byte {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failing is a fatal platform problem elsewhere too
+		// (loadOrGenKey has the same shape) - continuing with a zero
+		// secret would make every room ref computable offline by anyone,
+		// which is the one thing this secret exists to prevent.
+		log.Fatalf("[telemetry] crypto/rand: %v", err)
+	}
+	return b
+}()
+
+const (
+	// Events held per peer before the ring wraps and starts overwriting the
+	// oldest. 256 is a small fraction of the frontend's 4096-event ring
+	// (RING_CAPACITY, frontend/src/lib/telemetry/ring.ts): the relay only
+	// ever sees its OWN rendezvous protocol events for one peer, not the
+	// whole app-layer traffic a client vantage covers, so far fewer events
+	// carry the same useful window.
+	telemetryRingCapacity = 256
+	// Distinct peers the relay will hold a ring for at once. Unlike the
+	// registry's own maxTotalRegistrations, nothing else bounds this map's
+	// growth - a peer only needs to open and close one rendezvous stream to
+	// earn an entry, no REGISTER required - so it needs its own ceiling.
+	// Evicting the oldest-touched peer first (evictOldestPeerLocked) means a
+	// quiet peer's ring is what pays for a new arrival once the relay is
+	// this busy, not a peer still connected.
+	telemetryMaxTrackedPeers = 4096
+	// Signed-timestamp freshness window for a /telemetry upload, the same
+	// shape and width as mailboxAuthSkew: wide enough to tolerate ordinary
+	// clock drift, narrow enough that a captured request cannot be replayed
+	// hours later.
+	telemetryAuthSkew = 2 * time.Minute
+	// One uploaded bundle, post-staple, is capped here. 2 MiB comfortably
+	// covers a trimmed ClientBundle (the client itself trims to ~1.8 MB
+	// before signing, frontend/src/lib/telemetry/upload.ts) plus this
+	// relay's own stapled view, with headroom for JSON overhead.
+	telemetryMaxBody = 2 << 20
+	// Bundles kept per peer before the OLDEST is evicted to make room for a
+	// new one. Unlike the global ceiling below, a peer's own quota is not a
+	// resource anyone else depends on, so there is nothing to protect by
+	// refusing a new upload instead - eviction, not refusal, is correct
+	// here.
+	telemetryMaxPerPeer = 8
+	// Hard ceilings on everything under telemetryDir combined, the same
+	// per-IP-is-not-enough reasoning as mailboxGlobalMaxBytes: many peers
+	// each staying under their own quota can still fill the shared data
+	// volume. Global overflow REFUSES (507) rather than evicting, because
+	// unlike a peer's own quota, the resource being protected here belongs
+	// to every OTHER peer's telemetry too.
+	telemetryGlobalMaxBytes = 128 << 20
+	telemetryGlobalMaxFiles = 4096
+	// Unclaimed bundles are diagnostic exhaust, not user data anyone is
+	// waiting on - a week is long enough to debug a bug report, short
+	// enough that "opted in once, forgot about it" does not accumulate
+	// disclosure forever.
+	telemetryTTL = 7 * 24 * time.Hour
+	// Uploads per client IP per minute. Lower than mailboxDepositLimit: a
+	// real client uploads at most a few times per session (an explicit
+	// export, or the periodic upload described in the plan), never at line
+	// rate, so this only has to be generous enough for manual retries.
+	telemetryRateLimit = 4
+	// Requests per client IP per minute against the two operator read
+	// routes. These are cheap directory listings and file reads gated by a
+	// bearer token, not a guessing oracle like the mailbox/invite budgets -
+	// this only has to stop a misbehaving dashboard from hammering the
+	// relay, not resist a blind attacker who has no token to try.
+	telemetryAdminLimit = 30
+)
+
+// relayCloseGraceful and friends are exactly RelayCloseReason in
+// frontend/src/lib/telemetry/schema.ts - see that type's doc comment. Named
+// constants here so every call site spells a reason identically; a typo in
+// a raw string would silently split one reason into two on the wire.
+const (
+	relayCloseGraceful        = "graceful"
+	relayCloseLivenessTimeout = "liveness-timeout"
+	relayCloseIdleTimeout     = "idle-timeout"
+	relayCloseReadError       = "read-error"
+	relayCloseFrameOversize   = "frame-oversize"
+	relayCloseOutboxFull      = "outbox-full"
+	relayCloseStreamCap       = "stream-cap"
+	relayClosePeerDisconnect  = "peer-disconnect"
+	relayCloseEvicted         = "evicted"
+)
+
+// telemetryPeerIDRe is the shape of a libp2p Ed25519 identity-multihash
+// peerId as base58btc: no leading zero, no 0/O/I/l. Every path this
+// package builds from a peerId - the on-disk directory and the admin `id`
+// query param - validates against this BEFORE the string ever touches
+// filepath.Join, per relay-audit.md's own path-traversal lesson.
+var telemetryPeerIDRe = regexp.MustCompile(`^[1-9A-HJ-NP-Za-km-z]{40,64}$`)
+
+// telemetryFileNameRe is the shape of a stored bundle's filename: hex
+// nanoseconds plus the .json this package always writes.
+var telemetryFileNameRe = regexp.MustCompile(`^[0-9a-f]+\.json$`)
+
+// ── Per-peer event ring ──────────────────────────────────────────────────
+
+// relayDiagEvent is this relay's copy of DiagEvent
+// (frontend/src/lib/telemetry/schema.ts). It must marshal to that FULL
+// shape, not a subset: the dashboard merges relay events into the same
+// timeline as client events and reads every field.
+type relayDiagEvent struct {
+	// 1-based within this PEER's ring (not the process), so a gap - the
+	// ring wrapped, or a peer was evicted and its ring restarted at 1 - is
+	// visible on the wire exactly like a client event's own seq gap.
+	Seq int `json:"seq"`
+	// Absolute unix milliseconds. This is the one place relayDiagEvent
+	// diverges from a CLIENT event's `t`, which is relative to that
+	// session's own startedAt - the dashboard treats a relay event's `t` as
+	// already absolute and must not try to rebase it.
+	T int64 `json:"t"`
+	// A DiagKind literal - see the call sites in main.go for which ones
+	// this relay actually emits.
+	Kind string `json:"kind"`
+	// "debug" | "info" | "warn" | "error" - see diagSeverityFor.
+	Sev string `json:"sev"`
+	// The peerId this event is about. Never nil for a relay event: every
+	// ring here is keyed by, and every event in it is about, one peer.
+	Peer *string `json:"peer"`
+	// diagRoomRef output, or "" when the event has no room context. NEVER
+	// a raw room code.
+	Room string `json:"room"`
+	// JSON primitives only, <=12 keys - the same bound event.ts enforces
+	// client-side (frontend/src/lib/telemetry/event.ts). Every call site in
+	// this package respects it by construction: none builds more than a
+	// couple of keys.
+	D map[string]any `json:"d,omitempty"`
+}
+
+// peerDiag is one peer's diagnostic ring: a pre-allocated array plus a head
+// index, exactly the frontend's DiagRing (ring.ts) - wraparound overwrites
+// the oldest event and increments dropped rather than growing or shifting.
+type peerDiag struct {
+	mu        sync.Mutex
+	events    []relayDiagEvent
+	head      int // next write index
+	filled    int // valid slots, <= len(events)
+	dropped   int // evicted by wraparound
+	nextSeq   int // never resets while this peer's entry lives
+	lastTouch time.Time
+}
+
+func (pd *peerDiag) push(e relayDiagEvent) {
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	pd.nextSeq++
+	e.Seq = pd.nextSeq
+	if pd.filled >= len(pd.events) {
+		pd.dropped++
+	} else {
+		pd.filled++
+	}
+	pd.events[pd.head] = e
+	pd.head = (pd.head + 1) % len(pd.events)
+}
+
+// snapshot returns every live event, oldest first, and the dropped count.
+func (pd *peerDiag) snapshot() ([]relayDiagEvent, int) {
+	pd.mu.Lock()
+	defer pd.mu.Unlock()
+	out := make([]relayDiagEvent, pd.filled)
+	if pd.filled < len(pd.events) {
+		copy(out, pd.events[:pd.filled])
+	} else {
+		n := copy(out, pd.events[pd.head:])
+		copy(out[n:], pd.events[:pd.head])
+	}
+	return out, pd.dropped
+}
+
+// diagPeers is the process-wide table of per-peer rings. A plain map under
+// one mutex, not sync.Map: telemetryMaxTrackedPeers has to be checked
+// atomically with the insert, the same reason pluginproxy's rate limiter
+// and mailboxMu are not sync.Map either.
+var (
+	diagMu    sync.Mutex
+	diagPeers = map[string]*peerDiag{}
+)
+
+// diagSeverityFor is diagRecord's default severity per kind, matching the
+// classes KIND_SEV (frontend/src/lib/telemetry/schema.ts) draws for every
+// kind this relay actually emits: a *.fail/*.timeout/*.oversize/*.drop kind
+// is "error", rv.close and peer.disconnect are "warn", everything else -
+// rv.open, rv.register, rv.unregister here - is "info".
+func diagSeverityFor(kind string) string {
+	switch {
+	case strings.HasSuffix(kind, ".fail"),
+		strings.HasSuffix(kind, ".timeout"),
+		strings.HasSuffix(kind, ".oversize"),
+		strings.HasSuffix(kind, ".drop"):
+		return "error"
+	case kind == "rv.close", kind == "peer.disconnect":
+		return "warn"
+	default:
+		return "info"
+	}
+}
+
+// evictOldestPeerLocked drops the least-recently-touched peer's ring.
+// Caller holds diagMu. An O(n) scan over at most telemetryMaxTrackedPeers
+// entries is cheap next to letting the map grow without bound, and this
+// only runs once the table is already at its ceiling.
+func evictOldestPeerLocked() {
+	var oldestId string
+	var oldestAt time.Time
+	found := false
+	for id, pd := range diagPeers {
+		if !found || pd.lastTouch.Before(oldestAt) {
+			oldestId, oldestAt, found = id, pd.lastTouch, true
+		}
+	}
+	if found {
+		delete(diagPeers, oldestId)
+	}
+}
+
+// diagRecord appends one event to peerId's ring, filling in Seq/T/Sev/Peer -
+// callers set only Kind, Room and D. A no-op unless TELEMETRY_ENABLED, and
+// never called while registry.mu is held (see this file's header comment).
+func diagRecord(peerId string, e relayDiagEvent) {
+	if !telemetryEnabled {
+		return
+	}
+	now := time.Now()
+	e.T = now.UnixMilli()
+	e.Sev = diagSeverityFor(e.Kind)
+	e.Peer = &peerId
+
+	diagMu.Lock()
+	pd, ok := diagPeers[peerId]
+	if !ok {
+		if len(diagPeers) >= telemetryMaxTrackedPeers {
+			evictOldestPeerLocked()
+		}
+		pd = &peerDiag{events: make([]relayDiagEvent, telemetryRingCapacity)}
+		diagPeers[peerId] = pd
+	}
+	pd.lastTouch = now
+	diagMu.Unlock()
+
+	pd.push(e)
+}
+
+// diagSnapshot returns peerId's events (oldest first) and its dropped
+// count. A peer nothing has ever recorded for gets an empty slice, not
+// nil, so relayViewFor's JSON always carries `events: []`, never
+// `events: null`.
+func diagSnapshot(peerId string) ([]relayDiagEvent, int) {
+	diagMu.Lock()
+	pd, ok := diagPeers[peerId]
+	diagMu.Unlock()
+	if !ok {
+		return []relayDiagEvent{}, 0
+	}
+	return pd.snapshot()
+}
+
+// diagRoomRef is the room ref a relay-vantage event or RelayVantage.rooms
+// entry carries: never the room code itself, only an HMAC of it keyed by
+// this process's own boot secret. Stable for the life of one process (two
+// uploads see the same ref for the same room) and un-invertible once the
+// process exits, because the secret was never written anywhere.
+func diagRoomRef(roomCode string) string {
+	if roomCode == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, telemetryBootSecret)
+	mac.Write([]byte(roomCode))
+	return "h:" + hex.EncodeToString(mac.Sum(nil))[:12]
+}
+
+// readLoopCloseReason classifies why readLoop's s.Read returned err, so a
+// liveness timeout, an idle timeout, a graceful EOF and a genuine read
+// error are told apart. Today they all exit readLoop through the same
+// "stream closed" log line - see handleStream - which is the difference
+// between "a peer left" and "a peer wedged".
+func readLoopCloseReason(err error, registered bool) string {
+	if errors.Is(err, io.EOF) {
+		return relayCloseGraceful
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		if registered {
+			return relayCloseLivenessTimeout
+		}
+		return relayCloseIdleTimeout
+	}
+	return relayCloseReadError
+}
+
+// ── Relay vantage: what gets stapled onto an uploaded bundle ────────────
+
+// relayVantage mirrors RelayVantage in
+// frontend/src/lib/telemetry/schema.ts. Field names must match exactly -
+// json.Marshal uses the tags below, not the Go names.
+type relayVantage struct {
+	Vantage        string               `json:"vantage"` // always "relay"
+	RelayPeerId    string               `json:"relayPeerId"`
+	ObservedPeerId string               `json:"observedPeerId"`
+	Registry       relayVantageRegistry `json:"registry"`
+	Rooms          []relayVantageRoom   `json:"rooms"`
+	Streams        []relayVantageStream `json:"streams"`
+	Events         []relayDiagEvent     `json:"events"`
+}
+
+type relayVantageRegistry struct {
+	TotalRegistrations int  `json:"totalRegistrations"`
+	StreamsForPeer     int  `json:"streamsForPeer"`
+	AtTotalCap         bool `json:"atTotalCap"`
+}
+
+type relayVantageRoom struct {
+	Ref     string   `json:"ref"`
+	Size    int      `json:"size"`
+	Members []string `json:"members"`
+}
+
+type relayVantageStream struct {
+	Ref            string  `json:"ref"`
+	OpenedAt       int64   `json:"openedAt"`
+	ClosedAt       *int64  `json:"closedAt"`
+	CloseReason    *string `json:"closeReason"`
+	Rooms          int     `json:"rooms"`
+	Registers      int     `json:"registers"`
+	Unregisters    int     `json:"unregisters"`
+	Capped         int     `json:"capped"`
+	OracleSilenced int     `json:"oracleSilenced"`
+}
+
+// relayViewFor builds the RelayVantage this relay staples onto peerId's
+// uploaded bundle: the registry state relevant to that ONE peer (never
+// another peer's unrelated rooms), plus its diagnostic ring. Scoped to
+// rooms peerId itself currently holds a stream in, and to that peer's own
+// currently-live streams - a stream already closed by the time of upload
+// carries no entry here, but its close is still visible in Events via the
+// rv.close this package recorded when it happened.
+func relayViewFor(reg *registry, peerId string) relayVantage {
+	reg.mu.Lock()
+	total := reg.total
+	atCap := reg.total >= maxTotalRegistrations
+	streams := reg.clients[peerId]
+	streamsForPeer := len(streams)
+
+	roomSet := make(map[string]struct{}, streamsForPeer)
+	for c := range streams {
+		for room := range c.rooms {
+			roomSet[room] = struct{}{}
+		}
+	}
+	rooms := make([]relayVantageRoom, 0, len(roomSet))
+	for room := range roomSet {
+		members := reg.rooms[room]
+		rooms = append(rooms, relayVantageRoom{
+			Ref:     diagRoomRef(room),
+			Size:    distinctPeers(members),
+			Members: peersExcept(members, ""), // "" excludes nobody: every member is reported
+		})
+	}
+
+	streamViews := make([]relayVantageStream, 0, streamsForPeer)
+	for c := range streams {
+		streamViews = append(streamViews, relayVantageStream{
+			Ref:            c.diagRef,
+			OpenedAt:       c.diagOpenedAt.UnixMilli(),
+			ClosedAt:       nil,
+			CloseReason:    nil,
+			Rooms:          len(c.rooms),
+			Registers:      c.diagRegisters,
+			Unregisters:    c.diagUnregisters,
+			Capped:         c.diagCapped,
+			OracleSilenced: c.diagOracleSilenced,
+		})
+	}
+	reg.mu.Unlock()
+
+	events, _ := diagSnapshot(peerId)
+
+	return relayVantage{
+		Vantage:        "relay",
+		RelayPeerId:    relaySelfPeerId,
+		ObservedPeerId: peerId,
+		Registry: relayVantageRegistry{
+			TotalRegistrations: total,
+			StreamsForPeer:     streamsForPeer,
+			AtTotalCap:         atCap,
+		},
+		Rooms:   rooms,
+		Streams: streamViews,
+		Events:  events,
+	}
+}
+
+// stapleRelayView adds a "relayView" key to bundle, an uploaded
+// ClientBundle's raw JSON object, without needing this package to model
+// ClientBundle's full shape - it only ever needs to add one key next to
+// whatever the client sent.
+func stapleRelayView(bundle []byte, view relayVantage) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(bundle, &obj); err != nil {
+		return nil, fmt.Errorf("bundle is not a JSON object: %w", err)
+	}
+	viewBytes, err := json.Marshal(view)
+	if err != nil {
+		return nil, err
+	}
+	obj["relayView"] = viewBytes
+	return json.Marshal(obj)
+}
+
+// ── Auth ──────────────────────────────────────────────────────────────────
+
+// verifyTelemetryAuth proves the uploader owns peerId, without ever
+// learning a did:key.
+//
+// An Ed25519 libp2p peerId is an identity multihash: the public key is
+// INSIDE it (peer.ID.ExtractPublicKey). So a signature that verifies
+// against the key extracted from the CLAIMED peerId proves the uploader
+// holds that peerId's private key - and the relay already knows every
+// peerId it has seen, from the rendezvous protocol alone. Signing with the
+// identity key instead would hand this endpoint a did:key -> peerId
+// binding it must never learn (docs/spec.md "Server Privacy"); if a peerId
+// ever fails to yield a key this way, the upload is rejected outright,
+// never re-tried against some other key.
+//
+// tsMs is X-Awful-Ts parsed to an int64 (freshness check); tsStr is that
+// SAME header's raw string, reused verbatim in the signed message - the
+// client signs the string it sends, not a round-tripped reformatting of it.
+func verifyTelemetryAuth(peerIdStr string, tsMs int64, tsStr, sigB64, bodySha256Hex string) error {
+	if d := time.Since(time.UnixMilli(tsMs)); d > telemetryAuthSkew || d < -telemetryAuthSkew {
+		return fmt.Errorf("stale timestamp")
+	}
+	pid, err := peer.Decode(peerIdStr)
+	if err != nil {
+		return fmt.Errorf("bad peer id: %w", err)
+	}
+	pub, err := pid.ExtractPublicKey()
+	if err != nil {
+		return fmt.Errorf("peer id does not embed a public key: %w", err)
+	}
+	raw, err := pub.Raw()
+	if err != nil {
+		return fmt.Errorf("bad public key: %w", err)
+	}
+	// Same subgroup check as verifyMailboxAuth (mailbox.go) and for the
+	// identical reason: Go's crypto/ed25519 verifies a signature against a
+	// small-order key even without the matching private key, so a peerId
+	// naming a torsion point would authenticate for anybody.
+	if isSmallOrderPubKey(raw) {
+		return fmt.Errorf("small-order public key")
+	}
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		return fmt.Errorf("bad signature encoding: %w", err)
+	}
+	// "awful-telemetry:", not "awful-mailbox:" - the domain-separation
+	// prefix verifyMailboxAuth (mailbox.go) uses. Reusing that prefix would
+	// make one signature valid on both surfaces.
+	msg := []byte("awful-telemetry:" + tsStr + ":" + bodySha256Hex)
+	ok, err := pub.Verify(msg, sig)
+	if err != nil || !ok {
+		return fmt.Errorf("bad signature")
+	}
+	return nil
+}
+
+// ── POST /telemetry ingest ───────────────────────────────────────────────
+
+// handleTelemetryIngest returns the /telemetry handler bound to reg, so it
+// stays testable with a fresh registry per test rather than the process's
+// single global one. Order is fixed and matters, mirroring
+// handleTurnCredentials (turn.go): Origin, then rate budget, then whether
+// telemetry is even turned on, then the body bound, then auth - so even the
+// 204 "not set up" path is metered.
+func handleTelemetryIngest(reg *registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isAllowedOrigin(r.Header.Get("Origin")) {
+			apiError(w, r, "Origin not allowed", http.StatusForbidden)
+			return
+		}
+		if !rateAllow("tm:"+clientIP(r), telemetryRateLimit) {
+			apiError(w, r, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		if !telemetryEnabled {
+			// "Not set up" - the /plugin-proxy and /turn-credentials
+			// convention: 204 rather than 404, so the client keeps quietly
+			// not uploading until an operator opts in.
+			withCors(w, r, func(w http.ResponseWriter) { w.WriteHeader(http.StatusNoContent) })
+			return
+		}
+
+		peerId := r.Header.Get("X-Awful-Peer")
+		tsStr := r.Header.Get("X-Awful-Ts")
+		sig := r.Header.Get("X-Awful-Sig")
+		if !telemetryPeerIDRe.MatchString(peerId) || tsStr == "" || sig == "" {
+			apiError(w, r, "bad request", http.StatusBadRequest)
+			return
+		}
+		tsMs, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil {
+			apiError(w, r, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, telemetryMaxBody))
+		if err != nil {
+			apiError(w, r, "body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		sum := sha256.Sum256(body)
+		if err := verifyTelemetryAuth(peerId, tsMs, tsStr, sig, hex.EncodeToString(sum[:])); err != nil {
+			apiError(w, r, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		full, err := stapleRelayView(body, relayViewFor(reg, peerId))
+		if err != nil {
+			apiError(w, r, "bad request", http.StatusBadRequest)
+			return
+		}
+		bundleId, status, err := storeTelemetryBundle(peerId, full)
+		if err != nil {
+			apiError(w, r, err.Error(), status)
+			return
+		}
+
+		withCors(w, r, func(w http.ResponseWriter) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"bundleId": bundleId})
+		})
+	}
+}
+
+// ── Storage ───────────────────────────────────────────────────────────────
+
+// telemetryUsedBytes/telemetryFiles track the global quota incrementally,
+// the same mailboxUsedBytes/mailboxFiles scheme mailbox.go uses and for the
+// identical reason: a full-tree walk per upload does not scale. One walk at
+// startup (telemetryInitUsedBytes), then storeTelemetryBundle and the
+// sweeper adjust them at every write and removal. Guarded by telemetryMu.
+var (
+	telemetryMu        sync.Mutex
+	telemetryUsedBytes int64
+	telemetryFiles     int
+)
+
+func telemetryInitUsedBytes() {
+	telemetryMu.Lock()
+	defer telemetryMu.Unlock()
+	telemetryUsedBytes = 0
+	telemetryFiles = 0
+	peers, _ := os.ReadDir(telemetryDir)
+	for _, p := range peers {
+		if !p.IsDir() {
+			continue
+		}
+		entries, _ := os.ReadDir(filepath.Join(telemetryDir, p.Name()))
+		for _, e := range entries {
+			if info, err := e.Info(); err == nil {
+				telemetryUsedBytes += info.Size()
+				telemetryFiles++
+			}
+		}
+	}
+}
+
+// storeTelemetryBundle writes one already-stapled bundle to
+// <telemetryDir>/<peerId>/<id>.json and returns its bundleId
+// ("<peerId>/<id>.json", directly usable as the admin `id` query param).
+// Global overflow REFUSES (507); a peer over its own per-peer quota instead
+// EVICTS its oldest upload - see telemetryMaxPerPeer and
+// telemetryGlobalMaxBytes above.
+func storeTelemetryBundle(peerId string, full []byte) (bundleId string, status int, err error) {
+	size := int64(len(full))
+
+	telemetryMu.Lock()
+	defer telemetryMu.Unlock()
+
+	if telemetryUsedBytes+size > telemetryGlobalMaxBytes || telemetryFiles >= telemetryGlobalMaxFiles {
+		return "", http.StatusInsufficientStorage, fmt.Errorf("telemetry store full")
+	}
+
+	dir := filepath.Join(telemetryDir, peerId)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", http.StatusInternalServerError, err
+	}
+
+	id := strconv.FormatInt(time.Now().UnixNano(), 16) + ".json"
+	if err := os.WriteFile(filepath.Join(dir, id), full, 0o600); err != nil {
+		return "", http.StatusInternalServerError, err
+	}
+	telemetryFiles++
+	telemetryUsedBytes += size
+
+	// Per-peer eviction: oldest first. Hex-nanosecond filenames sort
+	// chronologically as plain strings, the same trick mailbox.go's own
+	// deposit path relies on for its tie-break.
+	entries, _ := os.ReadDir(dir)
+	var files []os.DirEntry
+	for _, e := range entries {
+		if telemetryFileNameRe.MatchString(e.Name()) {
+			files = append(files, e)
+		}
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
+	for len(files) > telemetryMaxPerPeer {
+		oldest := files[0]
+		files = files[1:]
+		info, err := oldest.Info()
+		if err != nil {
+			continue
+		}
+		if os.Remove(filepath.Join(dir, oldest.Name())) == nil {
+			telemetryFiles--
+			telemetryUsedBytes -= info.Size()
+		}
+	}
+
+	return peerId + "/" + id, http.StatusOK, nil
+}
+
+// sweepTelemetryOnce removes bundles older than telemetryTTL and reports
+// how many it removed. Split from startTelemetrySweeper so a test can drive
+// one pass without waiting an hour.
+func sweepTelemetryOnce(now time.Time) int {
+	cutoff := now.Add(-telemetryTTL)
+
+	telemetryMu.Lock()
+	defer telemetryMu.Unlock()
+
+	removed := 0
+	peers, _ := os.ReadDir(telemetryDir)
+	for _, p := range peers {
+		if !p.IsDir() {
+			continue
+		}
+		dir := filepath.Join(telemetryDir, p.Name())
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			info, err := e.Info()
+			if err != nil || !info.ModTime().Before(cutoff) {
+				continue
+			}
+			if os.Remove(filepath.Join(dir, e.Name())) == nil {
+				telemetryUsedBytes -= info.Size()
+				telemetryFiles--
+				removed++
+			}
+		}
+		os.Remove(dir) // no-op unless now empty
+	}
+	return removed
+}
+
+// startTelemetrySweeper expires bundles past telemetryTTL. Runs hourly,
+// beside startMailboxSweeper - a restart changes nothing because the state
+// is plain files under the data volume.
+func startTelemetrySweeper() {
+	telemetryInitUsedBytes()
+	go func() {
+		for {
+			if removed := sweepTelemetryOnce(time.Now()); removed > 0 {
+				log.Printf("[telemetry] expired %d bundle(s)", removed)
+			}
+			time.Sleep(time.Hour)
+		}
+	}()
+}
+
+// ── Operator read routes ─────────────────────────────────────────────────
+
+// telemetryAdminCORS handles method gating and CORS for the two operator
+// endpoints. Unlike every other handler in this file, it does NOT call
+// isAllowedOrigin: a bearer token is real authentication, and
+// isAllowedOrigin returns true for an empty Origin by design (cors.go) - it
+// was never the abuse control here. Echoing the REQUEST's own Origin
+// (never "*", and never with credentials) is what lets an operator's
+// dashboard on http://localhost:5174 reach a production relay.
+func telemetryAdminCORS(w http.ResponseWriter, r *http.Request) bool {
+	if origin := r.Header.Get("Origin"); origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Vary", "Origin")
+	}
+	w.Header().Set("Access-Control-Allow-Headers", "authorization")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return false
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return false
+	}
+	return true
+}
+
+// checkTelemetryAdminAuth compares the bearer token in constant time, the
+// same reason every password/token check anywhere should.
+func checkTelemetryAdminAuth(r *http.Request) bool {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return false
+	}
+	token := strings.TrimPrefix(h, prefix)
+	return subtle.ConstantTimeCompare([]byte(token), []byte(telemetryAdminToken)) == 1
+}
+
+type telemetryBundleInfo struct {
+	ID        string `json:"id"`
+	PeerId    string `json:"peerId"`
+	Size      int64  `json:"size"`
+	CreatedAt int64  `json:"createdAt"`
+}
+
+// handleTelemetryList answers GET /telemetry/list -> {"bundles":[...]},
+// newest first, capped at 500.
+func handleTelemetryList(w http.ResponseWriter, r *http.Request) {
+	// Absent unless configured - a plain 404, before anything else runs,
+	// so an unconfigured instance looks exactly like one with no such
+	// route at all.
+	if telemetryAdminToken == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if !telemetryAdminCORS(w, r) {
+		return
+	}
+	if !rateAllow("tma:"+clientIP(r), telemetryAdminLimit) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+		return
+	}
+	if !checkTelemetryAdminAuth(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var out []telemetryBundleInfo
+	peers, _ := os.ReadDir(telemetryDir)
+	for _, p := range peers {
+		if !p.IsDir() {
+			continue
+		}
+		dir := filepath.Join(telemetryDir, p.Name())
+		entries, _ := os.ReadDir(dir)
+		for _, e := range entries {
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			out = append(out, telemetryBundleInfo{
+				ID:        p.Name() + "/" + e.Name(),
+				PeerId:    p.Name(),
+				Size:      info.Size(),
+				CreatedAt: info.ModTime().UnixMilli(),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt > out[j].CreatedAt })
+	if len(out) > 500 {
+		out = out[:500]
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"bundles": out})
+}
+
+// handleTelemetryGet answers GET /telemetry/get?id=<peerId>/<file> with the
+// stored bundle's raw JSON.
+func handleTelemetryGet(w http.ResponseWriter, r *http.Request) {
+	if telemetryAdminToken == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if !telemetryAdminCORS(w, r) {
+		return
+	}
+	if !rateAllow("tma:"+clientIP(r), telemetryAdminLimit) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+		return
+	}
+	if !checkTelemetryAdminAuth(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	id := r.URL.Query().Get("id")
+	peerId, file, ok := strings.Cut(id, "/")
+	if !ok || !telemetryPeerIDRe.MatchString(peerId) || !telemetryFileNameRe.MatchString(file) {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	// Belt and suspenders against traversal: the regexes above already
+	// guarantee peerId and file are each one plain path segment with no
+	// "..", but this confirms the resolved path really did stay under
+	// telemetryDir regardless of how that guarantee could ever be defeated.
+	root, err := filepath.Abs(telemetryDir)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	path, err := filepath.Abs(filepath.Join(telemetryDir, peerId, file))
+	if err != nil || !strings.HasPrefix(path, root+string(filepath.Separator)) {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}

--- a/relay/telemetry_test.go
+++ b/relay/telemetry_test.go
@@ -1,0 +1,685 @@
+package main
+
+// Tests for relay/telemetry.go. Mirrors the idioms in mailbox_test.go and
+// invite_test.go: telemetryDir = t.TempDir() as the first statement of
+// every storage test, counters saved and restored via t.Cleanup,
+// resetRateLimiter(t) first in every rate-limited test, and the handler
+// always called through its postOnly/getOnly-shaped wrapper.
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// testPeer generates a fresh Ed25519 libp2p identity, the shape every real
+// awful.chat peerId has (sync.svelte.ts pins the "12D3KooW" identity-hash
+// prefix for exactly this key type).
+func testPeer(t *testing.T) (peer.ID, ic.PrivKey) {
+	t.Helper()
+	priv, pub, err := ic.GenerateEd25519Key(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	id, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		t.Fatalf("peer id: %v", err)
+	}
+	return id, priv
+}
+
+// telemetrySign signs tsStr+body exactly the way
+// frontend/src/lib/telemetry/upload.ts does.
+func telemetrySign(t *testing.T, priv ic.PrivKey, tsStr string, body []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(body)
+	msg := []byte("awful-telemetry:" + tsStr + ":" + hex.EncodeToString(sum[:]))
+	sig, err := priv.Sign(msg)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+func telemetryRequest(peerId, tsStr, sig string, body []byte) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/telemetry", bytes.NewReader(body))
+	req.Header.Set("X-Awful-Peer", peerId)
+	req.Header.Set("X-Awful-Ts", tsStr)
+	req.Header.Set("X-Awful-Sig", sig)
+	req.RemoteAddr = "203.0.113.50:9000"
+	return req
+}
+
+// enableTelemetry flips TELEMETRY_ENABLED on for one test. telemetryDir is
+// deliberately NOT touched here - every caller sets it as ITS OWN first
+// statement, the mailboxDir convention.
+func enableTelemetry(t *testing.T) {
+	t.Helper()
+	orig := telemetryEnabled
+	telemetryEnabled = true
+	t.Cleanup(func() { telemetryEnabled = orig })
+}
+
+// assertLastCloseReason fails the test unless the most recent event
+// recorded for peerId is an rv.close carrying d.reason == want.
+func assertLastCloseReason(t *testing.T, peerId, want string) {
+	t.Helper()
+	events, _ := diagSnapshot(peerId)
+	if len(events) == 0 {
+		t.Fatalf("no diag events recorded for %s", peerId)
+	}
+	last := events[len(events)-1]
+	if last.Kind != "rv.close" {
+		t.Fatalf("last event kind = %q, want rv.close", last.Kind)
+	}
+	got, _ := last.D["reason"].(string)
+	if got != want {
+		t.Fatalf("rv.close reason = %q, want %q", got, want)
+	}
+	if last.Peer == nil || *last.Peer != peerId {
+		t.Fatalf("rv.close peer = %v, want %q", last.Peer, peerId)
+	}
+}
+
+// ── POST /telemetry ─────────────────────────────────────────────────────
+
+func TestTelemetryDisabledAnswersNoContentAndWritesNothing(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	orig := telemetryEnabled
+	telemetryEnabled = false
+	t.Cleanup(func() { telemetryEnabled = orig })
+
+	reg := newRegistry()
+	peerId, priv := testPeer(t)
+	body := []byte(`{"hello":"world"}`)
+	tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sig := telemetrySign(t, priv, tsStr, body)
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, telemetryRequest(peerId.String(), tsStr, sig, body))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("disabled telemetry: got %d, want 204", rec.Code)
+	}
+	entries, _ := os.ReadDir(telemetryDir)
+	if len(entries) != 0 {
+		t.Fatalf("disabled telemetry wrote %d entries under telemetryDir", len(entries))
+	}
+}
+
+func TestTelemetryIngestHappyPath(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+
+	reg := newRegistry()
+	peerId, priv := testPeer(t)
+	body := []byte(`{"hello":"world"}`)
+	tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sig := telemetrySign(t, priv, tsStr, body)
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, telemetryRequest(peerId.String(), tsStr, sig, body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("happy path: got %d, want 200, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		BundleId string `json:"bundleId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if resp.BundleId == "" {
+		t.Fatal("empty bundleId")
+	}
+	stored, err := os.ReadFile(filepath.Join(telemetryDir, resp.BundleId))
+	if err != nil {
+		t.Fatalf("stored bundle not found at %s: %v", resp.BundleId, err)
+	}
+	var staple map[string]any
+	if err := json.Unmarshal(stored, &staple); err != nil {
+		t.Fatalf("stored bundle is not JSON: %v", err)
+	}
+	if _, ok := staple["relayView"]; !ok {
+		t.Fatal("stored bundle is missing its stapled relayView")
+	}
+	if staple["hello"] != "world" {
+		t.Fatalf("stored bundle lost the client's own field: %+v", staple)
+	}
+}
+
+func TestTelemetryRejectsSignatureFromWrongKey(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+
+	reg := newRegistry()
+	peerId, _ := testPeer(t)
+	_, otherPriv := testPeer(t)
+	body := []byte(`{"a":1}`)
+	tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sig := telemetrySign(t, otherPriv, tsStr, body) // signed by a key OTHER than peerId's own
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, telemetryRequest(peerId.String(), tsStr, sig, body))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong-key signature: got %d, want 401", rec.Code)
+	}
+	entries, _ := os.ReadDir(telemetryDir)
+	if len(entries) != 0 {
+		t.Fatal("a rejected upload must not be stored")
+	}
+}
+
+func TestTelemetryRejectsStaleTimestamp(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+
+	reg := newRegistry()
+	peerId, priv := testPeer(t)
+	body := []byte(`{"a":1}`)
+	staleMs := time.Now().Add(-telemetryAuthSkew - time.Minute).UnixMilli()
+	tsStr := strconv.FormatInt(staleMs, 10)
+	sig := telemetrySign(t, priv, tsStr, body)
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, telemetryRequest(peerId.String(), tsStr, sig, body))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("stale timestamp: got %d, want 401", rec.Code)
+	}
+}
+
+// An RSA public key is too large to embed in its own peerId (go-libp2p
+// hashes it instead), so ExtractPublicKey fails - a peerId/key mismatch
+// distinct from "the signature does not verify".
+func TestTelemetryRejectsPeerIdWithoutEmbeddedKey(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+
+	reg := newRegistry()
+	priv, pub, err := ic.GenerateRSAKeyPair(2048, rand.Reader)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	rsaId, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		t.Fatalf("peer id: %v", err)
+	}
+	body := []byte(`{"a":1}`)
+	tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sig := telemetrySign(t, priv, tsStr, body)
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, telemetryRequest(rsaId.String(), tsStr, sig, body))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("peerId with no embedded key: got %d, want 401", rec.Code)
+	}
+}
+
+func TestTelemetryRejectsOversizeBody(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+
+	reg := newRegistry()
+	peerId, priv := testPeer(t)
+	body := make([]byte, telemetryMaxBody+1)
+	tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sig := telemetrySign(t, priv, tsStr, body)
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, telemetryRequest(peerId.String(), tsStr, sig, body))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize body: got %d, want 413", rec.Code)
+	}
+}
+
+// Disallowed Origin is refused before any of the work above.
+func TestTelemetryRejectsDisallowedOrigin(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+	origDomain, origStrict := domain, strictOrigin
+	domain, strictOrigin = "example.com", true
+	t.Cleanup(func() { domain, strictOrigin = origDomain, origStrict })
+
+	reg := newRegistry()
+	peerId, priv := testPeer(t)
+	body := []byte(`{"a":1}`)
+	tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+	sig := telemetrySign(t, priv, tsStr, body)
+	req := telemetryRequest(peerId.String(), tsStr, sig, body)
+	req.Header.Set("Origin", "https://evil.example")
+
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("disallowed Origin: got %d, want 403", rec.Code)
+	}
+}
+
+// Minting was unmetered for turn-credentials before RELAY-audit fixed it;
+// /telemetry gets the same shape of test.
+func TestTelemetryIngestRateLimited(t *testing.T) {
+	telemetryDir = t.TempDir()
+	resetRateLimiter(t)
+	enableTelemetry(t)
+
+	reg := newRegistry()
+	call := func() int {
+		peerId, priv := testPeer(t)
+		body := []byte(`{"a":1}`)
+		tsStr := strconv.FormatInt(time.Now().UnixMilli(), 10)
+		sig := telemetrySign(t, priv, tsStr, body)
+		req := telemetryRequest(peerId.String(), tsStr, sig, body)
+		req.RemoteAddr = "198.51.100.88:5000"
+		rec := httptest.NewRecorder()
+		postOnly(handleTelemetryIngest(reg))(rec, req)
+		return rec.Code
+	}
+	for i := 0; i < telemetryRateLimit; i++ {
+		if code := call(); code == http.StatusTooManyRequests {
+			t.Fatalf("request %d throttled inside the budget", i)
+		}
+	}
+	if code := call(); code != http.StatusTooManyRequests {
+		t.Fatalf("request over the budget got %d, want 429", code)
+	}
+}
+
+func TestTelemetryMethodGating(t *testing.T) {
+	reg := newRegistry()
+
+	req := httptest.NewRequest(http.MethodGet, "/telemetry", nil)
+	rec := httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /telemetry: want 405, got %d", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodOptions, "/telemetry", nil)
+	rec = httptest.NewRecorder()
+	postOnly(handleTelemetryIngest(reg))(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS /telemetry: want 204, got %d", rec.Code)
+	}
+}
+
+// ── Storage: eviction, global refusal, TTL sweep ────────────────────────
+
+func TestTelemetryPerPeerEvictionAtNineUploads(t *testing.T) {
+	telemetryDir = t.TempDir()
+	savedBytes, savedFiles := telemetryUsedBytes, telemetryFiles
+	t.Cleanup(func() { telemetryUsedBytes, telemetryFiles = savedBytes, savedFiles })
+	telemetryUsedBytes, telemetryFiles = 0, 0
+
+	const peerId = "peer-evict-test-0000000000000000000000000"
+	var ids []string
+	for i := 0; i < telemetryMaxPerPeer+1; i++ {
+		id, status, err := storeTelemetryBundle(peerId, []byte(fmt.Sprintf(`{"n":%d}`, i)))
+		if err != nil {
+			t.Fatalf("upload %d: %v (status %d)", i, err, status)
+		}
+		ids = append(ids, id)
+		time.Sleep(time.Millisecond) // hex-nanosecond filenames must not collide
+	}
+
+	entries, err := os.ReadDir(filepath.Join(telemetryDir, peerId))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != telemetryMaxPerPeer {
+		t.Fatalf("peer has %d stored bundles, want the cap of %d", len(entries), telemetryMaxPerPeer)
+	}
+	if _, err := os.Stat(filepath.Join(telemetryDir, ids[0])); !os.IsNotExist(err) {
+		t.Fatalf("oldest upload %s should have been evicted", ids[0])
+	}
+	if _, err := os.Stat(filepath.Join(telemetryDir, ids[len(ids)-1])); err != nil {
+		t.Fatalf("newest upload %s should survive: %v", ids[len(ids)-1], err)
+	}
+}
+
+func TestTelemetryGlobalRefusalAt507(t *testing.T) {
+	telemetryDir = t.TempDir()
+	savedBytes, savedFiles := telemetryUsedBytes, telemetryFiles
+	t.Cleanup(func() { telemetryUsedBytes, telemetryFiles = savedBytes, savedFiles })
+	telemetryUsedBytes, telemetryFiles = telemetryGlobalMaxBytes, 0
+
+	_, status, err := storeTelemetryBundle("peer-global-refusal-0000000000000000000000", []byte(`{"a":1}`))
+	if err == nil || status != http.StatusInsufficientStorage {
+		t.Fatalf("over the global byte ceiling: got status %d err %v, want 507", status, err)
+	}
+}
+
+func TestTelemetrySweeperExpiresAgedBundlesAndDecrementsCounters(t *testing.T) {
+	telemetryDir = t.TempDir()
+	savedBytes, savedFiles := telemetryUsedBytes, telemetryFiles
+	t.Cleanup(func() { telemetryUsedBytes, telemetryFiles = savedBytes, savedFiles })
+	telemetryUsedBytes, telemetryFiles = 0, 0
+
+	const peerId = "peer-sweep-test-00000000000000000000000000"
+	id, status, err := storeTelemetryBundle(peerId, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("setup upload: %v (status %d)", err, status)
+	}
+	path := filepath.Join(telemetryDir, id)
+	old := time.Now().Add(-telemetryTTL - time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if removed := sweepTelemetryOnce(time.Now()); removed != 1 {
+		t.Fatalf("swept %d bundle(s), want 1", removed)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("expired bundle should have been removed from disk")
+	}
+	if telemetryUsedBytes != 0 {
+		t.Fatalf("telemetryUsedBytes = %d after sweeping the only bundle, want 0", telemetryUsedBytes)
+	}
+	if telemetryFiles != 0 {
+		t.Fatalf("telemetryFiles = %d after sweeping the only bundle, want 0", telemetryFiles)
+	}
+}
+
+// ── Operator read routes ─────────────────────────────────────────────────
+
+func TestTelemetryAdminRoutesAbsentWithoutToken(t *testing.T) {
+	orig := telemetryAdminToken
+	telemetryAdminToken = ""
+	t.Cleanup(func() { telemetryAdminToken = orig })
+	resetRateLimiter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/telemetry/list", nil)
+	rec := httptest.NewRecorder()
+	handleTelemetryList(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/telemetry/list with no admin token: got %d, want 404", rec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/telemetry/get?id=x/y.json", nil)
+	rec = httptest.NewRecorder()
+	handleTelemetryGet(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/telemetry/get with no admin token: got %d, want 404", rec.Code)
+	}
+}
+
+func TestTelemetryAdminRoutesRejectWrongToken(t *testing.T) {
+	orig := telemetryAdminToken
+	telemetryAdminToken = "s3cr3t"
+	t.Cleanup(func() { telemetryAdminToken = orig })
+	resetRateLimiter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/telemetry/list", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rec := httptest.NewRecorder()
+	handleTelemetryList(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("/telemetry/list with a wrong token: got %d, want 401", rec.Code)
+	}
+}
+
+func TestTelemetryAdminListAndGetWithRightToken(t *testing.T) {
+	telemetryDir = t.TempDir()
+	savedBytes, savedFiles := telemetryUsedBytes, telemetryFiles
+	t.Cleanup(func() { telemetryUsedBytes, telemetryFiles = savedBytes, savedFiles })
+	telemetryUsedBytes, telemetryFiles = 0, 0
+	origToken := telemetryAdminToken
+	telemetryAdminToken = "s3cr3t"
+	t.Cleanup(func() { telemetryAdminToken = origToken })
+	resetRateLimiter(t)
+
+	peerId, _ := testPeer(t)
+	id, status, err := storeTelemetryBundle(peerId.String(), []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("setup upload: %v (status %d)", err, status)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/telemetry/list", nil)
+	req.Header.Set("Authorization", "Bearer s3cr3t")
+	rec := httptest.NewRecorder()
+	handleTelemetryList(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin list with the right token: got %d, want 200", rec.Code)
+	}
+	var body struct {
+		Bundles []telemetryBundleInfo `json:"bundles"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	found := false
+	for _, b := range body.Bundles {
+		if b.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("uploaded bundle %s not in admin list: %+v", id, body.Bundles)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/telemetry/get?id="+id, nil)
+	getReq.Header.Set("Authorization", "Bearer s3cr3t")
+	getRec := httptest.NewRecorder()
+	handleTelemetryGet(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("admin get with the right token: got %d, want 200", getRec.Code)
+	}
+	stored, _ := os.ReadFile(filepath.Join(telemetryDir, id))
+	if getRec.Body.String() != string(stored) {
+		t.Fatal("admin get did not return the stored bundle verbatim")
+	}
+}
+
+func TestTelemetryAdminGetRejectsTraversal(t *testing.T) {
+	telemetryDir = t.TempDir()
+	origToken := telemetryAdminToken
+	telemetryAdminToken = "s3cr3t"
+	t.Cleanup(func() { telemetryAdminToken = origToken })
+	resetRateLimiter(t)
+
+	for _, id := range []string{
+		"../../../etc/passwd",
+		"peer/../../../etc/passwd",
+		"peer/sub/dir.json",
+		"peer/..%2f..%2fsecret.json",
+	} {
+		req := httptest.NewRequest(http.MethodGet, "/telemetry/get?id="+url.QueryEscape(id), nil)
+		req.Header.Set("Authorization", "Bearer s3cr3t")
+		rec := httptest.NewRecorder()
+		handleTelemetryGet(rec, req)
+		if rec.Code == http.StatusOK {
+			t.Fatalf("traversal id %q was served, want a rejection", id)
+		}
+	}
+}
+
+// ── diagRoomRef ───────────────────────────────────────────────────────────
+
+func TestDiagRoomRefStableWithinProcessDiffersAcrossSecrets(t *testing.T) {
+	saved := telemetryBootSecret
+	t.Cleanup(func() { telemetryBootSecret = saved })
+
+	telemetryBootSecret = []byte("boot-secret-number-one-32-bytes")
+	refA1 := diagRoomRef("room-code-abc123")
+	refA2 := diagRoomRef("room-code-abc123")
+	if refA1 != refA2 {
+		t.Fatalf("diagRoomRef is not stable within one process: %q != %q", refA1, refA2)
+	}
+	if !strings.HasPrefix(refA1, "h:") {
+		t.Fatalf("diagRoomRef %q does not carry the h: prefix", refA1)
+	}
+
+	telemetryBootSecret = []byte("boot-secret-number-two-32-bytes")
+	refB := diagRoomRef("room-code-abc123")
+	if refB == refA1 {
+		t.Fatal("diagRoomRef did not change across a different boot secret")
+	}
+}
+
+// ── readLoop exit reasons ─────────────────────────────────────────────────
+
+// eofStream returns io.EOF immediately, the same as a peer that closed its
+// write side cleanly.
+type eofStream struct{ fakeStream }
+
+func (s *eofStream) Read([]byte) (int, error) { return 0, io.EOF }
+
+// resetErrStream returns a plain, non-timeout, non-EOF error immediately -
+// a genuine transport failure.
+type resetErrStream struct{ fakeStream }
+
+func (s *resetErrStream) Read([]byte) (int, error) { return 0, errors.New("stream reset by peer") }
+
+// oversizeFrameStream delivers one 4-byte length header over maxMsgLen on
+// its first Read, so readLoop's own guard fires without a real oversized
+// frame on the wire.
+type oversizeFrameStream struct {
+	fakeStream
+	sent bool
+}
+
+func (s *oversizeFrameStream) Read(p []byte) (int, error) {
+	s.mu.Lock()
+	if !s.sent {
+		s.sent = true
+		size := maxMsgLen + 1
+		header := []byte{byte(size >> 24), byte(size >> 16), byte(size >> 8), byte(size)}
+		n := copy(p, header)
+		s.mu.Unlock()
+		return n, nil
+	}
+	s.mu.Unlock()
+	return s.fakeStream.Read(p)
+}
+
+func TestReadLoopRecordsGracefulClose(t *testing.T) {
+	enableTelemetry(t)
+	r := newRegistry()
+	s := &eofStream{}
+	c := addClient(r, "peer-diag-graceful", s)
+
+	reason := r.readLoop(s, "peer-diag-graceful", c)
+	if reason != relayCloseGraceful {
+		t.Fatalf("readLoop reason = %q, want %q", reason, relayCloseGraceful)
+	}
+	assertLastCloseReason(t, "peer-diag-graceful", relayCloseGraceful)
+}
+
+func TestReadLoopRecordsReadErrorClose(t *testing.T) {
+	enableTelemetry(t)
+	r := newRegistry()
+	s := &resetErrStream{}
+	c := addClient(r, "peer-diag-read-error", s)
+
+	reason := r.readLoop(s, "peer-diag-read-error", c)
+	if reason != relayCloseReadError {
+		t.Fatalf("readLoop reason = %q, want %q", reason, relayCloseReadError)
+	}
+	assertLastCloseReason(t, "peer-diag-read-error", relayCloseReadError)
+}
+
+func TestReadLoopRecordsFrameOversizeClose(t *testing.T) {
+	enableTelemetry(t)
+	r := newRegistry()
+	s := &oversizeFrameStream{}
+	c := addClient(r, "peer-diag-oversize", s)
+
+	reason := r.readLoop(s, "peer-diag-oversize", c)
+	if reason != relayCloseFrameOversize {
+		t.Fatalf("readLoop reason = %q, want %q", reason, relayCloseFrameOversize)
+	}
+	if !s.wasReset() {
+		t.Fatal("an oversized frame should reset the stream")
+	}
+	assertLastCloseReason(t, "peer-diag-oversize", relayCloseFrameOversize)
+}
+
+func TestReadLoopRecordsIdleTimeoutClose(t *testing.T) {
+	enableTelemetry(t)
+	orig := rendezvousIdleTimeout
+	rendezvousIdleTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { rendezvousIdleTimeout = orig })
+
+	r := newRegistry()
+	s := &fakeStream{}
+	c := addClient(r, "peer-diag-idle", s)
+
+	var reason string
+	done := make(chan struct{})
+	go func() {
+		reason = r.readLoop(s, "peer-diag-idle", c)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not return once the idle window elapsed")
+	}
+	if reason != relayCloseIdleTimeout {
+		t.Fatalf("readLoop reason = %q, want %q", reason, relayCloseIdleTimeout)
+	}
+	assertLastCloseReason(t, "peer-diag-idle", relayCloseIdleTimeout)
+}
+
+func TestReadLoopRecordsLivenessTimeoutClose(t *testing.T) {
+	enableTelemetry(t)
+	origIdle, origPing := rendezvousIdleTimeout, rendezvousPingInterval
+	rendezvousIdleTimeout = time.Hour // must not be what ends this test
+	rendezvousPingInterval = 20 * time.Millisecond
+	rendezvousLivenessTimeout = 3 * rendezvousPingInterval
+	t.Cleanup(func() {
+		rendezvousIdleTimeout = origIdle
+		rendezvousPingInterval = origPing
+		rendezvousLivenessTimeout = 3 * rendezvousPingInterval
+	})
+
+	r := newRegistry()
+	s := &registerOnceStream{frame: encodeClientFrame(clientMsg{Type: "REGISTER", Room: "diag-room"})}
+	c := addClient(r, "peer-diag-liveness", s)
+
+	var reason string
+	done := make(chan struct{})
+	go func() {
+		reason = r.readLoop(s, "peer-diag-liveness", c)
+		close(done)
+	}()
+	s.waitFrames(t, 1) // the REGISTER's own PEERS reply proves readLoop dispatched it
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop did not return once the liveness window elapsed")
+	}
+	if reason != relayCloseLivenessTimeout {
+		t.Fatalf("readLoop reason = %q, want %q", reason, relayCloseLivenessTimeout)
+	}
+	assertLastCloseReason(t, "peer-diag-liveness", relayCloseLivenessTimeout)
+}

--- a/sfu/index.test.ts
+++ b/sfu/index.test.ts
@@ -5,7 +5,8 @@
 //   - the unconnected-transport reaper (Task 1)
 //   - ms:produce source validation (Task 3)
 //   - the dead-socket and stuck-backpressured producer reap (finding 6)
-import { test } from "node:test";
+//   - ms:diag (SFU telemetry vantage) enabled/rate-limited/disabled
+import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { spawn, ChildProcess } from "node:child_process";
 import path from "node:path";
@@ -27,18 +28,17 @@ const HEARTBEAT_INTERVAL_MS = 100;
 const MAX_QUEUED_FRAME_BYTES = 2000;
 
 let child: ChildProcess;
-let stoppingChild = false;
 
-function wsUrl(): string {
-  return `ws://127.0.0.1:${PORT}`;
+function wsUrl(port: number = PORT): string {
+  return `ws://127.0.0.1:${port}`;
 }
 
-async function waitForServer(): Promise<void> {
+async function waitForServer(port: number = PORT): Promise<void> {
   const deadline = Date.now() + 20_000;
   for (;;) {
     try {
       await new Promise<void>((resolve, reject) => {
-        const ws = new WebSocket(wsUrl());
+        const ws = new WebSocket(wsUrl(port));
         ws.once("open", () => {
           ws.close();
           resolve();
@@ -50,46 +50,75 @@ async function waitForServer(): Promise<void> {
       if (Date.now() > deadline) {
         throw new Error("sfu process never started listening");
       }
+      // Polling a real subprocess's real listening socket, not a guessed
+      // test delay - there is no event to await here until it exists.
       await new Promise((r) => setTimeout(r, 200));
     }
   }
 }
 
-test.before(async () => {
-  child = spawn(
+interface SpawnedSfu {
+  proc: ChildProcess;
+  stop(): Promise<void>;
+}
+
+// Spawns a real SFU process on `port` with `extraEnv` layered on top of the
+// baseline test env, and returns a handle to stop it. Shared by the
+// module's main child (below) and the SFU_TELEMETRY-disabled describe
+// block, which needs its own process because SFU_TELEMETRY is read once at
+// module load and cannot be toggled on a running server.
+function spawnSfu(port: number, extraEnv: Record<string, string>): SpawnedSfu {
+  const proc = spawn(
     process.execPath,
     [path.join(__dirname, "node_modules", ".bin", "tsx"), path.join(__dirname, "index.ts")],
     {
       env: {
         ...process.env,
-        SFU_PORT: String(PORT),
+        SFU_PORT: String(port),
         SFU_TRANSPORT_CONNECT_TIMEOUT_MS: String(TRANSPORT_CONNECT_TIMEOUT_MS),
         SFU_HEARTBEAT_INTERVAL_MS: String(HEARTBEAT_INTERVAL_MS),
         SFU_MAX_QUEUED_FRAME_BYTES: String(MAX_QUEUED_FRAME_BYTES),
         ANNOUNCED_IP: "127.0.0.1",
+        ...extraEnv,
       },
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
   let output = "";
-  child.stdout?.on("data", (d) => (output += d.toString()));
-  child.stderr?.on("data", (d) => (output += d.toString()));
-  child.on("exit", (code) => {
-    if (!stoppingChild && code !== null && code !== 0) {
-      console.error(`[sfu test] server exited early (${code}):\n${output}`);
+  let stopping = false;
+  proc.stdout?.on("data", (d) => (output += d.toString()));
+  proc.stderr?.on("data", (d) => (output += d.toString()));
+  proc.on("exit", (code) => {
+    if (!stopping && code !== null && code !== 0) {
+      console.error(`[sfu test] server on port ${port} exited early (${code}):\n${output}`);
     }
   });
-  await waitForServer();
+  return {
+    proc,
+    async stop() {
+      if (proc.exitCode !== null) return;
+      stopping = true;
+      const { promise, resolve } = Promise.withResolvers<void>();
+      proc.once("exit", () => resolve());
+      proc.kill("SIGTERM");
+      // A real child process against the real OS scheduler, not something a
+      // fake clock drives - the genuine-delay exception for a hung exit.
+      setTimeout(() => proc.kill("SIGKILL"), 3000).unref();
+      await promise;
+    },
+  };
+}
+
+let sfu: SpawnedSfu;
+
+test.before(async () => {
+  sfu = spawnSfu(PORT, { SFU_TELEMETRY: "1" });
+  child = sfu.proc;
+  await waitForServer(PORT);
 });
 
 test.after(async () => {
-  if (!child || child.exitCode !== null) return;
-  stoppingChild = true;
-  await new Promise<void>((resolve) => {
-    child.once("exit", () => resolve());
-    child.kill("SIGTERM");
-    setTimeout(() => child.kill("SIGKILL"), 3000).unref();
-  });
+  await sfu.stop();
 });
 
 // Waits for the next message matching `filter` (or any message, if omitted).
@@ -114,8 +143,12 @@ function nextMessage(
   });
 }
 
-async function connectAndJoin(roomCode: string, peerId: string): Promise<WebSocket> {
-  const ws = new WebSocket(wsUrl());
+async function connectAndJoin(
+  roomCode: string,
+  peerId: string,
+  port: number = PORT,
+): Promise<WebSocket> {
+  const ws = new WebSocket(wsUrl(port));
   await new Promise<void>((resolve, reject) => {
     ws.once("open", () => resolve());
     ws.once("error", reject);
@@ -323,4 +356,95 @@ test("sweepHeartbeatConnection: a non-backpressured socket still uses the ordina
   // pre-existing isAlive contract always has.
   sweepHeartbeatConnection(w, 2_000, 200);
   assert.equal(terminated, 1);
+});
+
+test("ms:diag returns a snapshot naming this peer's own transport and producer", async () => {
+  const ws = await connectAndJoin("room-diag", "peer-diag-a");
+  try {
+    const producerId = await produceRealAudio(ws, 44444444);
+
+    ws.send(JSON.stringify({ type: "ms:diag", requestId: "diag-1" }));
+    const reply = await nextMessage(
+      ws,
+      (m) => m.type === "ms:diag" && m.requestId === "diag-1",
+    );
+
+    assert.equal(reply.snapshot.self.peerId, "peer-diag-a");
+    const sendTransport = reply.snapshot.self.transports.find(
+      (t: { dir: string }) => t.dir === "send",
+    );
+    assert.ok(sendTransport, "expected the send transport to be in the snapshot");
+    // PRIVACY: never a remote ICE candidate address anywhere in the reply.
+    assert.ok(!JSON.stringify(reply).includes("remoteIp"));
+    const producer = reply.snapshot.self.producers.find(
+      (p: { id: string }) => p.id === producerId,
+    );
+    assert.ok(producer, "expected the produced audio track to be in the snapshot");
+    assert.equal(producer.source, "camera");
+  } finally {
+    ws.close();
+  }
+});
+
+test("a second immediate ms:diag is refused as rate-limited, not answered again", async () => {
+  const ws = await connectAndJoin("room-diag-rate", "peer-diag-rate");
+  try {
+    ws.send(JSON.stringify({ type: "ms:diag", requestId: "diag-a" }));
+    const first = await nextMessage(
+      ws,
+      (m) => m.requestId === "diag-a",
+    );
+    assert.equal(first.type, "ms:diag");
+
+    ws.send(JSON.stringify({ type: "ms:diag", requestId: "diag-b" }));
+    const second = await nextMessage(
+      ws,
+      (m) => m.requestId === "diag-b",
+    );
+    assert.equal(second.type, "ms:diag-unavailable");
+    assert.equal(second.reason, "rate-limited");
+  } finally {
+    ws.close();
+  }
+});
+
+// SFU_TELEMETRY is read once at module load (DIAG_ENABLED, sfu/index.ts), so
+// the "disabled" behaviour needs a SEPARATE process from the one above,
+// which runs with SFU_TELEMETRY=1 for the whole file.
+describe("ms:diag with SFU_TELEMETRY unset", () => {
+  const DISABLED_PORT = PORT + 500;
+  let disabledSfu: SpawnedSfu;
+
+  before(async () => {
+    disabledSfu = spawnSfu(DISABLED_PORT, {});
+    await waitForServer(DISABLED_PORT);
+  });
+
+  after(async () => {
+    await disabledSfu.stop();
+  });
+
+  test("ms:diag answers disabled, and the session is not latched by it", async () => {
+    const ws = await connectAndJoin("room-diag-disabled", "peer-diag-disabled", DISABLED_PORT);
+    try {
+      ws.send(JSON.stringify({ type: "ms:diag", requestId: "diag-1" }));
+      const reply = await nextMessage(
+        ws,
+        (m) => m.requestId === "diag-1",
+      );
+      assert.equal(reply.type, "ms:diag-unavailable");
+      assert.equal(reply.reason, "disabled");
+
+      // The regression this guards: ms:diag must answer with
+      // ms:diag-unavailable, NEVER ms:error - the client treats a bare
+      // ms:error as a whole-session refusal and latches it permanently. A
+      // still-working ms:get-capabilities after the "disabled" reply proves
+      // this session was not latched.
+      ws.send(JSON.stringify({ type: "ms:get-capabilities" }));
+      const caps = await nextMessage(ws, (m) => m.type === "ms:capabilities");
+      assert.ok(caps.rtpCapabilities);
+    } finally {
+      ws.close();
+    }
+  });
 });

--- a/sfu/index.ts
+++ b/sfu/index.ts
@@ -2,6 +2,16 @@ import * as mediasoup from "mediasoup";
 import { WebSocketServer, WebSocket } from "ws";
 import { IncomingMessage } from "http";
 import { sweepHeartbeatConnection, type HeartbeatSocket } from "./heartbeat";
+import {
+  SFU_DIAG_SCHEMA_VERSION,
+  pickTransportStats,
+  pickRtpStats,
+  serializeSnapshot,
+  type SfuSnapshot,
+  type DiagTransportView,
+  type DiagProducerView,
+  type DiagConsumerView,
+} from "./telemetry";
 
 // ── Types mirrored from client mediasoup.ts ───────────────────────────────────
 
@@ -134,6 +144,30 @@ interface MSPeerLeft {
   peerId: string;
 }
 
+// Client -> server: ask for a point-in-time diagnostic snapshot of this
+// peer's own transports/producers/consumers plus the room's producer roster.
+interface MSDiag {
+  type: "ms:diag";
+  requestId: string;
+}
+// Server -> client: the snapshot answering an MSDiag.
+interface MSDiagReply {
+  type: "ms:diag";
+  requestId: string;
+  snapshot: SfuSnapshot;
+}
+// Server -> client: MSDiag was refused. Deliberately NOT ms:error - the
+// client treats an ms:error with no `direction` as a refusal of the WHOLE
+// SESSION and latches it permanently (mediasoup.ts failSession). A refused
+// diag request must fail only that one request, exactly like
+// MSConsumeFailed above, or asking for diagnostics on a session the operator
+// never enabled telemetry for would itself end the call.
+interface MSDiagUnavailable {
+  type: "ms:diag-unavailable";
+  requestId: string;
+  reason: "disabled" | "rate-limited";
+}
+
 // Envelope sent by the client over this WebSocket connection.
 // All messages from client arrive as: { type: "join" } or { type: "ms:*", ... }
 type ClientJoin = { type: "join"; roomCode: string; peerId: string };
@@ -146,7 +180,8 @@ type ClientMsg =
   | MSConsume
   | MSCloseConsumer
   | MSCloseProducer
-  | MSResumeConsumer;
+  | MSResumeConsumer
+  | MSDiag;
 
 // ── Per-peer state ────────────────────────────────────────────────────────────
 
@@ -204,6 +239,11 @@ interface PeerState {
   // The liveness probe outstanding against this session, if any. Shared so
   // that a flood of duplicate joins costs one ping rather than one ping each.
   livenessProbe: Promise<boolean> | null;
+  // Wall-clock ms of the last accepted ms:diag reply, 0 until the first one.
+  // Rate-limits diag requests to DIAG_MIN_INTERVAL_MS apart so a peer cannot
+  // poll snapshots - and the getStats() worker round-trips each one costs -
+  // faster than that.
+  lastDiagAt: number;
 }
 
 // ── Resource ceilings ─────────────────────────────────────────────────────────
@@ -262,6 +302,20 @@ const TRANSPORT_CONNECT_TIMEOUT_MS = parseInt(
 // base58 libp2p peer id; anything long, non-string or carrying control
 // characters is junk.
 const MAX_ID_LENGTH = 128;
+// Telemetry is an operator-configured disclosure change (it walks every
+// retained transport/producer/consumer and reports ICE/DTLS state, bitrate
+// and loss to the requesting peer), so it defaults OFF: without this flag
+// set, ms:diag always answers ms:diag-unavailable and the heartbeat sweep
+// never logs a [sfu-telemetry] line.
+const DIAG_ENABLED = process.env.SFU_TELEMETRY === "1";
+// Floor between one peer's ms:diag requests. Each one calls getStats() on
+// every retained transport/producer/consumer - a worker round-trip apiece -
+// so a peer with no floor could poll fast enough to compete with the room's
+// real media traffic for the same worker thread.
+const DIAG_MIN_INTERVAL_MS = parseInt(
+  process.env.SFU_DIAG_MIN_INTERVAL_MS ?? "10000",
+  10,
+);
 
 function isValidId(value: unknown): value is string {
   return (
@@ -1091,6 +1145,20 @@ function handlePeerLeft(peer: PeerState): void {
   }
   peer.consumers.clear();
 
+  // Other peers' producers can still list this peer in their viewer set
+  // (entry.consumers, populated in handleConsume) if this peer was watching
+  // them. Nothing else removes a departed viewer from a SURVIVING peer's
+  // producer, so without this the reported viewer count over-reports after
+  // every disconnect - it only ever shrank via an explicit
+  // ms:close-consumer (handleCloseConsumer), never via the implicit close
+  // a peer leaving performs on its own consumers above.
+  for (const [otherPeerId, otherPeer] of room) {
+    if (otherPeerId === peer.peerId) continue;
+    for (const entry of otherPeer.producers.values()) {
+      entry.consumers.delete(peer.peerId);
+    }
+  }
+
   peer.sendTransport?.close();
   peer.recvTransport?.close();
   // Both transports are gone (or were never built); their reap timers would
@@ -1125,6 +1193,202 @@ function handlePeerLeft(peer: PeerState): void {
         console.error(`[sfu] error closing router for room ${peer.roomCode}:`, err);
       });
     }
+  }
+}
+
+// Answers ms:diag with a point-in-time SfuSnapshot of this peer's own
+// transports/producers/consumers plus the room's producer roster. Scoped to
+// the REQUESTER'S ROOM ONLY - never a whole-instance dump - and gated by
+// DIAG_ENABLED / DIAG_MIN_INTERVAL_MS so an anonymous client cannot use it to
+// keep this peer's worker round-trips busier than its real media traffic
+// does.
+async function handleDiag(peer: PeerState, msg: MSDiag): Promise<void> {
+  if (!DIAG_ENABLED) {
+    send(peer.ws, {
+      type: "ms:diag-unavailable",
+      requestId: msg.requestId,
+      reason: "disabled",
+    } as MSDiagUnavailable);
+    return;
+  }
+
+  const now = Date.now();
+  if (now - peer.lastDiagAt < DIAG_MIN_INTERVAL_MS) {
+    send(peer.ws, {
+      type: "ms:diag-unavailable",
+      requestId: msg.requestId,
+      reason: "rate-limited",
+    } as MSDiagUnavailable);
+    return;
+  }
+  peer.lastDiagAt = now;
+
+  // Every getStats() below is a worker round-trip; the session can be
+  // replaced or closed while any one of them is in flight, the same window
+  // guarded at ":580", ":745" and ":926" for produce()/consume(). Re-checked
+  // after each await, and the whole reply is dropped silently when stale -
+  // exactly like those three call sites.
+  const isStale = (): boolean =>
+    rooms.get(peer.roomCode)?.get(peer.peerId) !== peer;
+
+  const transports: DiagTransportView[] = [];
+  for (const dir of ["send", "recv"] as const) {
+    const transport = dir === "send" ? peer.sendTransport : peer.recvTransport;
+    if (!transport) continue;
+    let picked: Pick<DiagTransportView, "tuple" | "bytesSent" | "bytesReceived" | "rtt">;
+    try {
+      picked = pickTransportStats(await transport.getStats());
+    } catch {
+      picked = { tuple: null, bytesSent: 0, bytesReceived: 0, rtt: null };
+    }
+    if (isStale()) return;
+    transports.push({
+      dir,
+      iceState: transport.iceState,
+      dtlsState: transport.dtlsState,
+      ...picked,
+    });
+  }
+
+  const producers: DiagProducerView[] = [];
+  for (const [producerId, entry] of peer.producers) {
+    let rtp = { bitrate: 0, packetsLost: 0 };
+    try {
+      rtp = pickRtpStats(await entry.producer.getStats());
+    } catch {
+      // keep the zeroed default
+    }
+    if (isStale()) return;
+    let score = 0;
+    for (const s of entry.producer.score) score = Math.max(score, s.score);
+    producers.push({
+      id: producerId,
+      kind: entry.producer.kind,
+      source: entry.source,
+      score,
+      consumers: entry.consumers.size,
+      bitrate: rtp.bitrate,
+      packetsLost: rtp.packetsLost,
+    });
+  }
+
+  const consumers: DiagConsumerView[] = [];
+  for (const [consumerId, entry] of peer.consumers) {
+    let rtp = { bitrate: 0, packetsLost: 0 };
+    try {
+      rtp = pickRtpStats(await entry.consumer.getStats());
+    } catch {
+      // keep the zeroed default
+    }
+    if (isStale()) return;
+    consumers.push({
+      id: consumerId,
+      producerId: entry.producerId,
+      kind: entry.consumer.kind,
+      score: entry.consumer.score.score,
+      paused: entry.consumer.paused,
+      producerPaused: entry.consumer.producerPaused,
+      bitrate: rtp.bitrate,
+      packetsLost: rtp.packetsLost,
+    });
+  }
+
+  const room = rooms.get(peer.roomCode);
+  if (!room || room.get(peer.peerId) !== peer) return;
+
+  const roomView: SfuSnapshot["room"] = [];
+  for (const [otherPeerId, otherPeer] of room) {
+    roomView.push({
+      peerId: otherPeerId,
+      producers: Array.from(otherPeer.producers.entries()).map(([id, e]) => ({
+        id,
+        source: e.source,
+        kind: e.producer.kind,
+        consumers: e.consumers.size,
+      })),
+    });
+  }
+
+  const snapshot: SfuSnapshot = {
+    schemaVersion: SFU_DIAG_SCHEMA_VERSION,
+    takenAt: now,
+    roomPeerCount: room.size,
+    self: {
+      peerId: peer.peerId,
+      transports,
+      producers,
+      consumers,
+      cumulativeProduces: peer.cumulativeProduces,
+      backpressured: Boolean(
+        (peer.ws as unknown as { backpressured?: boolean }).backpressured,
+      ),
+    },
+    room: roomView,
+    ceilings: {
+      peersPerRoom: MAX_PEERS_PER_ROOM,
+      producersPerPeer: MAX_PRODUCERS_PER_PEER,
+      consumersPerPeer: MAX_CONSUMERS_PER_PEER,
+      rooms: rooms.size,
+      maxRooms: MAX_ROOMS,
+    },
+  };
+
+  send(peer.ws, {
+    type: "ms:diag",
+    requestId: msg.requestId,
+    snapshot: serializeSnapshot(snapshot, MAX_PEERS_PER_ROOM, MAX_PRODUCERS_PER_PEER),
+  } as MSDiagReply);
+}
+
+// Emits one structured line per room per heartbeat sweep, gated by
+// DIAG_ENABLED. Cheap enough to run every tick because it reads only
+// synchronous getters (iceState/dtlsState) - never getStats(), which is a
+// worker round-trip; the richer per-peer snapshot with bitrate/loss is what
+// ms:diag is for. Room codes and peer ids are in CLEAR here: that is the
+// established precedent for the SFU's own log (see the join/leave lines
+// above) and this is the operator's own container log, not a client-facing
+// surface.
+function emitSfuTelemetrySweep(): void {
+  if (!DIAG_ENABLED) return;
+  let emitted = 0;
+  for (const [roomCode, room] of rooms) {
+    if (emitted >= MAX_ROOMS) break;
+
+    const peers: Array<{
+      peerId: string;
+      producers: Array<{ id: string; source: string; kind: string; consumers: number }>;
+      send: { iceState: string; dtlsState: string } | null;
+      recv: { iceState: string; dtlsState: string } | null;
+    }> = [];
+    let producerCount = 0;
+    for (const [peerId, roomPeer] of room) {
+      const producers = Array.from(roomPeer.producers.entries()).map(([id, entry]) => ({
+        id,
+        source: entry.source,
+        kind: entry.producer.kind,
+        consumers: entry.consumers.size,
+      }));
+      producerCount += producers.length;
+      peers.push({
+        peerId,
+        producers,
+        send: roomPeer.sendTransport
+          ? { iceState: roomPeer.sendTransport.iceState, dtlsState: roomPeer.sendTransport.dtlsState }
+          : null,
+        recv: roomPeer.recvTransport
+          ? { iceState: roomPeer.recvTransport.iceState, dtlsState: roomPeer.recvTransport.dtlsState }
+          : null,
+      });
+    }
+
+    // A room with no producers is a bare join with nothing to route yet;
+    // logging it every sweep for the life of an idle call adds noise with
+    // no diagnostic value.
+    if (producerCount === 0) continue;
+    emitted++;
+    console.log(
+      `[sfu-telemetry] ${JSON.stringify({ v: 1, t: Date.now(), room: roomCode, peers })}`,
+    );
   }
 }
 
@@ -1221,6 +1485,7 @@ async function main(): Promise<void> {
         BACKPRESSURE_DEADLINE_MS,
       );
     });
+    emitSfuTelemetrySweep();
   }, HEARTBEAT_INTERVAL_MS);
 
   wss.on("close", () => {
@@ -1378,6 +1643,7 @@ async function main(): Promise<void> {
           consumersInFlight: 0,
           cumulativeProduces: 0,
           livenessProbe: null,
+          lastDiagAt: 0,
         };
         const room = getOrCreateRoom(joinMsg.roomCode);
         if (oldPeer) {
@@ -1461,6 +1727,9 @@ async function main(): Promise<void> {
             break;
           case "ms:close-producer":
             handleCloseProducer(peer, msg as MSCloseProducer);
+            break;
+          case "ms:diag":
+            await handleDiag(peer, msg as MSDiag);
             break;
           default:
             console.warn("[sfu] unknown message type:", (msg as any).type);

--- a/sfu/package.json
+++ b/sfu/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx watch index.ts",
-    "test": "tsx --test index.test.ts"
+    "test": "tsx --test index.test.ts telemetry.test.ts"
   },
   "dependencies": {
     "mediasoup": "^3.14.18",

--- a/sfu/scripts/capture-sfu-vantage.ts
+++ b/sfu/scripts/capture-sfu-vantage.ts
@@ -1,0 +1,138 @@
+/**
+ * Capture a real SFU vantage for the analysis dashboard's fixtures.
+ *
+ * The dashboard's `parseSfuTelemetry` must be validated against lines a real
+ * SFU printed, and its `SfuSnapshot` reader against a snapshot a real
+ * mediasoup router produced. A hand-written fixture would only prove the
+ * parser agrees with itself.
+ *
+ * Two peers join one room, one produces audio, then this script asks for a
+ * snapshot over `ms:diag`. Run it against an SFU started with
+ * `SFU_TELEMETRY=1`, and capture that SFU's stdout separately - the
+ * `[sfu-telemetry]` sweep prints there, once per room per 10 s.
+ *
+ *   cd sfu
+ *   SFU_TELEMETRY=1 npx tsx index.ts > /tmp/sfu.log 2>&1 &
+ *   npx tsx scripts/capture-sfu-vantage.ts
+ *
+ * It writes the snapshot next to the bundle fixtures. See
+ * dashboard/src/lib/analysis/fixtures/README.md.
+ */
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { WebSocket } from "ws";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const OUT = join(HERE, "../../dashboard/src/lib/analysis/fixtures");
+const PORT = Number(process.env.SFU_PORT ?? 3000);
+const ROOM = process.env.ROOM ?? "fixturecapture01";
+
+interface Msg {
+  type: string;
+  [key: string]: unknown;
+}
+
+function nextMessage(
+  ws: WebSocket,
+  filter: (m: Msg) => boolean,
+  timeoutMs = 8000
+): Promise<Msg> {
+  const { promise, resolve, reject } = Promise.withResolvers<Msg>();
+  const timer = setTimeout(() => {
+    ws.off("message", onMessage);
+    reject(new Error("timed out waiting for a message"));
+  }, timeoutMs);
+  function onMessage(raw: Buffer): void {
+    const msg = JSON.parse(raw.toString()) as Msg;
+    if (!filter(msg)) return;
+    clearTimeout(timer);
+    ws.off("message", onMessage);
+    resolve(msg);
+  }
+  ws.on("message", onMessage);
+  return promise;
+}
+
+async function joinRoom(roomCode: string, peerId: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${PORT}/sfu`);
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  ws.once("open", () => resolve());
+  ws.once("error", reject);
+  await promise;
+  ws.send(JSON.stringify({ type: "join", roomCode, peerId }));
+  return ws;
+}
+
+/** The same shape `sfu/index.test.ts` uses, so the SFU accepts a real produce. */
+function audioRtpParameters(ssrc: number): unknown {
+  return {
+    mid: "0",
+    codecs: [
+      {
+        mimeType: "audio/opus",
+        payloadType: 100,
+        clockRate: 48000,
+        channels: 2,
+        parameters: {},
+        rtcpFeedback: [],
+      },
+    ],
+    headerExtensions: [],
+    encodings: [{ ssrc }],
+    rtcp: { cname: `capture-${ssrc}`, reducedSize: true },
+  };
+}
+
+async function produce(ws: WebSocket, ssrc: number): Promise<string> {
+  ws.send(JSON.stringify({ type: "ms:create-transport", direction: "send" }));
+  await nextMessage(
+    ws,
+    (m) => m.type === "ms:transport-options" && m.direction === "send"
+  );
+  ws.send(
+    JSON.stringify({
+      type: "ms:produce",
+      kind: "audio",
+      rtpParameters: audioRtpParameters(ssrc),
+      source: "camera",
+    })
+  );
+  const produced = await nextMessage(ws, (m) => m.type === "ms:produced");
+  return String(produced.producerId);
+}
+
+async function main(): Promise<void> {
+  const a = await joinRoom(ROOM, "capture-peer-a");
+  const b = await joinRoom(ROOM, "capture-peer-b");
+
+  const producerId = await produce(a, 44444444);
+  console.log(`produced ${producerId}`);
+  await nextMessage(b, (m) => m.type === "ms:new-producer");
+
+  // Give the 10 s heartbeat sweep time to print at least one line.
+  await new Promise((r) => setTimeout(r, 12_000));
+
+  a.send(JSON.stringify({ type: "ms:diag", requestId: "capture-1" }));
+  const reply = await nextMessage(
+    a,
+    (m) => m.type === "ms:diag" || m.type === "ms:diag-unavailable"
+  );
+  if (reply.type !== "ms:diag") {
+    console.error(`refused: ${JSON.stringify(reply)}`);
+    process.exit(1);
+  }
+
+  writeFileSync(
+    join(OUT, "sfu-snapshot.json"),
+    JSON.stringify(reply.snapshot, null, 1)
+  );
+  console.log("wrote sfu-snapshot.json");
+
+  a.close();
+  b.close();
+  process.exit(0);
+}
+
+void main();

--- a/sfu/telemetry.test.ts
+++ b/sfu/telemetry.test.ts
@@ -1,0 +1,223 @@
+// Pure unit tests against telemetry.ts - no mediasoup worker, no websocket.
+// Fixtures below mirror the REAL shapes mediasoup's getStats() returns
+// (WebRtcTransportStat for a transport, RtpStreamRecvStats/SendStats for a
+// producer/consumer), per heartbeat.test-style fakes rather than a live
+// worker.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  pickTransportStats,
+  pickRtpStats,
+  serializeSnapshot,
+  type SfuSnapshot,
+} from "./telemetry";
+
+test("pickTransportStats: a realistic WebRtcTransportStat report", () => {
+  const reports = [
+    {
+      type: "webrtc-transport",
+      transportId: "transport-1",
+      timestamp: 1750000000000,
+      iceRole: "controlled",
+      iceState: "connected",
+      iceSelectedTuple: {
+        localIp: "10.0.0.5",
+        localAddress: "10.0.0.5",
+        localPort: 40017,
+        remoteIp: "203.0.113.9",
+        remotePort: 54321,
+        protocol: "udp",
+      },
+      dtlsState: "connected",
+      bytesReceived: 123456,
+      recvBitrate: 48000,
+      bytesSent: 654321,
+      sendBitrate: 96000,
+      rtpBytesReceived: 100000,
+      rtpRecvBitrate: 40000,
+      rtpBytesSent: 600000,
+      rtpSendBitrate: 90000,
+      rtxBytesReceived: 0,
+      rtxRecvBitrate: 0,
+      rtxBytesSent: 0,
+      rtxSendBitrate: 0,
+      probationBytesSent: 0,
+      probationSendBitrate: 0,
+    },
+  ];
+
+  const picked = pickTransportStats(reports);
+
+  assert.deepEqual(picked.tuple, { protocol: "udp", localPort: 40017 });
+  assert.equal(picked.bytesSent, 654321);
+  assert.equal(picked.bytesReceived, 123456);
+  // WebRtcTransportStat carries no rtt field in this mediasoup version.
+  assert.equal(picked.rtt, null);
+});
+
+test("pickTransportStats: a malformed report array never throws and falls back safely", () => {
+  assert.doesNotThrow(() => pickTransportStats([]));
+  assert.deepEqual(pickTransportStats([]), {
+    tuple: null,
+    bytesSent: 0,
+    bytesReceived: 0,
+    rtt: null,
+  });
+
+  assert.doesNotThrow(() => pickTransportStats([null]));
+  assert.doesNotThrow(() => pickTransportStats([undefined]));
+  assert.doesNotThrow(() => pickTransportStats(["not an object"]));
+  assert.doesNotThrow(() =>
+    pickTransportStats([
+      {
+        // Wrong types throughout: a real report never looks like this, but a
+        // future mediasoup version renaming/retyping a field must not throw.
+        iceSelectedTuple: "garbage",
+        bytesSent: "a lot",
+        bytesReceived: null,
+        rtt: "12ms",
+      },
+    ]),
+  );
+
+  const picked = pickTransportStats([
+    { iceSelectedTuple: { protocol: 7, localPort: "x" }, bytesSent: NaN, bytesReceived: Infinity },
+  ]);
+  assert.equal(picked.tuple, null);
+  assert.equal(picked.bytesSent, 0);
+  assert.equal(picked.bytesReceived, 0);
+  assert.equal(picked.rtt, null);
+});
+
+test("pickRtpStats: a realistic RtpStreamRecvStats report", () => {
+  const reports = [
+    {
+      type: "inbound-rtp",
+      timestamp: 1750000000000,
+      ssrc: 11111111,
+      kind: "audio",
+      mimeType: "audio/opus",
+      packetsLost: 3,
+      fractionLost: 0.01,
+      jitter: 2,
+      packetsDiscarded: 0,
+      packetsRetransmitted: 0,
+      packetsRepaired: 0,
+      nackCount: 0,
+      nackPacketCount: 0,
+      pliCount: 0,
+      firCount: 0,
+      roundTripTime: 24,
+      score: 9,
+      packetCount: 5000,
+      byteCount: 640000,
+      bitrate: 32000,
+      bitrateByLayer: {},
+    },
+  ];
+
+  assert.deepEqual(pickRtpStats(reports), { bitrate: 32000, packetsLost: 3 });
+});
+
+test("pickRtpStats: a malformed report array never throws and falls back to zero", () => {
+  assert.doesNotThrow(() => pickRtpStats([]));
+  assert.deepEqual(pickRtpStats([]), { bitrate: 0, packetsLost: 0 });
+  assert.deepEqual(pickRtpStats([null]), { bitrate: 0, packetsLost: 0 });
+  assert.deepEqual(
+    pickRtpStats([{ bitrate: "fast", packetsLost: -Infinity }]),
+    { bitrate: 0, packetsLost: 0 },
+  );
+});
+
+function fixtureSnapshot(roomSize: number, producersPerPeer: number): SfuSnapshot {
+  return {
+    schemaVersion: 1,
+    takenAt: 1750000000000,
+    roomPeerCount: roomSize,
+    self: {
+      peerId: "self-peer",
+      transports: [],
+      producers: [],
+      consumers: [],
+      cumulativeProduces: 0,
+      backpressured: false,
+    },
+    room: Array.from({ length: roomSize }, (_, i) => ({
+      peerId: `peer-${i}`,
+      producers: Array.from({ length: producersPerPeer }, (_, j) => ({
+        id: `peer-${i}-producer-${j}`,
+        source: "camera",
+        kind: "video",
+        consumers: 0,
+      })),
+    })),
+    ceilings: {
+      peersPerRoom: 32,
+      producersPerPeer: 8,
+      consumersPerPeer: 256,
+      rooms: 1,
+      maxRooms: 250,
+    },
+  };
+}
+
+test("serializeSnapshot: truncates at both the room-peer cap and the per-peer producer cap", () => {
+  const snapshot = fixtureSnapshot(5, 3);
+  const truncated = serializeSnapshot(snapshot, 2, 1);
+
+  assert.equal(truncated.room.length, 2);
+  for (const entry of truncated.room) {
+    assert.equal(entry.producers.length, 1);
+  }
+  // roomPeerCount reports the TRUE count, unaffected by display truncation.
+  assert.equal(truncated.roomPeerCount, 5);
+});
+
+test("serializeSnapshot: under both caps leaves the snapshot untouched", () => {
+  const snapshot = fixtureSnapshot(2, 1);
+  const result = serializeSnapshot(snapshot, 32, 8);
+  assert.deepEqual(result.room, snapshot.room);
+});
+
+test("a serialized snapshot never contains a remote address", () => {
+  const remoteIp = "203.0.113.42";
+  const picked = pickTransportStats([
+    {
+      iceSelectedTuple: {
+        localIp: "10.0.0.1",
+        localAddress: "10.0.0.1",
+        localPort: 40001,
+        remoteIp,
+        remotePort: 55555,
+        protocol: "udp",
+      },
+      bytesSent: 1,
+      bytesReceived: 1,
+    },
+  ]);
+
+  const snapshot: SfuSnapshot = {
+    ...fixtureSnapshot(1, 1),
+    self: {
+      peerId: "self-peer",
+      transports: [
+        {
+          dir: "send",
+          iceState: "connected",
+          dtlsState: "connected",
+          ...picked,
+        },
+      ],
+      producers: [],
+      consumers: [],
+      cumulativeProduces: 0,
+      backpressured: false,
+    },
+  };
+
+  const serialized = serializeSnapshot(snapshot, 32, 8);
+  const json = JSON.stringify(serialized);
+  assert.ok(!json.includes(remoteIp), "serialized snapshot must never carry a remote address");
+  assert.ok(json.includes("udp"), "the protocol should still be present");
+  assert.ok(json.includes("40001"), "the local port should still be present");
+});

--- a/sfu/telemetry.ts
+++ b/sfu/telemetry.ts
@@ -1,0 +1,184 @@
+// The SFU-side telemetry vantage. Types below are mirrored TWICE elsewhere:
+//   - frontend/src/lib/telemetry/schema.ts (the wire contract - DiagEvent and
+//     the "sfu" DiagKind literals live there; the DiagTransportView /
+//     DiagProducerView / DiagConsumerView / SfuSnapshot types below are
+//     copied from that file byte-for-byte)
+//   - dashboard/src/lib/schema.ts (the analysis app's own copy of the same
+//     types)
+// A change to any type in this file MUST be made in all three, in the same
+// commit. There is no version handshake: SfuSnapshot carries schemaVersion,
+// and a reader that sees an unknown version refuses it rather than guessing.
+//
+// Split out of index.ts for the same reason heartbeat.ts is: index.ts boots
+// a real mediasoup worker and opens a listening socket at import time, so it
+// cannot be loaded by a test. This module has no side effects on import -
+// every input is duck-typed (StatsSource, plain report objects) and every
+// clock value is passed in, so a test can exercise it with fakes.
+//
+// PRIVACY: `DiagTransportView.tuple` carries the protocol and the LOCAL port
+// only. A remote ICE candidate address must never appear in a produced view -
+// see deploy/README.md on why coturn's own verbose logging is off for
+// exactly this reason.
+
+/** Must equal DIAG_SCHEMA_VERSION in frontend/src/lib/telemetry/schema.ts. */
+export const SFU_DIAG_SCHEMA_VERSION = 1;
+
+export interface DiagTransportView {
+  dir: "send" | "recv";
+  iceState: string;
+  dtlsState: string;
+  /** Protocol and LOCAL port only. NEVER a remote address. */
+  tuple: { protocol: string; localPort: number } | null;
+  bytesSent: number;
+  bytesReceived: number;
+  rtt: number | null;
+}
+
+export interface DiagProducerView {
+  id: string;
+  kind: string;
+  source: string;
+  score: number;
+  consumers: number;
+  bitrate: number;
+  packetsLost: number;
+}
+
+export interface DiagConsumerView {
+  id: string;
+  producerId: string;
+  kind: string;
+  score: number;
+  paused: boolean;
+  producerPaused: boolean;
+  bitrate: number;
+  packetsLost: number;
+}
+
+export interface SfuSnapshot {
+  schemaVersion: number;
+  takenAt: number;
+  roomPeerCount: number;
+  self: {
+    peerId: string;
+    transports: DiagTransportView[];
+    producers: DiagProducerView[];
+    consumers: DiagConsumerView[];
+    cumulativeProduces: number;
+    backpressured: boolean;
+  };
+  room: Array<{
+    peerId: string;
+    producers: Array<{
+      id: string;
+      source: string;
+      kind: string;
+      consumers: number;
+    }>;
+  }>;
+  ceilings: {
+    peersPerRoom: number;
+    producersPerPeer: number;
+    consumersPerPeer: number;
+    rooms: number;
+    maxRooms: number;
+  };
+}
+
+/** Duck-typed so a test needs no real mediasoup Transport/Producer/Consumer. */
+export interface StatsSource {
+  getStats(): Promise<unknown[]>;
+}
+
+// Safely reads one field off a value that might not even be an object - a
+// mediasoup stat report is `unknown` at this boundary, and a version that
+// renames or drops a field must degrade gracefully. ms:diag runs inside the
+// same per-frame try/catch as every other handler, and a throw here would
+// answer the request with nothing instead of a partial snapshot.
+function pickField(source: unknown, key: string): unknown {
+  return typeof source === "object" && source !== null
+    ? (source as Record<string, unknown>)[key]
+    : undefined;
+}
+
+// Coerces a field read via pickField to a finite number, or `fallback` when
+// it is absent, `NaN`, `Infinity`, or the wrong type. Every numeric field
+// pulled from an untrusted report goes through this one contract so a
+// malformed report degrades the same way everywhere.
+function finiteNumber(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+/**
+ * Picks the transport-level fields telemetry needs out of a real
+ * `WebRtcTransport.getStats()` report array. `reports[0]` is the transport's
+ * own report; there is exactly one per WebRtcTransport.
+ */
+export function pickTransportStats(
+  reports: unknown[],
+): Pick<DiagTransportView, "tuple" | "bytesSent" | "bytesReceived" | "rtt"> {
+  const report = Array.isArray(reports) ? reports[0] : undefined;
+
+  const rawTuple = pickField(report, "iceSelectedTuple");
+  const protocol = pickField(rawTuple, "protocol");
+  const localPort = pickField(rawTuple, "localPort");
+  // NEVER copy localIp/localAddress/remoteIp/remotePort onto `tuple` - see
+  // the file header. Only the two fields named on DiagTransportView cross
+  // this boundary.
+  const tuple =
+    typeof protocol === "string" && typeof localPort === "number"
+      ? { protocol, localPort }
+      : null;
+  // mediasoup's WebRtcTransportStat carries no round-trip-time field today;
+  // `rtt` is read defensively in case a future version adds one, and stays
+  // null otherwise rather than fabricating a number.
+  const rawRtt = pickField(report, "rtt");
+  const rtt = typeof rawRtt === "number" && Number.isFinite(rawRtt) ? rawRtt : null;
+
+  return {
+    tuple,
+    bytesSent: finiteNumber(pickField(report, "bytesSent"), 0),
+    bytesReceived: finiteNumber(pickField(report, "bytesReceived"), 0),
+    rtt,
+  };
+}
+
+/**
+ * Picks the RTP-stream fields out of a real `Producer.getStats()` /
+ * `Consumer.getStats()` report array. `reports[0]` is the primary encoding's
+ * report, which is what a single-line diagnostic summary needs.
+ */
+export function pickRtpStats(
+  reports: unknown[],
+): { bitrate: number; packetsLost: number } {
+  const report = Array.isArray(reports) ? reports[0] : undefined;
+  return {
+    bitrate: finiteNumber(pickField(report, "bitrate"), 0),
+    packetsLost: finiteNumber(pickField(report, "packetsLost"), 0),
+  };
+}
+
+/**
+ * Bounds a snapshot so an `ms:diag` reply can never approach MAX_FRAME_BYTES
+ * (256 KiB, index.ts) even in a room at the peer ceiling. Truncates the
+ * `room` array to `maxRoomPeers` entries and each entry's `producers` list to
+ * `maxProducersPerPeer`, oldest-kept-first (array order, unchanged) - the
+ * entries that remain stay a complete, undistorted view of the peers and
+ * producers they describe, rather than every entry being trimmed a little.
+ * `self.*` is never truncated: at most 2 transports and at most
+ * MAX_PRODUCERS_PER_PEER/MAX_CONSUMERS_PER_PEER entries, already bounded by
+ * index.ts's own ceilings.
+ */
+export function serializeSnapshot(
+  s: SfuSnapshot,
+  maxRoomPeers: number,
+  maxProducersPerPeer: number,
+): SfuSnapshot {
+  return {
+    ...s,
+    room: s.room.slice(0, maxRoomPeers).map((entry) => ({
+      ...entry,
+      producers: entry.producers.slice(0, maxProducersPerPeer),
+    })),
+  };
+}


### PR DESCRIPTION
Connection, peer and call bugs were undiagnosable after the fact. The detail already existed — a 17-variant `TransportStatus` union, three counter bags, per-peer WebRTC state — and every bit of it was destroyed within ten seconds (`TransportStatus.svelte` deletes each toast on a timer), reachable only through `window.__awful` in a DEV build, or swallowed in an empty `catch`.

Each tab now keeps a bounded flight recorder in memory, **always on from boot**. A bug is over by the time anyone thinks to flip a switch, so the switch is not on the recording — it is on every exit.

## The recorder

`frontend/src/lib/telemetry/`

- **`schema.ts`** freezes 112 `DiagKind` literals, a severity per kind, and a per-kind rate budget. Mirrored byte-for-byte into `dashboard/src/lib/schema.ts`, and its SFU view types a third time into `sfu/telemetry.ts`, exactly as the `ms:*` protocol is mirrored today.
- **`ring.ts`** is a 4096-event wraparound ring. Its per-kind throttle is what stops one hot kind evicting every rare event, and it emits a synthetic `meta.suppressed` so a reader holding only the events still sees the gap.
- **`event.ts`** — `ev()` never throws, for any input, in any state. It is called from inside `catch` blocks, from emitters and from a `finally`; a throw there would turn a diagnosable bug into an undiagnosable one. Tested against a circular object, a `Proxy` that throws on get, a `BigInt`, a 1 MB string.
- **`taps.ts`** adds one line inside each of the three buses' private `emit`. That is where the nine `TransportStatus` variants that reach no UI at all stop being discarded. About sixty hand-placed probes cover the sites where the information exists nowhere else: a silent `catch`, a `console.warn`, a bare `return`.

## Three gated exits, all off by default

| exit | gate | where |
| --- | --- | --- |
| disk | `diagPrefs.persist` | sealed chunks in a new `diagnostics` IndexedDB store — 3 sessions, 8 MB, never synced and never backed up |
| file | the Export button | `Settings → Diagnostics` writes `awful-diag-<id>.json` |
| network | `diagPrefs.upload` | `POST <apiUrl>/telemetry`, signed with the **device** libp2p key |

An Ed25519 peerId is an identity multihash, so the public key is inside it and the relay can check a signature against the claimed peerId. Signing with the identity key instead would hand the collector a `did:key → peerId` binding it must never learn.

Without `TELEMETRY_ENABLED=1` the relay answers 204, stores nothing, and the app hides its Upload button.

## Three vantages on one session

- **client** — the bundle above.
- **relay** (`relay/telemetry.go`) — a per-peer event ring, room refs as `HMAC(bootSecret, code)` under a secret that is never persisted, and its own view stapled onto an uploaded bundle. Its most valuable half is smaller than that: `readLoop` now carries its **real** exit reason into both the log line and the event, so a liveness timeout, an idle timeout and a clean close are no longer one indistinguishable message.
- **sfu** (`sfu/telemetry.ts`) — `ms:diag` returns a live snapshot of the requester's room. A dedicated `ms:diag-unavailable` frame refuses it, because an `ms:error` with no `direction` latches the client's whole session permanently. `SFU_TELEMETRY=1` also prints one structured line per room per sweep.

They are joined by peerId. No shared secret, no new wire message.

## The console

`dashboard/` — a new Svelte 5 + Vite app, **not deployed**. It merges the vantages into one clock-corrected timeline (`peer.clock` samples solved by least squares, and it says so when it has none), folds the topology over time with **directed** links so "A sees B, B never saw A" is visible, runs 29 deterministic rules that name what failed and where, and builds a prompt pack that asks a model why.

Every module under `analysis/` is pure with a `.test.ts` sibling; every rune lives in `sources.svelte.ts`; a `.svelte` file renders and nothing else. No `bits-ui`, no icon pack, no graph library — the Topology and Matrix views are hand-rolled SVG.

## Redaction, enforced by tests

A room code, a `did:key`, message or file content, an infoHash and an ICE candidate address have no field in the schema. A room becomes an ordinal, a file becomes an ordinal, a message becomes a byte length, an error becomes a name and a message with no stack (a stack carries local paths). peerIds stay whole: the relay and the SFU already have them.

`bundle.test.ts` is the gate for the whole feature — it feeds the recorder a real room code, a real `did:key:`, a chat payload and an infoHash through the paths that really carry them, then asserts none of the four strings survives serialization. `prompt.test.ts` applies the same gate to the console's own output.

`docs/spec.md`'s Server Privacy invariant is **amended**, because an upload makes it false otherwise.

## Three bugs the end-to-end capture found

All fixed here, and all of the class this proof exists to catch:

1. The relay's CORS preflight allowed neither `POST` nor the `x-awful-*` auth headers, so a cross-origin upload could never work — and the client could only report `Failed to fetch`.
2. `rendezvous-wedged` fired on every healthy registration, because a relay vantage records `rv.register` and never records `rv.peers`: the PEERS reply is something the relay sends, not something it logs.
3. `sync-stalled` emitted one finding per unanswered digest — thirty copies of one fact, burying every other rule.

Also fixes an SFU viewer-set over-report: `handlePeerLeft` never removed the departing peer from other peers' consumer sets, so the count grew after every disconnect. A telemetry snapshot must not lie.

## Clean cutover

`verifyIncoming` collapsed six distinct rejections into a bare `false`, so a dropped message could not be explained. It now returns a named reason. Every caller updated; no wrapper, no alias.

## Verification

| component | result |
| --- | --- |
| `frontend` | `pnpm check` 0 errors · 1127 tests · `pnpm build` ok · both CI env-leak guards pass |
| `relay` | `go vet ./...` clean · `go test -race -count=1` ok |
| `sfu` | `npx tsc --noEmit` clean · 15/15 |
| `dashboard` | `pnpm check` 0 errors · 219 tests · `pnpm build` ok |

CI gains a fifth job for the dashboard, carrying the frontend's own "no build-time env reads" guard. It is deliberately **not** in the `images` matrix: the console is not deployed.

### The proof is real data

`dashboard/src/lib/analysis/fixtures/` holds a real capture: two browser profiles, a real relay and SFU, `blockWebrtcDial` in one peer, one real message, both peers uploaded and read back through the operator endpoint. `e2e.test.ts` runs the whole pipeline over it, 34 assertions.

Half of them are must-not-fire guards — no `relay-unreachable` for a relay that answered, no `asymmetric-link` when both peers saw each other, no `sfu-*` or `voice-*` when neither ran. A console that invents a relay failure is worse than no console.

The relay log's room code is replaced by a placeholder; peer id suffixes are real, because they are what the suffix resolver is tested against. `fixtures/README.md` documents the capture, the one substitution, and how to regenerate it.

## Notes for review

- `RelayVantage.streams[].closedAt` / `closeReason` are always `null`: that array reports the peer's currently-open rendezvous streams, and a close is fully visible as an `rv.close` event instead. Flagged rather than silently reshaped.
- Two frontend suites (`files-announce`, `files-inline`) fail on node 25 with `localStorage.getItem is not a function` from `media-prefs.svelte.ts`. **Pre-existing and unrelated** — confirmed by stashing the only change to that import chain. CI runs node 24, where the global does not exist.
- The relay hardcodes `/app/data` for its key, which blocks a native local run on a read-only root. Not changed here; noted in `fixtures/README.md`.

Off by default end to end: a fresh checkout records in memory, writes nothing, uploads nothing, and its relay answers 204.