### PR TITLE
TURN: hand the relay the TURN_PORT it reads

### DIFF
--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -40,6 +40,13 @@ services:
       # forwards neither UDP nor raw TCP, so TURN silently points at something
       # that cannot serve it and mobile/CGNAT peers just time out.
       - TURN_HOST=${TURN_HOST:-}
+      # The port coturn below was told to listen on. The relay builds its
+      # default TURN urls from it, and compose does NOT inject a variable into
+      # a container just because the .env defines it - so without this line
+      # TURN_PORT moves coturn while the relay keeps advertising 3478, and
+      # every client is sent to a port this stack is not on. On a host running
+      # two stacks that port belongs to the other one, which answers 401.
+      - TURN_PORT=${TURN_PORT:-}
       - TURN_URLS=${TURN_URLS:-}
       # Generic plugin proxy: allowlisted upstream hosts and named secrets
       # substituted server-side ({{secret:NAME}}). Bind secrets to their


### PR DESCRIPTION
Follow-up to #37, which was half a fix and measurably did nothing.

`relay/turn.go` now builds its TURN urls from `TURN_PORT`, but the relay service's `environment:` block never listed it. Compose uses `.env` for `${...}` interpolation; it does not inject a variable into a container just because the file defines one. So `os.Getenv("TURN_PORT")` came back empty and the default 3478 was used exactly as before.

The coturn side reads the same variable through interpolation into `command:`, which is why that half worked and hid this one.

## Measured on dev, after #37 deployed

```
GET https://dev-relay.awful.chat/turn-credentials
  -> turn:dev.awful.chat:3478?transport=udp   (unchanged)

UDP Allocate -> 31.97.90.100:3478   401, REALM "awful.chat"    (production's coturn)
UDP Allocate -> 31.97.90.100:3479   timeout                    (dev's coturn, firewalled)
```

coturn on dev is healthy - `Default realm: dev.awful.chat`, relay ports initialised, no bind errors - and its users still have no TURN.

## Still needed on the host, separately from this PR

3479 is dropped rather than refused, so even with the right port advertised nothing reaches it. Open on the VPS:

- UDP and TCP **3479** (`TURN_PORT`)
- UDP **50200-51199** (`TURN_MIN_PORT`-`TURN_MAX_PORT`) - without the relay range, allocations succeed and no media flows, which is the same silent failure one layer down

`go test ./...` passes.