### PR TITLE
TURN: advertise the port coturn was given, and let the second port move too

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,16 @@ TURN_SECRET=
 # TURN realm. Defaults to DOMAIN.
 #TURN_REALM=
 
+# The two ports coturn LISTENS on. Both matter when a host runs more than one
+# stack: coturn is network_mode: host, so these are host-wide, and a second
+# stack that leaves either at its default collides with the first. The loser
+# does not start, and the symptom is remote and confusing - its relay keeps
+# minting credentials, they reach whichever coturn DID bind the port, and that
+# one rejects them with 401 because they were signed with another secret.
+# Move BOTH for a second stack, not just TURN_PORT.
+#TURN_PORT=3478
+#TURN_ALT_PORT=5349
+
 # TURN over TLS: certificate directory and the extra coturn args enabling it.
 # turns: on 5349 is what gets through restrictive mobile carriers. Without a
 # certificate those users have no working TURN transport at all.

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -244,7 +244,7 @@ services:
       --no-multicast-peers
       --no-tcp-relay
       --listening-port=${TURN_PORT:-3478}
-      --alt-listening-port=5349
+      --alt-listening-port=${TURN_ALT_PORT:-5349}
       --denied-peer-ip=${ANNOUNCED_IP}
       --denied-peer-ip=100.64.0.0-100.127.255.255
       --denied-peer-ip=10.0.0.0-10.255.255.255

--- a/relay/turn.go
+++ b/relay/turn.go
@@ -38,9 +38,21 @@ func defaultTurnURLs() []string {
 	if host == "" {
 		return nil
 	}
+	// TURN_PORT moves coturn (compose passes it to --listening-port), and
+	// this used to keep advertising 3478 regardless. The failure is silent
+	// and total: clients get credentials for a port coturn is not on, so
+	// gathering yields no relay candidate at all, while every health signal
+	// - the credential fetch included - still reports success. Worse on a
+	// host running two stacks, where 3478 belongs to whichever bound it
+	// first: the credentials then reach a DIFFERENT instance's coturn, which
+	// rejects them with 401 because it was minted with another secret.
+	port := strings.TrimSpace(os.Getenv("TURN_PORT"))
+	if port == "" {
+		port = "3478"
+	}
 	return []string{
-		"turn:" + host + ":3478?transport=udp",
-		"turn:" + host + ":3478?transport=tcp",
+		"turn:" + host + ":" + port + "?transport=udp",
+		"turn:" + host + ":" + port + "?transport=tcp",
 	}
 }
 

--- a/relay/turn_test.go
+++ b/relay/turn_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
@@ -251,5 +252,35 @@ func TestTurnCredentialsUsernameCarriesAPerClientID(t *testing.T) {
 	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
 	if c1 != want {
 		t.Fatalf("credential is not HMAC-SHA1 over the full username")
+	}
+}
+
+func TestDefaultTurnURLsUsesConfiguredPort(t *testing.T) {
+	t.Setenv("TURN_HOST", "")
+	t.Setenv("DOMAIN", "dev.example.chat")
+
+	// Unset: the long-standing default, which every existing deploy relies on.
+	t.Setenv("TURN_PORT", "")
+	got := defaultTurnURLs()
+	want := []string{
+		"turn:dev.example.chat:3478?transport=udp",
+		"turn:dev.example.chat:3478?transport=tcp",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("default port: got %v, want %v", got, want)
+	}
+
+	// Set: coturn has been moved, usually because another stack on the same
+	// host already owns 3478. Advertising 3478 anyway sends clients to that
+	// other instance's coturn, which rejects the credentials with 401 - and
+	// nothing in the app can tell that apart from "no TURN".
+	t.Setenv("TURN_PORT", "3479")
+	got = defaultTurnURLs()
+	want = []string{
+		"turn:dev.example.chat:3479?transport=udp",
+		"turn:dev.example.chat:3479?transport=tcp",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configured port: got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Two half-parameterized ports, and between them a TURN server that no client can use.

## What is broken

`TURN_PORT` moves coturn (compose passes it to `--listening-port`), but `relay/turn.go` hardcoded `:3478` in the URLs it mints. Clients are then handed credentials for a port coturn is not listening on. The failure is silent and total: gathering yields no relay candidate at all, while every signal anyone would check still reports success, because the credential *fetch* worked.

It is worse than nothing on a host running two stacks. coturn is `network_mode: host`, so `3478` belongs to whichever stack bound it first, and the second stack's users are sent to the *first* stack's coturn - which rejects them with `401`, because the credential was signed with a secret it has never seen.

`--alt-listening-port` was hardcoded at `5349` while only the main port was configurable, so two stacks cannot both be given a full set of ports.

## Evidence, from the dev deploy

`TURN_PORT=3479` is set and dev's coturn is healthy on it (`Default realm: dev.awful.chat`, relay ports initialised, no bind errors). Its users still have no TURN, because the relay advertises 3478 - and 3478 belongs to production:

```
UDP Allocate -> 31.97.90.100:3478   10/10 replies: 401, REALM "awful.chat"
UDP Allocate -> 31.97.90.100:3479    4/4 timeouts (dropped, not refused)
```

That stack's `DOMAIN` is `dev.awful.chat`, so production's coturn is answering for dev's clients and rejecting them. Every mobile, CGNAT and restrictive-network user on dev currently has no TURN at all.

## What this changes

- `relay/turn.go` derives the advertised port from `TURN_PORT`, defaulting to 3478, so nothing that works today changes. Tested for both the default and the configured case.
- `--alt-listening-port` takes `${TURN_ALT_PORT:-5349}`.
- `.env.example` says that a second stack has to move BOTH ports, and why the symptom is remote from the cause.

## What this does NOT fix

On dev, the advertised port is only half of it: **3479 is dropped at the firewall**, so pointing clients there does nothing until UDP and TCP 3479 (and the `TURN_MIN_PORT`-`TURN_MAX_PORT` relay range) are opened on the host. Deploying this without that change swaps one silent failure for another.

The `--alt-listening-port` change is hardening rather than a fix for the observed fault: dev's coturn never bound 5349 at all, because the TLS listeners do not start without a certificate.

## Verification

`go vet ./...` clean, `go test ./...` passes.

After deploy and a firewall change, a TURN Allocate to the configured port should answer with that stack's own realm instead of a `401` from another one.