### PR TITLE
lab: browsers in containers, on networks we control

### DIFF
--- a/frontend/e2e/driver.mjs
+++ b/frontend/e2e/driver.mjs
@@ -94,7 +94,7 @@ export class Peer {
       () => this.eval(`(() => {
         const t = document.body.innerText;
         if (/Welcome back/i.test(t)) return 'locked';
-        if (document.querySelector('input[placeholder="Room code or room link"]')) return 'ready';
+        if (document.querySelector('input[placeholder="Room code, short code or link"]')) return 'ready';
         if (document.querySelector('textarea')) return 'ready';
         if (/Create new identity/i.test(t)) return 'ready';
         return false;
@@ -236,7 +236,7 @@ export class Peer {
     await sleep(800);
     await this.clickText("skip for now");
     await this.waitFor("landing", () =>
-      this.eval(`!!document.querySelector('input[placeholder="Room code or room link"]')`));
+      this.eval(`!!document.querySelector('input[placeholder="Room code, short code or link"]')`));
     await this.clickText("Got it");
     return this;
   }
@@ -284,10 +284,10 @@ export class Peer {
     if (await this.eval(`!!window.__awful?.state.roomCode`)) {
       await this.clickLabel("Create or join room");
     }
-    await this.waitFor("join field", () => this.fill("Room code or room link", code));
+    await this.waitFor("join field", () => this.fill("Room code, short code or link", code));
     return this.waitFor(`room ${code}`, async () => {
       if ((await this.eval(`window.__awful?.state.roomCode`)) === code) return true;
-      await this.fill("Room code or room link", code);
+      await this.fill("Room code, short code or link", code);
       await this.clickText("Join Room");
       return false;
     });

--- a/frontend/e2e/scenarios/prod-smoke.mjs
+++ b/frontend/e2e/scenarios/prod-smoke.mjs
@@ -39,9 +39,9 @@ try {
   console.log("room:", code);
 
   // Bob joins by code through the UI.
-  await bob.waitFor("join field", () => bob.fill("Room code or room link", code));
+  await bob.waitFor("join field", () => bob.fill("Room code, short code or link", code));
   await bob.waitFor("room joined", async () => {
-    await bob.fill("Room code or room link", code);
+    await bob.fill("Room code, short code or link", code);
     await bob.clickText("Join Room");
     return bob.eval(`location.pathname.startsWith('/r/') ? true : null`);
   });

--- a/lab/.gitignore
+++ b/lab/.gitignore
@@ -1,0 +1,2 @@
+.app-url
+.relay-multiaddr

--- a/lab/.gitignore
+++ b/lab/.gitignore
@@ -1,2 +1,3 @@
 .app-url
 .relay-multiaddr
+captures/

--- a/lab/.gitignore
+++ b/lab/.gitignore
@@ -1,3 +1,4 @@
 .app-url
 .relay-multiaddr
 captures/
+reports/

--- a/lab/.gitignore.captures
+++ b/lab/.gitignore.captures
@@ -1,0 +1,1 @@
+captures/

--- a/lab/Dockerfile.netem
+++ b/lab/Dockerfile.netem
@@ -1,0 +1,9 @@
+# Network shaping for a browser container, run in that container's namespace.
+#
+# The browser image has neither tc nor iptables, and adding them to it would
+# mean maintaining a fork of an image whose only job is to be a browser. A
+# sidecar started with `--network container:<browser>` shares the same network
+# namespace, so `tc qdisc` here shapes exactly the interface the browser uses.
+FROM alpine:3.20
+RUN apk add --no-cache iproute2 iptables
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/lab/README.md
+++ b/lab/README.md
@@ -1,0 +1,141 @@
+# lab
+
+Browsers in containers, on networks we control, driving the real app.
+
+Two modes. The lab brings its own relay, SFU, coturn and frontend, or drives
+one you already deployed.
+
+```sh
+# Mode A - the lab's own stack, disposable and reproducible
+./stack.sh
+node scenarios/call-audio.mjs
+node matrix.mjs
+./down.sh
+
+# Mode B - a deployed instance, over the real internet
+./up.sh                                     # browsers only
+LAB_APP_URL=https://dev.awful.chat node scenarios/call-audio.mjs
+LAB_APP_URL=https://dev.awful.chat node matrix.mjs
+```
+
+Mode A synthesises the network with `tc netem`, which is what makes a finding
+reproducible. Mode B tests the real path: real DNS, real TLS, real TURN, real
+routing. Neither replaces the other, and a failure in B that passes in A is
+the deployment or the path to it.
+
+## Why this exists
+
+`frontend/e2e` drives real browsers and finds real bugs, but it cannot test the
+two things that break in production. Its own note says why:
+
+> NOT `v.links`: headless ICE never completes, so a link object is torn down
+> within a second of being built - `scenarios/call-join-speed.mjs`
+
+Every call test there asserts a counter: an offer was sent, a roster holds two
+names. A counter cannot tell a working call from a pair who cannot hear each
+other, and that pair is exactly what gets reported. Nothing in this repo had
+ever asserted that audio arrived.
+
+The lab does. `selfcheck.mjs` is the proof, and it runs against no app at all:
+two browsers, a real offer/answer, a real ICE handshake between two network
+namespaces, real Opus. If it fails, the lab is broken and every green run it
+prints is a lie - so ask it first.
+
+## The one question this answers
+
+Run the same scenario on a good network and a bad one:
+
+| result | reading |
+| --- | --- |
+| fails everywhere | the code - the network was never the reason |
+| fails only when impaired | the network, and the profile names which one |
+| passes everywhere | nothing to chase |
+
+`matrix.mjs` runs the profiles and prints that verdict. No per-event heuristic
+gets close to it, because the comparison controls for everything else.
+
+## Profiles
+
+`./impair.sh lab-browser-2 loss3` shapes ONE browser's uplink, from inside its
+own network namespace, so one peer is on a bad network and the others are not.
+
+| profile | what it is |
+| --- | --- |
+| `clean` | no shaping |
+| `loss3` | 3% loss - "it was breaking up" |
+| `loss15` | 15% loss - bad wifi |
+| `jitter` | 150ms +/- 60ms - mobile on a good day |
+| `slow` | 300ms, 500kbit |
+| `reorder` | 20ms with 10% reordering |
+| `udp-block` | everything but DNS: ICE must use TURN over TCP or fail |
+
+`netem` shapes egress only. Two peers each shaped on egress is a path degraded
+in both directions, which is the condition being tested; an ingress qdisc needs
+an ifb device and buys nothing here.
+
+## Things that are load-bearing, and were all found the hard way
+
+- **`--headless`, not `--headless=new`.** The new headless shell ignores
+  `--remote-debugging-address` and binds the debug port to loopback inside the
+  container, where nothing can reach it (Chromium 124).
+- **Browsers reach the app as `http://localhost:5173`**, resolved to the
+  frontend container by `--host-resolver-rules`. WebRTC and WebCrypto need a
+  secure context: on `http://172.30.0.12:5173`, `crypto.subtle` and
+  `navigator.mediaDevices` are simply absent, so the app cannot create an
+  identity, let alone open a microphone.
+  `--unsafely-treat-insecure-origin-as-secure` did not take effect here.
+  Chrome always trusts `localhost`, so the lab uses that - a real secure
+  context, with no security switches disabled.
+- **Static addresses.** The SFU must announce an address the browsers can
+  reach. `docker-compose.dev.yml` announces `127.0.0.1`, which is correct for a
+  developer's desktop browser and impossible for a browser in a container: it
+  would be handed its own loopback as the media address.
+- **Vite 7 answers 403** for a `Host` header outside `server.allowedHosts`, so
+  `http://frontend:5173` is refused while the same server answers for
+  `localhost` and for its IP.
+- **coturn allows this lab's subnet back in.** Production denies relaying to
+  RFC1918 ranges and the lab lives inside 172.16/12, so without that one
+  `--allowed-peer-ip` every relayed candidate is useless and `udp-block`
+  "fails" for a reason that exists only in the lab. Every other private range
+  stays denied, as it ships.
+
+## What a scenario asserts
+
+`scenarios/call-audio.mjs` drives the real UI - sign up, create a room, join
+it, join the call - and then asserts the only thing that matters: bytes
+arrived, both ways, and are still arriving. A count that is merely non-zero
+can be a stream that died ten seconds ago.
+
+It reads the connections themselves. A shim installed before any page script
+captures every `RTCPeerConnection` the app builds, and `getStats()` is read
+across all of them. `window.__awful` cannot be the source: that handle is
+`import.meta.env.DEV` only, so it does not exist on a deployed build, which is
+where the interesting failures are. The same shim records uncaught throws, and
+a scenario fails on any of them - nothing in the app is supposed to reach the
+window.
+
+The UI flows are ported from `frontend/e2e/driver.mjs`. Those selectors were
+paid for with a day of tests that failed for harness reasons, and the rules
+they encode - no fixed sleeps, wipe storage first, retry a click until the
+state changes - apply here unchanged.
+
+## What it has found
+
+Ordered by how hard each would have been to find any other way.
+
+- **TURN was dead on the dev deployment.** Three independent breaks, none
+  visible from inside the app: the relay advertised a hardcoded port while
+  coturn had been moved, the port variable never reached the relay container,
+  and the firewall rejected the new port. Every client fetched credentials
+  successfully and then gathered no relay candidate at all, so every health
+  signal read green. Users on mobile, CGNAT or a restrictive network had no
+  voice, and nothing said so.
+- **Every Chromium user in a relayed call was told it was direct.**
+  `RTCIceCandidatePairStats` carries no candidate type in Chrome; the app read
+  one off the pair and got `undefined`. Firefox does expose it inline, which is
+  why it survived - the one engine `frontend/e2e` drives was the one where the
+  old code was right.
+- **`frontend/e2e` could not join a room.** Six references to a placeholder the
+  UI had renamed.
+
+Two of those three are in code that had passing tests.

--- a/lab/capture.mjs
+++ b/lab/capture.mjs
@@ -13,14 +13,19 @@ import { mkdirSync, writeFileSync } from "node:fs";
 
 const DIR = new URL("./captures/", import.meta.url).pathname;
 
+/** Capture even when a run passed. A failing bundle means little without one
+ *  from a healthy run beside it - "roomPeerCount is 0 when it breaks" is only
+ *  evidence if it is 1 when it works. */
+const ALWAYS = process.env.LAB_CAPTURE_ALWAYS === "1";
+
 export async function captureOnFailure(scenario, peers, failures) {
-  if (failures.length === 0) return null;
+  if (failures.length === 0 && !ALWAYS) return null;
   try {
     mkdirSync(DIR, { recursive: true });
   } catch {
     return null;
   }
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const stamp = `${new Date().toISOString().replace(/[:.]/g, "-")}-${failures.length === 0 ? "PASS" : "FAIL"}`;
   const saved = [];
   for (const peer of peers) {
     let json = null;

--- a/lab/capture.mjs
+++ b/lab/capture.mjs
@@ -1,0 +1,51 @@
+/**
+ * Save the app's own flight recorder from every peer, when a run fails.
+ *
+ * A failing scenario proves something is wrong and says nothing about where.
+ * The bundle carries the client's view - every producer announced, every
+ * consume attempted, every one that failed - so the next question after "the
+ * late joiner received no video" is answerable without another run.
+ *
+ * Written next to the run rather than uploaded: these contain peer ids and
+ * session detail, and the lab should not quietly ship them anywhere.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const DIR = new URL("./captures/", import.meta.url).pathname;
+
+export async function captureOnFailure(scenario, peers, failures) {
+  if (failures.length === 0) return null;
+  try {
+    mkdirSync(DIR, { recursive: true });
+  } catch {
+    return null;
+  }
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const saved = [];
+  for (const peer of peers) {
+    let json = null;
+    try {
+      json = await peer.captureDiagBundle();
+    } catch {
+      json = null;
+    }
+    if (!json) continue;
+    const file = `${DIR}${stamp}-${scenario}-${peer.name}.json`;
+    try {
+      writeFileSync(file, json);
+      saved.push(file);
+    } catch {
+      // A capture that cannot be written is not worth failing a run over.
+    }
+  }
+  if (saved.length > 0) {
+    console.log(`\ndiagnostics captured:\n  ${saved.join("\n  ")}`);
+    console.log("  (load these in dashboard/ to see what the client actually did)");
+  } else {
+    console.log(
+      "\ndiagnostics NOT captured: this build has no Diagnostics pane, or it" +
+        " could not be reached. The failure above still stands."
+    );
+  }
+  return saved;
+}

--- a/lab/cdp.mjs
+++ b/lab/cdp.mjs
@@ -1,0 +1,184 @@
+/**
+ * A Chrome DevTools Protocol client, small enough to read in one sitting.
+ *
+ * The e2e harness next door speaks WebDriver BiDi to Firefox. The lab speaks
+ * CDP to Chrome for one reason: Firefox headless never completes an ICE
+ * handshake in that harness (see the note in `e2e/scenarios/call-join-speed.mjs`),
+ * so every voice and SFU test it has asserts signalling counters and never
+ * once asserts that audio arrived. A lab that cannot carry media cannot test
+ * the two things that break in production.
+ */
+
+const CDP_TIMEOUT_MS = 30_000;
+
+export class Cdp {
+  #ws = null;
+  #id = 0;
+  #pending = new Map();
+  #sessionId = null;
+
+  constructor(port, host = "127.0.0.1") {
+    this.port = port;
+    this.host = host;
+  }
+
+  /** Find the browser's websocket, then attach to its first page target. */
+  async open() {
+    const res = await fetch(`http://${this.host}:${this.port}/json/version`);
+    const { webSocketDebuggerUrl } = await res.json();
+    this.#ws = new WebSocket(webSocketDebuggerUrl);
+    this.#ws.addEventListener("message", (e) => this.#onMessage(e));
+    await new Promise((resolve, reject) => {
+      this.#ws.addEventListener("open", resolve, { once: true });
+      this.#ws.addEventListener("error", reject, { once: true });
+    });
+
+    const { targetInfos } = await this.send("Target.getTargets");
+    const page = targetInfos.find((t) => t.type === "page");
+    if (!page) throw new Error("no page target");
+    const { sessionId } = await this.send("Target.attachToTarget", {
+      targetId: page.targetId,
+      flatten: true,
+    });
+    this.#sessionId = sessionId;
+    await this.send("Runtime.enable");
+    await this.send("Page.enable");
+    // Headless defaults to 800x600, which is a phone as far as this app's
+    // layout is concerned: the member list and half the call controls never
+    // render, and a scenario then "cannot see" a peer who is present. Desktop
+    // is what the flows were written against.
+    await this.send("Emulation.setDeviceMetricsOverride", {
+      width: 1600,
+      height: 1000,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+    return this;
+  }
+
+  #onMessage(e) {
+    const msg = JSON.parse(e.data);
+    if (!msg.id) return; // an event, not a reply
+    const waiting = this.#pending.get(msg.id);
+    if (!waiting) return;
+    this.#pending.delete(msg.id);
+    if (msg.error) waiting.reject(new Error(JSON.stringify(msg.error).slice(0, 400)));
+    else waiting.resolve(msg.result);
+  }
+
+  send(method, params = {}) {
+    const id = ++this.#id;
+    const frame = { id, method, params };
+    // Every call after the attach is scoped to the page session.
+    if (this.#sessionId && method !== "Target.attachToTarget") {
+      frame.sessionId = this.#sessionId;
+    }
+    this.#ws.send(JSON.stringify(frame));
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(new Error(`CDP timeout: ${method}`));
+      }, CDP_TIMEOUT_MS);
+      this.#pending.set(id, {
+        resolve: (v) => (clearTimeout(timer), resolve(v)),
+        reject: (e) => (clearTimeout(timer), reject(e)),
+      });
+    });
+  }
+
+  /**
+   * Capture every RTCPeerConnection the page creates, before it creates any.
+   *
+   * The lab must be able to say whether audio ARRIVED, and the only honest
+   * source for that is the connection itself. `window.__awful` cannot be it:
+   * that handle is `import.meta.env.DEV` only, so it does not exist on any
+   * deployed build - which is precisely where the interesting failures are.
+   * Wrapping the constructor needs no cooperation from the app, works
+   * identically on a dev server and on production, and is the same trick the
+   * app's own PeerConnection census uses.
+   */
+  async installPcCapture() {
+    await this.send("Page.addScriptToEvaluateOnNewDocument", {
+      source: `(() => {
+        if (window.__labPcs) return;
+        const Native = window.RTCPeerConnection;
+        if (typeof Native !== "function") return;
+        const list = [];
+        window.__labPcs = list;
+        class Captured extends Native {
+          constructor(...args) {
+            super(...args);
+            try { list.push(this); } catch (e) {}
+          }
+        }
+        window.RTCPeerConnection = Captured;
+        // Uncaught throws too, from the same shim and for the same reason: on
+        // a deployed build there is no app handle to read them from, and an
+        // exception nobody caught is the most valuable event in a run.
+        window.__labErrs = [];
+        addEventListener("error", (e) => {
+          try { window.__labErrs.push(String((e.error && e.error.message) || e.message)); } catch (x) {}
+        });
+        addEventListener("unhandledrejection", (e) => {
+          try {
+            const r = e.reason;
+            window.__labErrs.push("rejection: " + String((r && r.message) || r));
+          } catch (x) {}
+        });
+      })()`,
+    });
+  }
+
+  async goto(url) {
+    await this.send("Page.navigate", { url });
+    // Wait for the document rather than a fixed sleep, the same rule the e2e
+    // driver follows: a slow container makes a run slower, not wrong.
+    await this.waitFor("document ready", `document.readyState === "complete"`);
+  }
+
+  /**
+   * Evaluate an expression and return its value. Promises are awaited, so a
+   * caller can hand this an async IIFE and get the resolved value back.
+   */
+  async eval(expression) {
+    const { result, exceptionDetails } = await this.send("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (exceptionDetails) {
+      const text =
+        exceptionDetails.exception?.description ??
+        exceptionDetails.text ??
+        "page threw";
+      throw new Error(String(text).slice(0, 500));
+    }
+    return result.value;
+  }
+
+  /** Poll an expression until it is truthy. No fixed sleeps anywhere. */
+  async waitFor(label, expression, { timeout = 30_000, interval = 250 } = {}) {
+    const deadline = Date.now() + timeout;
+    let last;
+    for (;;) {
+      try {
+        last = await this.eval(expression);
+        if (last) return last;
+      } catch (err) {
+        last = `threw: ${err.message}`;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`timed out waiting for ${label} (last: ${JSON.stringify(last)?.slice(0, 200)})`);
+      }
+      await new Promise((r) => setTimeout(r, interval));
+    }
+  }
+
+  close() {
+    try {
+      this.#ws?.close();
+    } catch {
+      // Nothing left to do about it.
+    }
+  }
+}

--- a/lab/cdp.mjs
+++ b/lab/cdp.mjs
@@ -130,10 +130,21 @@ export class Cdp {
   }
 
   async goto(url) {
-    await this.send("Page.navigate", { url });
+    const res = await this.send("Page.navigate", { url });
     // Wait for the document rather than a fixed sleep, the same rule the e2e
     // driver follows: a slow container makes a run slower, not wrong.
     await this.waitFor("document ready", `document.readyState === "complete"`);
+    // A navigation that failed leaves the browser on chrome-error://, where
+    // every later step fails in some unrelated way - the first symptom was a
+    // localStorage exception three calls downstream. Chrome does not always
+    // set errorText, so the URL is checked too. This must be loud: a target
+    // that did not load is not a fault in the app being tested.
+    const landed = await this.eval(`location.href`);
+    if (res.errorText || String(landed).startsWith("chrome-error://")) {
+      throw new Error(
+        `UNREACHABLE: ${url} did not load (${res.errorText ?? landed})`
+      );
+    }
   }
 
   /**

--- a/lab/docker-compose.lab.yml
+++ b/lab/docker-compose.lab.yml
@@ -1,0 +1,122 @@
+# The lab's own stack: the whole app on one network the browsers can reach.
+#
+# Not `docker-compose.dev.yml` with browsers bolted on. That file publishes
+# ports to the host and tells the SFU to announce 127.0.0.1, which is correct
+# for a developer with a browser on their desktop and impossible for a browser
+# in a container: it would be handed its OWN loopback as the media address and
+# every ICE check would fail against itself. Static addresses on a private
+# subnet are what make the SFU announceable, and they make a run reproducible
+# on any host, which a lab needs more than convenience.
+#
+# DOMAIN is deliberately unset: the relay's origin gate is strict only when
+# DOMAIN is set or NODE_ENV is production (relay/cors.go), so the lab's
+# http://frontend:5173 origin is accepted without weakening anything that
+# ships.
+name: awful-lab
+
+services:
+  relay:
+    image: awful2-relay:latest
+    build:
+      context: ../relay
+      dockerfile: Dockerfile.dev
+    environment:
+      NODE_ENV: development
+      HTTP_PORT: "8080"
+      KLIPY_API_KEY: dev-key
+      # The lab's whole point is bundles that can be read back, so both the
+      # ingest endpoint and the operator read endpoints are on.
+      TELEMETRY_ENABLED: "1"
+      TELEMETRY_ADMIN_TOKEN: ${LAB_ADMIN_TOKEN:-lab}
+      # Shared with coturn below. Without it the relay answers 204, the client
+      # stays STUN-only, and the udp-block profile tests nothing at all - the
+      # peer simply has no path, which is the lab failing rather than the app.
+      TURN_SECRET: ${LAB_TURN_SECRET:-lab-turn-secret}
+      TURN_HOST: "172.30.0.13"
+    volumes:
+      - lab_relay_data:/app/data
+      - ../relay:/app
+    ports:
+      # Published so the controller on the host can pull bundles back out.
+      - "127.0.0.1:18081:8081"
+    networks:
+      lab:
+        ipv4_address: 172.30.0.10
+
+  sfu:
+    image: awful2-sfu:latest
+    build:
+      context: ../sfu
+    environment:
+      NODE_ENV: development
+      SFU_PORT: "3000"
+      # The address the browsers must actually reach. This is the line the
+      # dev compose cannot get right.
+      ANNOUNCED_IP: "172.30.0.11"
+      RTC_MIN_PORT: "40000"
+      RTC_MAX_PORT: "40019"
+      SFU_TELEMETRY: "1"
+    networks:
+      lab:
+        ipv4_address: 172.30.0.11
+
+  coturn:
+    image: coturn/coturn:4.17.2-alpine
+    # One deliberate deviation from the production flags, and it has to be
+    # said out loud: prod denies relaying to RFC1918 ranges, and the lab's own
+    # subnet is inside 172.16/12. Denying it here would make every relayed
+    # candidate useless and the udp-block profile would "fail" for a reason
+    # that exists only in the lab. The one range this lab uses is allowed back
+    # in; every other private range stays denied, exactly as it ships.
+    command: >
+      --log-file=stdout
+      --realm=lab
+      --external-ip=172.30.0.13
+      --listening-ip=0.0.0.0
+      --use-auth-secret
+      --static-auth-secret=${LAB_TURN_SECRET:-lab-turn-secret}
+      --fingerprint
+      --no-multicast-peers
+      --no-tcp-relay
+      --listening-port=3478
+      --allowed-peer-ip=172.30.0.0-172.30.0.255
+      --denied-peer-ip=10.0.0.0-10.255.255.255
+      --denied-peer-ip=192.168.0.0-192.168.255.255
+      --denied-peer-ip=127.0.0.0-127.255.255.255
+      --denied-peer-ip=169.254.0.0-169.254.255.255
+      --min-port=49152
+      --max-port=49200
+    networks:
+      lab:
+        ipv4_address: 172.30.0.13
+
+  frontend:
+    image: awful2-frontend:latest
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile.dev
+    environment:
+      # Service names, not localhost: these are resolved by the BROWSER, and
+      # the browser is in a container on this network.
+      VITE_API_URL: http://relay:8081
+      VITE_SFU_URL: http://sfu:3000
+      # Written by stack.sh once the relay has reported its identity.
+      VITE_RELAY_MULTIADDR: ${LAB_RELAY_MULTIADDR:?run ./stack.sh, which discovers this}
+    volumes:
+      - ../frontend:/app
+      - /app/node_modules
+    depends_on:
+      - relay
+    networks:
+      lab:
+        ipv4_address: 172.30.0.12
+
+volumes:
+  lab_relay_data:
+
+networks:
+  lab:
+    name: awful-lab
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/lab/down.sh
+++ b/lab/down.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Stop everything the lab started. Leaves images and the relay's identity
+# volume alone, so the next `stack.sh` is fast and the peer id is unchanged.
+set -u
+cd "$(dirname "$0")"
+docker rm -f lab-page $(docker ps -aq --filter "name=lab-browser-") >/dev/null 2>&1
+LAB_RELAY_MULTIADDR=placeholder docker compose -f docker-compose.lab.yml down >/dev/null 2>&1
+echo "lab down"

--- a/lab/impair.sh
+++ b/lab/impair.sh
@@ -62,9 +62,16 @@ case "$PROFILE" in
     # first is what makes this profile test ICE rather than DNS.
     run "iptables -A OUTPUT -o lo -j ACCEPT; iptables -A OUTPUT -p udp --dport 53 -j ACCEPT; iptables -A OUTPUT -p udp -j DROP"
     ;;
+  blackout)
+    # Everything except loopback: the tab keeps running, its network is gone.
+    # A tunnel, a lift, a wifi handover. The question this profile asks is not
+    # whether a call survives the outage - it cannot - but whether it comes
+    # back afterwards, which is repair logic rather than setup logic.
+    run "iptables -A OUTPUT -o lo -j ACCEPT; iptables -A OUTPUT -j DROP"
+    ;;
   *)
     echo "unknown profile: $PROFILE" >&2
-    echo "profiles: clean loss3 loss15 jitter slow reorder udp-block" >&2
+    echo "profiles: clean loss3 loss15 jitter slow reorder udp-block blackout" >&2
     exit 2
     ;;
 esac

--- a/lab/impair.sh
+++ b/lab/impair.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Shape one browser's network, from inside its own namespace.
+#
+#   ./impair.sh lab-browser-2 loss3      # 3% loss, both directions
+#   ./impair.sh lab-browser-2 clean      # back to normal
+#
+# Each profile is a network a real user actually has. The point is never to
+# break a call - it is to run the SAME scenario on a good network and a bad
+# one, because a finding that appears in both is the code and a finding that
+# only appears on the bad one is the network. That comparison is the only
+# reliable way to answer "is it my internet or your app", and no amount of
+# per-event cleverness substitutes for it.
+set -u
+CONTAINER="${1:?usage: impair.sh <container> <profile>}"
+PROFILE="${2:?usage: impair.sh <container> <profile>}"
+IFACE="${LAB_IFACE:-eth0}"
+
+run() {
+  docker run --rm --network "container:$CONTAINER" --cap-add=NET_ADMIN \
+    lab-netem:latest "$1"
+}
+
+# netem shapes egress only. Ingress needs an ifb device, which is more moving
+# parts than this needs: two peers each shaped on egress produces a path that
+# is degraded in both directions, which is the condition being tested.
+case "$PROFILE" in
+  clean)
+    run "tc qdisc del dev $IFACE root 2>/dev/null; iptables -F OUTPUT 2>/dev/null; true"
+    ;;
+  loss3)
+    # Enough to hurt audio, far short of a disconnect: the shape users
+    # describe as "it was breaking up" rather than "the call dropped".
+    run "tc qdisc replace dev $IFACE root netem loss 3%"
+    ;;
+  loss15)
+    run "tc qdisc replace dev $IFACE root netem loss 15%"
+    ;;
+  jitter)
+    # Mobile on a good day: latency that moves, which is what actually
+    # defeats a jitter buffer.
+    run "tc qdisc replace dev $IFACE root netem delay 150ms 60ms distribution normal"
+    ;;
+  slow)
+    run "tc qdisc replace dev $IFACE root netem delay 300ms rate 500kbit"
+    ;;
+  reorder)
+    run "tc qdisc replace dev $IFACE root netem delay 20ms reorder 10% 50%"
+    ;;
+  udp-block)
+    # Everything but DNS. A blanket UDP drop also kills name resolution, which
+    # stops the browser reaching the relay at all - that is a broken lab, not a
+    # corporate firewall, and it fails so early that nothing about ICE is
+    # tested. Real restrictive networks permit 53 and drop the rest, so ICE
+    # must fall back to TURN over TCP or fail.
+    #
+    # `--dport 53` alone is NOT enough, and the way it fails is silent. Docker
+    # runs its embedded resolver behind a DNAT in the container's own
+    # namespace: 127.0.0.11:53 is rewritten to a high port by nat/OUTPUT,
+    # which runs BEFORE filter/OUTPUT, so the rule below never sees port 53
+    # and every lookup is dropped. The browser then cannot resolve the relay
+    # and the run looks like a connectivity bug in the app. Accepting loopback
+    # first is what makes this profile test ICE rather than DNS.
+    run "iptables -A OUTPUT -o lo -j ACCEPT; iptables -A OUTPUT -p udp --dport 53 -j ACCEPT; iptables -A OUTPUT -p udp -j DROP"
+    ;;
+  *)
+    echo "unknown profile: $PROFILE" >&2
+    echo "profiles: clean loss3 loss15 jitter slow reorder udp-block" >&2
+    exit 2
+    ;;
+esac
+echo "$CONTAINER: $PROFILE"

--- a/lab/matrix.mjs
+++ b/lab/matrix.mjs
@@ -1,0 +1,89 @@
+/**
+ * Run one scenario across every network, and read the answer off the table.
+ *
+ * This is the whole point of the lab. A single run tells you a call failed; it
+ * cannot tell you why, and neither can any amount of per-event cleverness. The
+ * same scenario on a good network and a bad one can:
+ *
+ *   fails everywhere            -> the code. The network was never the reason.
+ *   fails only when impaired    -> the network, and the profile names which
+ *                                 impairment it cannot survive.
+ *   passes everywhere           -> nothing to chase here today.
+ *
+ * That comparison is worth more than any single verdict, because it is the
+ * question a user actually asks: is it me or is it the app.
+ *
+ *   node matrix.mjs                       # the default profiles
+ *   node matrix.mjs clean loss15          # only these
+ */
+import { spawn } from "node:child_process";
+
+const PROFILES = process.argv.slice(2).length
+  ? process.argv.slice(2)
+  : ["clean", "jitter", "loss3", "loss15", "udp-block"];
+const SCENARIO = process.env.LAB_SCENARIO ?? "scenarios/call-audio.mjs";
+
+const run = (profile) =>
+  new Promise((resolve) => {
+    const started = Date.now();
+    const child = spawn(process.execPath, [SCENARIO], {
+      env: { ...process.env, LAB_IMPAIR: profile },
+      cwd: new URL(".", import.meta.url).pathname,
+    });
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (out += d));
+    child.on("close", (code) => {
+      const failed = [...out.matchAll(/^FAIL (.+?)(?: \{|$)/gm)].map((m) => m[1]);
+      // Scraped from the scenario's own summary line. This used to look for
+      // "relayed: alice=true", which the scenario has never printed, so the
+      // column read false in every run - including the ones that were
+      // genuinely relayed through TURN. A diagnostic that quietly reports the
+      // wrong answer is worse than one that reports nothing.
+      const relayed = /relayed: (true|false)\/(true|false)/.exec(out);
+      const anyRelayed = relayed ? relayed[1] === "true" || relayed[2] === "true" : false;
+      resolve({
+        profile,
+        ok: code === 0,
+        failed,
+        relayed: anyRelayed,
+        seconds: Math.round((Date.now() - started) / 1000),
+        out,
+      });
+    });
+  });
+
+const results = [];
+for (const profile of PROFILES) {
+  process.stdout.write(`running ${profile}... `);
+  const r = await run(profile);
+  console.log(`${r.ok ? "pass" : "FAIL"} (${r.seconds}s)`);
+  results.push(r);
+}
+
+console.log("\n profile      result  relayed  failed");
+console.log(" ------------------------------------------------------");
+for (const r of results) {
+  console.log(
+    ` ${r.profile.padEnd(12)} ${(r.ok ? "pass" : "FAIL").padEnd(7)} ${String(r.relayed).padEnd(8)} ${r.failed.join(", ")}`
+  );
+}
+
+// The reading, spelled out, so nobody has to remember the rule.
+const failures = results.filter((r) => !r.ok);
+const clean = results.find((r) => r.profile === "clean");
+console.log("");
+if (failures.length === 0) {
+  console.log("VERDICT: healthy on every network tested.");
+} else if (clean && !clean.ok) {
+  console.log(
+    "VERDICT: CODE. It fails on a clean network, so no network condition is the cause."
+  );
+} else {
+  console.log(
+    `VERDICT: NETWORK-DEPENDENT. Only these profiles fail: ${failures
+      .map((f) => f.profile)
+      .join(", ")}. The app survives a clean network, so this is what it cannot survive.`
+  );
+}
+process.exit(failures.length === 0 ? 0 : 1);

--- a/lab/matrix.mjs
+++ b/lab/matrix.mjs
@@ -16,7 +16,28 @@
  *   node matrix.mjs                       # the default profiles
  *   node matrix.mjs clean loss15          # only these
  */
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
+import { EXIT_ENVIRONMENT } from "./preflight.mjs";
+
+/**
+ * Fresh browsers before every profile.
+ *
+ * `frontend/e2e/run-all.sh` learned this first and wrote it down: "scenarios
+ * that pass in isolation failed partway through a long run - which reads as an
+ * app bug and is not one". A profile that inherits the previous one's browser
+ * state is measuring the run order as much as the app.
+ */
+function restartBrowsers() {
+  try {
+    execFileSync(new URL("./up.sh", import.meta.url).pathname, [], {
+      stdio: "ignore",
+      timeout: 120_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const PROFILES = process.argv.slice(2).length
   ? process.argv.slice(2)
@@ -35,6 +56,7 @@ const run = (profile) =>
     child.stderr.on("data", (d) => (out += d));
     child.on("close", (code) => {
       const failed = [...out.matchAll(/^FAIL (.+?)(?: \{|$)/gm)].map((m) => m[1]);
+      const environment = code === EXIT_ENVIRONMENT;
       // Scraped from the scenario's own summary line. This used to look for
       // "relayed: alice=true", which the scenario has never printed, so the
       // column read false in every run - including the ones that were
@@ -45,6 +67,7 @@ const run = (profile) =>
       resolve({
         profile,
         ok: code === 0,
+        environment,
         failed,
         relayed: anyRelayed,
         seconds: Math.round((Date.now() - started) / 1000),
@@ -56,28 +79,63 @@ const run = (profile) =>
 const results = [];
 for (const profile of PROFILES) {
   process.stdout.write(`running ${profile}... `);
-  const r = await run(profile);
-  console.log(`${r.ok ? "pass" : "FAIL"} (${r.seconds}s)`);
+  restartBrowsers();
+  let r = await run(profile);
+  // One retry before calling it a failure. A single run is a sample, not a
+  // measurement, and a flake reported as a finding costs someone an afternoon
+  // reading code that was never wrong.
+  if (!r.ok && !r.environment) {
+    process.stdout.write("retry... ");
+    restartBrowsers();
+    const again = await run(profile);
+    if (again.ok) again.flaky = true;
+    r = again.ok ? again : r;
+  }
+  console.log(
+    `${r.environment ? "ENVIRONMENT" : r.ok ? (r.flaky ? "pass (flaky)" : "pass") : "FAIL"} (${r.seconds}s)`
+  );
   results.push(r);
 }
 
 console.log("\n profile      result  relayed  failed");
 console.log(" ------------------------------------------------------");
 for (const r of results) {
+  const state = r.environment ? "env" : r.ok ? (r.flaky ? "flaky" : "pass") : "FAIL";
   console.log(
-    ` ${r.profile.padEnd(12)} ${(r.ok ? "pass" : "FAIL").padEnd(7)} ${String(r.relayed).padEnd(8)} ${r.failed.join(", ")}`
+    ` ${r.profile.padEnd(12)} ${state.padEnd(7)} ${String(r.relayed).padEnd(8)} ${r.failed.join(", ")}`
   );
 }
 
 // The reading, spelled out, so nobody has to remember the rule.
-const failures = results.filter((r) => !r.ok);
-const clean = results.find((r) => r.profile === "clean");
+const env = results.filter((r) => r.environment);
+const tested = results.filter((r) => !r.environment);
+const failures = tested.filter((r) => !r.ok);
+const clean = tested.find((r) => r.profile === "clean");
 console.log("");
-if (failures.length === 0) {
-  console.log("VERDICT: healthy on every network tested.");
+if (env.length > 0) {
+  console.log(
+    `INCONCLUSIVE for ${env.map((r) => r.profile).join(", ")}: never reached an` +
+      " assertion because the target or the lab was unavailable. Not a claim" +
+      " about the app."
+  );
+}
+if (tested.length === 0) {
+  // Saying "healthy" here is how a harness earns distrust: nothing ran.
+  console.log("VERDICT: none. Nothing was actually tested.");
+} else if (failures.length === 0) {
+  console.log(
+    `VERDICT: healthy on ${tested.map((r) => r.profile).join(", ")}.` +
+      (env.length > 0 ? " The rest were not tested." : "")
+  );
 } else if (clean && !clean.ok) {
   console.log(
     "VERDICT: CODE. It fails on a clean network, so no network condition is the cause."
+  );
+} else if (!clean) {
+  console.log(
+    `VERDICT: fails on ${failures.map((f) => f.profile).join(", ")}, but "clean"` +
+      " was not among the profiles tested, so this cannot yet be separated from" +
+      " a fault that fails everywhere. Re-run including clean."
   );
 } else {
   console.log(
@@ -86,4 +144,4 @@ if (failures.length === 0) {
       .join(", ")}. The app survives a clean network, so this is what it cannot survive.`
   );
 }
-process.exit(failures.length === 0 ? 0 : 1);
+process.exit(failures.length === 0 && env.length === 0 ? 0 : 1);

--- a/lab/pages/blank.html
+++ b/lab/pages/blank.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>lab</title>
+<p>lab origin</p>

--- a/lab/peer.mjs
+++ b/lab/peer.mjs
@@ -277,4 +277,70 @@ export class LabPeer extends Cdp {
       `window.__awful ? JSON.stringify(window.__awful.diag()) : "null"`
     ).then(JSON.parse);
   }
+
+  /**
+   * The app's OWN flight recorder for this session, as JSON.
+   *
+   * When a scenario fails, "the lab saw no video" and "here is why" are still
+   * far apart. This closes that gap: the bundle carries the client's view of
+   * every producer announced, every consume attempted and every one that
+   * failed, so a failing run stops being merely reproducible and becomes
+   * diagnosable.
+   *
+   * It drives Settings -> Diagnostics -> Export, the same path a user would,
+   * so it works on a DEPLOYED build where `window.__awful` does not exist.
+   * The export normally hands the browser a download; instead the Blob is
+   * intercepted at URL.createObjectURL and read in the page, which needs no
+   * download directory, no file plumbing and no container round trip.
+   *
+   * Returns null when the pane is not there - an instance built before the
+   * recorder shipped, or one where the feature is off. A capture that cannot
+   * happen must not turn a real finding into a harness error.
+   */
+  async captureDiagBundle() {
+    try {
+      await this.eval(`(() => {
+        if (window.__labBlobs) return true;
+        window.__labBlobs = [];
+        const orig = URL.createObjectURL.bind(URL);
+        URL.createObjectURL = (blob) => {
+          try { window.__labBlobs.push(blob); } catch (e) {}
+          return orig(blob);
+        };
+        return true;
+      })()`);
+
+      const opened = await this.waitFor(
+        "settings open",
+        `(() => {
+          if ([...document.querySelectorAll('button')].some((b) => /Export bundle/i.test(b.textContent))) return "diagnostics";
+          const diag = [...document.querySelectorAll('button')].find((b) => b.textContent.trim() === 'Diagnostics');
+          if (diag) { diag.click(); return null; }
+          const settings = [...document.querySelectorAll('button')]
+            .find((b) => (b.getAttribute('aria-label') || '') === 'Settings');
+          if (settings) { settings.click(); return null; }
+          return null;
+        })()`,
+        { timeout: 20_000 }
+      ).catch(() => null);
+      if (!opened) return null;
+
+      const json = await this.eval(`(async () => {
+        const btn = [...document.querySelectorAll('button')]
+          .find((b) => /Export bundle/i.test(b.textContent));
+        if (!btn) return null;
+        window.__labBlobs.length = 0;
+        btn.click();
+        // The click builds the bundle synchronously and hands it straight to
+        // createObjectURL, but give the frame a beat rather than assume.
+        await new Promise((r) => setTimeout(r, 750));
+        const blob = window.__labBlobs[window.__labBlobs.length - 1];
+        return blob ? await blob.text() : null;
+      })()`);
+      return json;
+    } catch {
+      // Diagnosis is a bonus; it must never become the reason a run fails.
+      return null;
+    }
+  }
 }

--- a/lab/peer.mjs
+++ b/lab/peer.mjs
@@ -1,0 +1,290 @@
+/**
+ * One browser, driving the real app.
+ *
+ * The UI flows are ported from `frontend/e2e/driver.mjs` rather than
+ * reinvented: those selectors were paid for with a day of tests that failed
+ * for harness reasons, and every rule they encode still applies here. What is
+ * new is below the flows - this peer can be asked whether audio actually
+ * ARRIVED, which is the one question the Firefox harness cannot answer.
+ */
+import { Cdp } from "./cdp.mjs";
+
+const PASSWORD = "lab-password";
+
+export class LabPeer extends Cdp {
+  constructor(port, name, appUrl) {
+    super(port);
+    this.name = name;
+    this.appUrl = appUrl;
+  }
+
+  async start({ wipe = true } = {}) {
+    await this.open();
+    // Before the first navigation: a connection built earlier than this is
+    // invisible for the rest of the run.
+    await this.installPcCapture();
+    await this.goto(`${this.appUrl}/app`);
+    if (wipe) {
+      // A PWA serves the previous run's bundle otherwise, and the run then
+      // measures code that is no longer in the repo.
+      await this.eval(`(async () => {
+        if (navigator.serviceWorker) {
+          const regs = await navigator.serviceWorker.getRegistrations();
+          await Promise.all(regs.map((r) => r.unregister()));
+        }
+        if (window.caches) {
+          const keys = await caches.keys();
+          await Promise.all(keys.map((k) => caches.delete(k)));
+        }
+        localStorage.clear();
+        const dbs = await indexedDB.databases();
+        await Promise.all(dbs.map((d) => new Promise((res) => {
+          const req = indexedDB.deleteDatabase(d.name);
+          req.onsuccess = req.onerror = req.onblocked = () => res();
+        })));
+        return true;
+      })()`);
+      await this.goto(`${this.appUrl}/app`);
+    }
+    return this;
+  }
+
+  clickText(text) {
+    return this.eval(`(() => {
+      const b = [...document.querySelectorAll('button')]
+        .find((x) => x.textContent.trim().toLowerCase().includes(${JSON.stringify(text.toLowerCase())}));
+      if (b) b.click();
+      return !!b;
+    })()`);
+  }
+
+  clickLabel(label) {
+    return this.eval(`(() => {
+      const b = [...document.querySelectorAll('button')]
+        .find((x) => (x.getAttribute('aria-label') || '') === ${JSON.stringify(label)});
+      if (b) b.click();
+      return !!b;
+    })()`);
+  }
+
+  fill(placeholder, value) {
+    return this.eval(`(() => {
+      const el = document.querySelector('input[placeholder=' + ${JSON.stringify(JSON.stringify(placeholder))} + ']');
+      if (!el) return false;
+      const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      set.call(el, ${JSON.stringify(value)});
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    })()`);
+  }
+
+  async signUp(displayName) {
+    await this.waitFor("app shell", `!!document.querySelector('button')`);
+    await this.clickText("Got it");
+    await this.waitFor("identity screen", `(() => {
+      const b = [...document.querySelectorAll('button')].find((x) => /create new identity/i.test(x.textContent));
+      if (b) b.click();
+      return !!b;
+    })()`);
+    await this.waitFor("password field", `(() => {
+      const el = document.querySelector('input[placeholder*="password" i]');
+      if (!el) return false;
+      const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      for (const input of document.querySelectorAll('input[type=password]')) {
+        set.call(input, ${JSON.stringify(PASSWORD)});
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+      return true;
+    })()`);
+    await this.clickText("create identity");
+    await this.waitFor("mnemonic acknowledged", `(() => {
+      const btn = [...document.querySelectorAll('button')].find((x) => /ready/i.test(x.textContent));
+      if (btn && !btn.disabled) return true;
+      const box = document.querySelector('[role=checkbox]') || document.querySelector('input[type=checkbox]');
+      if (box) box.click();
+      return false;
+    })()`);
+    await this.clickText("ready");
+    await this.waitFor("profile step", `(() => {
+      const el = document.querySelector('input[placeholder="Your display name"]');
+      if (!el) return false;
+      const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      set.call(el, ${JSON.stringify(displayName)});
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    })()`);
+    await this.clickText("done");
+    await this.waitFor("past the biometric step", `(() => {
+      if (document.querySelector('input[placeholder="Room code, short code or link"]')) return true;
+      const b = [...document.querySelectorAll('button')].find((x) => /skip for now/i.test(x.textContent));
+      if (b) b.click();
+      return false;
+    })()`);
+    await this.clickText("Got it");
+    return this;
+  }
+
+  async createRoom(name) {
+    await this.waitFor("create form", `(() => {
+      const el = document.querySelector('input[placeholder="Room name (optional)"]');
+      if (!el) return false;
+      const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      set.call(el, ${JSON.stringify(name)});
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    })()`);
+    await this.waitFor("room created", `(() => {
+      if (/Share this code/i.test(document.body.innerText)) return true;
+      const b = [...document.querySelectorAll('button')].find((x) => /create room/i.test(x.textContent));
+      if (b) b.click();
+      return false;
+    })()`);
+    // The URL is the room, on every build. window.__awful is DEV-only and is
+    // simply absent on a deployed instance.
+    return this.waitFor("room entered", `(() => {
+      const m = location.pathname.match(/^\\/r\\/([^/]+)/);
+      if (m) return decodeURIComponent(m[1]);
+      const b = [...document.querySelectorAll('button')].find((x) => /join room/i.test(x.textContent));
+      if (b) b.click();
+      return null;
+    })()`);
+  }
+
+  async joinRoom(code) {
+    await this.waitFor("join field", `(() => {
+      const el = document.querySelector('input[placeholder="Room code, short code or link"]');
+      if (!el) return false;
+      const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      set.call(el, ${JSON.stringify(code)});
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    })()`);
+    return this.waitFor(`room ${code}`, `(() => {
+      if (location.pathname.toUpperCase().includes(${JSON.stringify(code.toUpperCase())})) return true;
+      const b = [...document.querySelectorAll('button')].find((x) => /join room/i.test(x.textContent));
+      if (b) b.click();
+      return false;
+    })()`, { timeout: 60_000 });
+  }
+
+  /**
+   * The three helpers below read `window.__awful`, which exists only in a DEV
+   * build. They return null against a deployed instance rather than throwing,
+   * so a scenario can use them for extra detail without becoming Mode A only.
+   */
+  selfId() {
+    return this.eval(`window.__awful ? window.__awful.selfId() : null`);
+  }
+
+  voice() {
+    return this.eval(
+      `window.__awful ? JSON.stringify(window.__awful.voice()) : "null"`
+    ).then(JSON.parse);
+  }
+
+  async joinCall() {
+    // "Leave call" only exists once the call is joined, on every build.
+    await this.waitFor("in call", `(() => {
+      const has = (label) => [...document.querySelectorAll('button')]
+        .some((x) => (x.getAttribute('aria-label') || '') === label);
+      if (has('Leave call')) return true;
+      const b = [...document.querySelectorAll('button')]
+        .find((x) => (x.getAttribute('aria-label') || '') === 'Join call');
+      if (b) b.click();
+      return false;
+    })()`, { timeout: 60_000 });
+    return this;
+  }
+
+  /**
+   * Did audio actually arrive at this browser?
+   *
+   * Read from every RTCPeerConnection the page built, so it needs no app
+   * handle and works against a deployed build. Bytes are summed across
+   * connections: which one carries the voice is an implementation detail, and
+   * "any audio at all" is the question a listener would ask.
+   */
+  media() {
+    return this.eval(`(async () => {
+      const out = { pcs: 0, live: 0, audioBytes: 0, relayed: false, path: null, rtt: null };
+      for (const pc of (window.__labPcs || [])) {
+        out.pcs++;
+        if (pc.connectionState === "closed") continue;
+        out.live++;
+        let stats;
+        try { stats = await pc.getStats(); } catch (e) { continue; }
+        const cands = {};
+        let best = null;
+        for (const r of stats.values()) {
+          if (r.type === "inbound-rtp" && r.kind === "audio") out.audioBytes += (r.bytesReceived || 0);
+          if (r.type === "local-candidate" || r.type === "remote-candidate") cands[r.id] = r;
+          if (r.type === "candidate-pair" && r.state === "succeeded" && (!best || r.nominated)) best = r;
+        }
+        if (best) {
+          const t = (inline, id) => inline || (cands[id] && cands[id].candidateType) || "?";
+          const l = t(best.localCandidateType, best.localCandidateId);
+          const rm = t(best.remoteCandidateType, best.remoteCandidateId);
+          if (!out.path) {
+            out.path = l + "/" + rm;
+            out.rtt = Math.round((best.currentRoundTripTime || 0) * 1000);
+          }
+          if (l === "relay" || rm === "relay") out.relayed = true;
+        }
+      }
+      return JSON.stringify(out);
+    })()`).then(JSON.parse);
+  }
+
+  /** The recorder's whole ring, which is how the lab reads media truth. */
+  diag() {
+    return this.eval(
+      `window.__awful ? JSON.stringify(window.__awful.diag()) : "null"`
+    ).then(JSON.parse);
+  }
+
+  /**
+   * Did audio actually arrive at this browser?
+   *
+   * Read from every RTCPeerConnection the page built, so it needs no app
+   * handle and works against a deployed build. Bytes are summed across
+   * connections: which one carries the voice is an implementation detail, and
+   * "any audio at all" is the question a listener would ask.
+   */
+  media() {
+    return this.eval(`(async () => {
+      const out = { pcs: 0, live: 0, audioBytes: 0, relayed: false, path: null, rtt: null };
+      for (const pc of (window.__labPcs || [])) {
+        out.pcs++;
+        if (pc.connectionState === "closed") continue;
+        out.live++;
+        let stats;
+        try { stats = await pc.getStats(); } catch (e) { continue; }
+        const cands = {};
+        let best = null;
+        for (const r of stats.values()) {
+          if (r.type === "inbound-rtp" && r.kind === "audio") out.audioBytes += (r.bytesReceived || 0);
+          if (r.type === "local-candidate" || r.type === "remote-candidate") cands[r.id] = r;
+          if (r.type === "candidate-pair" && r.state === "succeeded" && (!best || r.nominated)) best = r;
+        }
+        if (best) {
+          const t = (inline, id) => inline || (cands[id] && cands[id].candidateType) || "?";
+          const l = t(best.localCandidateType, best.localCandidateId);
+          const rm = t(best.remoteCandidateType, best.remoteCandidateId);
+          if (!out.path) {
+            out.path = l + "/" + rm;
+            out.rtt = Math.round((best.currentRoundTripTime || 0) * 1000);
+          }
+          if (l === "relay" || rm === "relay") out.relayed = true;
+        }
+      }
+      return JSON.stringify(out);
+    })()`).then(JSON.parse);
+  }
+
+  /** The recorder's whole ring, which is how the lab reads media truth. */
+  diag() {
+    return this.eval(
+      `window.__awful ? JSON.stringify(window.__awful.diag()) : "null"`
+    ).then(JSON.parse);
+  }
+}

--- a/lab/peer.mjs
+++ b/lab/peer.mjs
@@ -197,16 +197,24 @@ export class LabPeer extends Cdp {
   }
 
   /**
-   * Did audio actually arrive at this browser?
+   * Did media actually arrive at this browser, and over what path?
    *
    * Read from every RTCPeerConnection the page built, so it needs no app
-   * handle and works against a deployed build. Bytes are summed across
-   * connections: which one carries the voice is an implementation detail, and
-   * "any audio at all" is the question a listener would ask.
+   * handle and works against a deployed build. Audio and video are counted
+   * SEPARATELY and their paths reported separately, because they do not
+   * travel together: voice is peer to peer, and camera and screen share go
+   * through the SFU on a different connection entirely. A single "is media
+   * flowing" number would hide the case where one works and the other does
+   * not, which is the case worth catching.
    */
   media() {
     return this.eval(`(async () => {
-      const out = { pcs: 0, live: 0, audioBytes: 0, relayed: false, path: null, rtt: null };
+      const out = {
+        pcs: 0, live: 0,
+        audioBytes: 0, videoBytes: 0,
+        relayed: false, path: null, rtt: null,
+        videoPath: null, videoRelayed: false, videoProto: null,
+      };
       for (const pc of (window.__labPcs || [])) {
         out.pcs++;
         if (pc.connectionState === "closed") continue;
@@ -214,74 +222,56 @@ export class LabPeer extends Cdp {
         let stats;
         try { stats = await pc.getStats(); } catch (e) { continue; }
         const cands = {};
-        let best = null;
+        let best = null, audio = 0, video = 0;
         for (const r of stats.values()) {
-          if (r.type === "inbound-rtp" && r.kind === "audio") out.audioBytes += (r.bytesReceived || 0);
+          if (r.type === "inbound-rtp" && r.kind === "audio") audio += (r.bytesReceived || 0);
+          if (r.type === "inbound-rtp" && r.kind === "video") video += (r.bytesReceived || 0);
           if (r.type === "local-candidate" || r.type === "remote-candidate") cands[r.id] = r;
           if (r.type === "candidate-pair" && r.state === "succeeded" && (!best || r.nominated)) best = r;
         }
+        out.audioBytes += audio;
+        out.videoBytes += video;
+        let path = null, relayed = false, proto = null;
         if (best) {
           const t = (inline, id) => inline || (cands[id] && cands[id].candidateType) || "?";
           const l = t(best.localCandidateType, best.localCandidateId);
           const rm = t(best.remoteCandidateType, best.remoteCandidateId);
-          if (!out.path) {
-            out.path = l + "/" + rm;
-            out.rtt = Math.round((best.currentRoundTripTime || 0) * 1000);
-          }
-          if (l === "relay" || rm === "relay") out.relayed = true;
+          path = l + "/" + rm;
+          relayed = l === "relay" || rm === "relay";
+          // The TRANSPORT, which a candidate type does not tell you. Under
+          // udp-block this is the whole claim: media reached us over TCP.
+          const lc = cands[best.localCandidateId];
+          proto = (lc && lc.protocol) || null;
+        }
+        // Attribute the path to the connection that carried each kind, so a
+        // relayed voice link next to a direct SFU link reads correctly.
+        if (path && !out.path) { out.path = path; out.rtt = Math.round((best.currentRoundTripTime || 0) * 1000); }
+        if (path && relayed) out.relayed = true;
+        if (video > 0 && path) {
+          out.videoPath = path;
+          out.videoRelayed = relayed;
+          out.videoProto = proto;
         }
       }
       return JSON.stringify(out);
     })()`).then(JSON.parse);
   }
 
-  /** The recorder's whole ring, which is how the lab reads media truth. */
-  diag() {
-    return this.eval(
-      `window.__awful ? JSON.stringify(window.__awful.diag()) : "null"`
-    ).then(JSON.parse);
+  /** Turn the camera on and wait until the app agrees that it is on. */
+  async startCamera() {
+    await this.waitFor("camera on", `(() => {
+      const btn = (label) => [...document.querySelectorAll('button')]
+        .find((x) => (x.getAttribute('aria-label') || '') === label);
+      if (btn('Turn off camera')) return true;   // label flips once it is on
+      const on = btn('Turn on camera');
+      if (on && !on.disabled) on.click();
+      return false;
+    })()`, { timeout: 60_000 });
+    return this;
   }
 
-  /**
-   * Did audio actually arrive at this browser?
-   *
-   * Read from every RTCPeerConnection the page built, so it needs no app
-   * handle and works against a deployed build. Bytes are summed across
-   * connections: which one carries the voice is an implementation detail, and
-   * "any audio at all" is the question a listener would ask.
-   */
-  media() {
-    return this.eval(`(async () => {
-      const out = { pcs: 0, live: 0, audioBytes: 0, relayed: false, path: null, rtt: null };
-      for (const pc of (window.__labPcs || [])) {
-        out.pcs++;
-        if (pc.connectionState === "closed") continue;
-        out.live++;
-        let stats;
-        try { stats = await pc.getStats(); } catch (e) { continue; }
-        const cands = {};
-        let best = null;
-        for (const r of stats.values()) {
-          if (r.type === "inbound-rtp" && r.kind === "audio") out.audioBytes += (r.bytesReceived || 0);
-          if (r.type === "local-candidate" || r.type === "remote-candidate") cands[r.id] = r;
-          if (r.type === "candidate-pair" && r.state === "succeeded" && (!best || r.nominated)) best = r;
-        }
-        if (best) {
-          const t = (inline, id) => inline || (cands[id] && cands[id].candidateType) || "?";
-          const l = t(best.localCandidateType, best.localCandidateId);
-          const rm = t(best.remoteCandidateType, best.remoteCandidateId);
-          if (!out.path) {
-            out.path = l + "/" + rm;
-            out.rtt = Math.round((best.currentRoundTripTime || 0) * 1000);
-          }
-          if (l === "relay" || rm === "relay") out.relayed = true;
-        }
-      }
-      return JSON.stringify(out);
-    })()`).then(JSON.parse);
-  }
-
-  /** The recorder's whole ring, which is how the lab reads media truth. */
+  /** The recorder's whole ring. Null on a deployed build, which has no
+   *  `__awful` handle - see the note on selfId above. */
   diag() {
     return this.eval(
       `window.__awful ? JSON.stringify(window.__awful.diag()) : "null"`

--- a/lab/preflight.mjs
+++ b/lab/preflight.mjs
@@ -1,0 +1,66 @@
+/**
+ * Is the lab and its target healthy enough for a result to mean anything?
+ *
+ * Written the moment the matrix printed "VERDICT: CODE. It fails on a clean
+ * network" for five profiles in a row, because the target had blipped. Every
+ * run had aborted before reaching a single assertion, and the table said the
+ * app was broken. A harness that blames the code for its own network trouble
+ * is worse than no harness: it sends someone to read source that was never
+ * involved.
+ *
+ * So a run now has three outcomes, not two. PASS and FAIL are claims about the
+ * app. ENVIRONMENT is a claim about the lab, and it must never be reported as
+ * either of the other two.
+ */
+import { Cdp } from "./cdp.mjs";
+
+export const EXIT_ENVIRONMENT = 3;
+
+/**
+ * The target answers and serves the app, seen from a lab browser - not from
+ * this host, whose network path is a different one.
+ */
+export async function targetIsReachable(port, appUrl, { attempts = 3 } = {}) {
+  const probe = new Cdp(port);
+  try {
+    await probe.open();
+    let last = "";
+    for (let i = 1; i <= attempts; i++) {
+      try {
+        await probe.goto(`${appUrl}/app`);
+        // The app shell, not merely a 200: a captive portal, a maintenance
+        // page and a 404 all load happily.
+        await probe.waitFor(
+          "app shell",
+          `document.querySelectorAll('button').length > 0 || null`,
+          { timeout: 45_000 }
+        );
+        return { ok: true, attempts: i };
+      } catch (err) {
+        // A browser that started seconds ago fails its FIRST external
+        // resolution and succeeds on the next - measured, repeatedly, right
+        // after up.sh. Declaring the environment dead on one cold attempt
+        // turned every profile in a matrix run into ENVIRONMENT.
+        last = err.message.slice(0, 200);
+        if (i < attempts) await new Promise((r) => setTimeout(r, 3000));
+      }
+    }
+    return { ok: false, why: `${last} (after ${attempts} attempts)` };
+  } catch (err) {
+    return { ok: false, why: err.message.slice(0, 200) };
+  } finally {
+    probe.close();
+  }
+}
+
+/** Exit with the ENVIRONMENT code and say so, or return and let the run go on. */
+export async function requireReachableTarget(port, appUrl) {
+  const seen = await targetIsReachable(port, appUrl);
+  if (seen.ok) return;
+  console.log(`ENVIRONMENT ${appUrl} is not serving the app: ${seen.why}`);
+  console.log(
+    "Nothing was tested. This is not a result about the app - it is the lab" +
+      " or the target being unavailable."
+  );
+  process.exit(EXIT_ENVIRONMENT);
+}

--- a/lab/scenarios/call-audio.mjs
+++ b/lab/scenarios/call-audio.mjs
@@ -15,6 +15,7 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { LabPeer } from "../peer.mjs";
+import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
 
 // Mode A points at the lab's own stack (./stack.sh writes .app-url); Mode B
 // points at a deployed instance:
@@ -52,6 +53,10 @@ const ok = (cond, label, extra) => {
 impair("lab-browser-1", "clean");
 impair("lab-browser-2", IMPAIR === "clean" ? "clean" : IMPAIR);
 console.log(`network: peer1=clean peer2=${IMPAIR}`);
+
+// Before anything is impaired or asserted: if the target is not serving the
+// app, this run has no claim to make about it.
+await requireReachableTarget(PORTS[0], APP);
 
 const alice = new LabPeer(PORTS[0], "Alice", APP);
 const bob = new LabPeer(PORTS[1], "Bob", APP);
@@ -129,6 +134,15 @@ try {
     ok(errs.length === 0, `${peer.name}: no uncaught errors`, errs);
   }
 } catch (err) {
+  // An unreachable target mid-run is the environment, not the app - the same
+  // distinction preflight makes, applied to a blip that lands after it.
+  if (/UNREACHABLE/.test(err.message)) {
+    console.log(`ENVIRONMENT ${err.message}`);
+    alice.close();
+    bob.close();
+    impair("lab-browser-2", "clean");
+    process.exit(EXIT_ENVIRONMENT);
+  }
   // Without this the matrix shows a bare FAIL with no reason, and its verdict
   // speaks as though the assertions had run and disagreed.
   ok(false, `aborted: ${err.message}`);

--- a/lab/scenarios/call-audio.mjs
+++ b/lab/scenarios/call-audio.mjs
@@ -1,0 +1,142 @@
+/**
+ * Two people join a call and can actually hear each other.
+ *
+ * This is the assertion the repo has never had. Every existing call test
+ * asserts a counter - an offer was sent, a roster holds two names - because
+ * headless Firefox never completes ICE there. A counter cannot tell a working
+ * call from a deaf pair, and a deaf pair is precisely what users report.
+ *
+ *   node scenarios/call-audio.mjs            # both peers on a clean network
+ *   LAB_IMPAIR=loss3 node scenarios/call-audio.mjs   # peer 2 on a bad one
+ *
+ * Run it twice, clean and impaired, and compare: a failure in both is the
+ * code, a failure only when impaired is the network.
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { LabPeer } from "../peer.mjs";
+
+// Mode A points at the lab's own stack (./stack.sh writes .app-url); Mode B
+// points at a deployed instance:
+//   LAB_APP_URL=https://dev.awful.chat node scenarios/call-audio.mjs
+function appUrl() {
+  if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
+  try {
+    return readFileSync(new URL("../.app-url", import.meta.url), "utf8").trim();
+  } catch {
+    console.error(
+      "No app to drive. Either run ./stack.sh for the lab's own stack, or set\n" +
+        "LAB_APP_URL=https://your-instance to drive a deployed one."
+    );
+    process.exit(2);
+  }
+}
+const APP = appUrl();
+const PORTS = (process.env.LAB_PORTS ?? "9331,9332").split(",").map(Number);
+const IMPAIR = process.env.LAB_IMPAIR ?? "clean";
+/** Audio must arrive within this long after both are in the call. */
+const AUDIO_DEADLINE_MS = Number(process.env.LAB_AUDIO_DEADLINE_MS ?? 45_000);
+
+const impair = (container, profile) =>
+  execFileSync(new URL("../impair.sh", import.meta.url).pathname, [container, profile], {
+    encoding: "utf8",
+  }).trim();
+
+const fail = [];
+const ok = (cond, label, extra) => {
+  console.log(`${cond ? "PASS" : "FAIL"} ${label}${extra === undefined ? "" : ` ${JSON.stringify(extra)}`}`);
+  if (!cond) fail.push(label);
+};
+
+// Always start from a known network, whatever the last run left behind.
+impair("lab-browser-1", "clean");
+impair("lab-browser-2", IMPAIR === "clean" ? "clean" : IMPAIR);
+console.log(`network: peer1=clean peer2=${IMPAIR}`);
+
+const alice = new LabPeer(PORTS[0], "Alice", APP);
+const bob = new LabPeer(PORTS[1], "Bob", APP);
+
+try {
+  await alice.start();
+  await bob.start();
+  await alice.signUp("Alice");
+  await bob.signUp("Bob");
+
+  const room = await alice.createRoom("lab");
+  console.log(`room: ${room}`);
+  await bob.joinRoom(room);
+
+  // The other person, in the app's own user list. That list is COLLAPSED by
+  // default, which is why a name never appears in the page text until it is
+  // opened - three earlier versions of this check called a healthy mesh a
+  // failure for that reason alone.
+  //
+  // Deliberately not a live RTCPeerConnection: with UDP blocked libp2p reaches
+  // the peer over the circuit relay and builds none. Deliberately not
+  // prod-smoke.mjs's "1 peer", which this UI has stopped saying.
+  for (const [peer, otherName] of [[alice, "Bob"], [bob, "Alice"]]) {
+    await peer.waitFor(
+      `${peer.name} sees ${otherName} in the user list`,
+      `(() => {
+        const txt = document.body.innerText;
+        if (/\\bUSERS\\b/.test(txt)) return txt.includes(${JSON.stringify(otherName)}) || null;
+        const b = [...document.querySelectorAll('button')]
+          .find((x) => (x.getAttribute('aria-label') || '') === 'Toggle user list');
+        if (b) b.click();
+        return null;
+      })()`,
+      { timeout: 90_000 }
+    );
+  }
+  ok(true, "mesh formed");
+
+  await alice.joinCall();
+  await bob.joinCall();
+  ok(true, "both in the call");
+
+  // Now the only thing that matters: audio that ARRIVED, and is still
+  // arriving. A byte count that is merely non-zero can be a stream that died
+  // ten seconds ago, so require it to GROW across a sample.
+  const first = { alice: await alice.media(), bob: await bob.media() };
+  await new Promise((r) => setTimeout(r, 5000));
+  let heard = { alice: null, bob: null };
+  const deadline = Date.now() + AUDIO_DEADLINE_MS;
+  for (;;) {
+    heard = { alice: await alice.media(), bob: await bob.media() };
+    const growing =
+      heard.alice.audioBytes > first.alice.audioBytes &&
+      heard.bob.audioBytes > first.bob.audioBytes;
+    if (growing || Date.now() > deadline) break;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  ok(heard.alice.audioBytes > first.alice.audioBytes, "Alice hears Bob", heard.alice);
+  ok(heard.bob.audioBytes > first.bob.audioBytes, "Bob hears Alice", heard.bob);
+
+  // Relayed or not is what makes a verdict attributable: a call that only
+  // works through TURN is a different report from one that never connects.
+  console.log(
+    `path: alice=${heard.alice.path} bob=${heard.bob.path}` +
+      `  relayed: ${heard.alice.relayed}/${heard.bob.relayed}` +
+      `  rtt: ${heard.alice.rtt}ms/${heard.bob.rtt}ms` +
+      `  pcs: ${heard.alice.live}/${heard.alice.pcs} and ${heard.bob.live}/${heard.bob.pcs}`
+  );
+
+  // An uncaught throw in either tab is a fact worth failing on, whatever else
+  // happened: nothing in the app is supposed to reach the window.
+  for (const peer of [alice, bob]) {
+    const errs = await peer.eval(`JSON.stringify((window.__labErrs || []).slice(0, 5))`).then(JSON.parse);
+    ok(errs.length === 0, `${peer.name}: no uncaught errors`, errs);
+  }
+} catch (err) {
+  // Without this the matrix shows a bare FAIL with no reason, and its verdict
+  // speaks as though the assertions had run and disagreed.
+  ok(false, `aborted: ${err.message}`);
+} finally {
+  alice.close();
+  bob.close();
+  impair("lab-browser-2", "clean");
+}
+
+console.log(fail.length === 0 ? "\nSCENARIO PASSED" : `\nSCENARIO FAILED: ${fail.join(", ")}`);
+process.exit(fail.length === 0 ? 0 : 1);

--- a/lab/scenarios/call-audio.mjs
+++ b/lab/scenarios/call-audio.mjs
@@ -16,6 +16,7 @@ import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { LabPeer } from "../peer.mjs";
 import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
+import { captureOnFailure } from "../capture.mjs";
 
 // Mode A points at the lab's own stack (./stack.sh writes .app-url); Mode B
 // points at a deployed instance:
@@ -147,6 +148,8 @@ try {
   // speaks as though the assertions had run and disagreed.
   ok(false, `aborted: ${err.message}`);
 } finally {
+  // Before the tabs are closed: the recorder lives in the page.
+  await captureOnFailure("audio", [alice, bob], fail);
   alice.close();
   bob.close();
   impair("lab-browser-2", "clean");

--- a/lab/scenarios/call-late-join.mjs
+++ b/lab/scenarios/call-late-join.mjs
@@ -19,6 +19,7 @@ import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { LabPeer } from "../peer.mjs";
 import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
+import { captureOnFailure } from "../capture.mjs";
 
 function appUrl() {
   if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
@@ -133,6 +134,8 @@ try {
   }
   ok(false, `aborted: ${err.message}`);
 } finally {
+  // Before the tabs are closed: the recorder lives in the page.
+  await captureOnFailure("late-join", [alice, bob], fail);
   alice.close();
   bob.close();
   impair("lab-browser-2", "clean");

--- a/lab/scenarios/call-late-join.mjs
+++ b/lab/scenarios/call-late-join.mjs
@@ -1,0 +1,142 @@
+/**
+ * Someone joins a call that is already running, and sees what is already there.
+ *
+ * This is the join-replay path, and it is where the worst SFU bug of the week
+ * lived: two consumes for one producer made the server answer with the same
+ * consumer id and mid, the duplicate media section made the browser reject the
+ * whole offer, and from then on NO remote stream could ever be added again -
+ * the receive transport was dead for the rest of the call. A late joiner is
+ * who exercises it, because every producer already exists when they arrive and
+ * all of them arrive at once, in a replay.
+ *
+ * The other scenarios cannot reach it: there, both peers join an empty call
+ * and each producer is announced live, one at a time.
+ *
+ *   node scenarios/call-late-join.mjs
+ *   LAB_APP_URL=https://dev.awful.chat node scenarios/call-late-join.mjs
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { LabPeer } from "../peer.mjs";
+import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
+
+function appUrl() {
+  if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
+  try {
+    return readFileSync(new URL("../.app-url", import.meta.url), "utf8").trim();
+  } catch {
+    console.error("No app to drive: run ./stack.sh, or set LAB_APP_URL.");
+    process.exit(2);
+  }
+}
+
+const APP = appUrl();
+const PORTS = (process.env.LAB_PORTS ?? "9331,9332").split(",").map(Number);
+const IMPAIR = process.env.LAB_IMPAIR ?? "clean";
+const DEADLINE_MS = Number(process.env.LAB_DEADLINE_MS ?? 60_000);
+
+const impair = (c, p) =>
+  execFileSync(new URL("../impair.sh", import.meta.url).pathname, [c, p], {
+    encoding: "utf8",
+  }).trim();
+
+const fail = [];
+const ok = (cond, label, extra) => {
+  console.log(`${cond ? "PASS" : "FAIL"} ${label}${extra === undefined ? "" : ` ${JSON.stringify(extra)}`}`);
+  if (!cond) fail.push(label);
+};
+
+const seesOther = (otherName) => `(() => {
+  const txt = document.body.innerText;
+  if (/\\bUSERS\\b/.test(txt)) return txt.includes(${JSON.stringify(otherName)}) || null;
+  const b = [...document.querySelectorAll('button')]
+    .find((x) => (x.getAttribute('aria-label') || '') === 'Toggle user list');
+  if (b) b.click();
+  return null;
+})()`;
+
+impair("lab-browser-1", "clean");
+impair("lab-browser-2", IMPAIR === "clean" ? "clean" : IMPAIR);
+console.log(`network: host=clean latecomer=${IMPAIR}`);
+
+await requireReachableTarget(PORTS[0], APP);
+
+const alice = new LabPeer(PORTS[0], "Alice", APP);
+const bob = new LabPeer(PORTS[1], "Bob", APP);
+
+try {
+  await alice.start();
+  await bob.start();
+  await alice.signUp("Alice");
+  await bob.signUp("Bob");
+
+  const room = await alice.createRoom("lab-late");
+  console.log(`room: ${room}`);
+  await bob.joinRoom(room);
+
+  for (const [peer, other] of [[alice, "Bob"], [bob, "Alice"]]) {
+    await peer.waitFor(`${peer.name} sees ${other}`, seesOther(other), { timeout: 90_000 });
+  }
+  ok(true, "mesh formed");
+
+  // Alice is alone in the call with a camera on, so everything she publishes
+  // exists BEFORE Bob arrives. That is the whole point.
+  await alice.joinCall();
+  await alice.startCamera();
+  ok(true, "Alice is in the call with her camera on");
+
+  // Let the producers settle, so Bob's arrival is a replay rather than a race
+  // with the live announcement.
+  await new Promise((r) => setTimeout(r, 5000));
+
+  await bob.joinCall();
+  ok(true, "Bob joined the call late");
+
+  const first = await bob.media();
+  let seen = first;
+  const deadline = Date.now() + DEADLINE_MS;
+  for (;;) {
+    seen = await bob.media();
+    const gotVideo = seen.videoBytes > first.videoBytes + 5000;
+    const gotAudio = seen.audioBytes > first.audioBytes;
+    if ((gotVideo && gotAudio) || Date.now() > deadline) break;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  // The camera was published before Bob existed, so this can only have come
+  // from the replay.
+  ok(
+    seen.videoBytes > first.videoBytes + 5000,
+    "the late joiner receives the camera that was already live",
+    { videoBytes: seen.videoBytes, videoPath: seen.videoPath, videoProto: seen.videoProto }
+  );
+  ok(seen.audioBytes > first.audioBytes, "the late joiner hears the call", {
+    audioBytes: seen.audioBytes,
+  });
+
+  const host = await alice.media();
+  ok(host.audioBytes > 0, "the host hears the late joiner", { audioBytes: host.audioBytes });
+
+  for (const peer of [alice, bob]) {
+    const errs = await peer
+      .eval(`JSON.stringify((window.__labErrs || []).slice(0, 5))`)
+      .then(JSON.parse);
+    ok(errs.length === 0, `${peer.name}: no uncaught errors`, errs);
+  }
+} catch (err) {
+  if (/UNREACHABLE/.test(err.message)) {
+    console.log(`ENVIRONMENT ${err.message}`);
+    alice.close();
+    bob.close();
+    impair("lab-browser-2", "clean");
+    process.exit(EXIT_ENVIRONMENT);
+  }
+  ok(false, `aborted: ${err.message}`);
+} finally {
+  alice.close();
+  bob.close();
+  impair("lab-browser-2", "clean");
+}
+
+console.log(fail.length === 0 ? "\nSCENARIO PASSED" : `\nSCENARIO FAILED: ${fail.join(", ")}`);
+process.exit(fail.length === 0 ? 0 : 1);

--- a/lab/scenarios/call-recovery.mjs
+++ b/lab/scenarios/call-recovery.mjs
@@ -16,6 +16,7 @@ import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { LabPeer } from "../peer.mjs";
 import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
+import { captureOnFailure } from "../capture.mjs";
 
 function appUrl() {
   if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
@@ -145,6 +146,8 @@ try {
   }
   ok(false, `aborted: ${err.message}`);
 } finally {
+  // Before the tabs are closed: the recorder lives in the page.
+  await captureOnFailure("recovery", [alice, bob], fail);
   alice.close();
   bob.close();
   impair("lab-browser-2", "clean");

--- a/lab/scenarios/call-recovery.mjs
+++ b/lab/scenarios/call-recovery.mjs
@@ -1,0 +1,154 @@
+/**
+ * A call loses the network, and comes back on its own.
+ *
+ * Every other scenario tests SETUP: does a call start on a given network. This
+ * one tests REPAIR, which is where every bug fixed this week actually lived - a
+ * rejoin ladder that forked into several, a receive transport that could never
+ * accept another consume, a voice link torn down and redialed forever. None of
+ * those stop a call from starting. They stop it from coming back.
+ *
+ * Nobody touches the UI after the cut. Recovery has to be the app's own doing.
+ *
+ *   node scenarios/call-recovery.mjs
+ *   LAB_OUTAGE_MS=30000 LAB_APP_URL=https://dev.awful.chat node scenarios/call-recovery.mjs
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { LabPeer } from "../peer.mjs";
+import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
+
+function appUrl() {
+  if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
+  try {
+    return readFileSync(new URL("../.app-url", import.meta.url), "utf8").trim();
+  } catch {
+    console.error("No app to drive: run ./stack.sh, or set LAB_APP_URL.");
+    process.exit(2);
+  }
+}
+
+const APP = appUrl();
+const PORTS = (process.env.LAB_PORTS ?? "9331,9332").split(",").map(Number);
+/** Long enough to kill ICE, short enough that a run is not an afternoon. */
+const OUTAGE_MS = Number(process.env.LAB_OUTAGE_MS ?? 20_000);
+/** How long the app may take to put the call back together. */
+const RECOVER_MS = Number(process.env.LAB_RECOVER_MS ?? 90_000);
+/** Connections one tab may hold before this is a leak rather than a repair. */
+const PC_CEILING = Number(process.env.LAB_PC_CEILING ?? 40);
+
+const impair = (c, p) =>
+  execFileSync(new URL("../impair.sh", import.meta.url).pathname, [c, p], {
+    encoding: "utf8",
+  }).trim();
+
+const fail = [];
+const ok = (cond, label, extra) => {
+  console.log(`${cond ? "PASS" : "FAIL"} ${label}${extra === undefined ? "" : ` ${JSON.stringify(extra)}`}`);
+  if (!cond) fail.push(label);
+};
+
+const seesOther = (otherName) => `(() => {
+  const txt = document.body.innerText;
+  if (/\\bUSERS\\b/.test(txt)) return txt.includes(${JSON.stringify("X")}) || null;
+  const b = [...document.querySelectorAll('button')]
+    .find((x) => (x.getAttribute('aria-label') || '') === 'Toggle user list');
+  if (b) b.click();
+  return null;
+})()`.replace(JSON.stringify("X"), JSON.stringify(otherName));
+
+impair("lab-browser-1", "clean");
+impair("lab-browser-2", "clean");
+
+await requireReachableTarget(PORTS[0], APP);
+
+const alice = new LabPeer(PORTS[0], "Alice", APP);
+const bob = new LabPeer(PORTS[1], "Bob", APP);
+
+/** Audio arriving at BOTH ends right now, measured over a window. */
+async function audioFlowing() {
+  const before = { a: await alice.media(), b: await bob.media() };
+  await new Promise((r) => setTimeout(r, 4000));
+  const after = { a: await alice.media(), b: await bob.media() };
+  return {
+    growing:
+      after.a.audioBytes > before.a.audioBytes && after.b.audioBytes > before.b.audioBytes,
+    detail: {
+      aliceDelta: after.a.audioBytes - before.a.audioBytes,
+      bobDelta: after.b.audioBytes - before.b.audioBytes,
+    },
+    after,
+  };
+}
+
+try {
+  await alice.start();
+  await bob.start();
+  await alice.signUp("Alice");
+  await bob.signUp("Bob");
+
+  const room = await alice.createRoom("lab-recovery");
+  console.log(`room: ${room}`);
+  await bob.joinRoom(room);
+
+  for (const [peer, other] of [[alice, "Bob"], [bob, "Alice"]]) {
+    await peer.waitFor(`${peer.name} sees ${other}`, seesOther(other), { timeout: 90_000 });
+  }
+
+  await alice.joinCall();
+  await bob.joinCall();
+
+  const healthy = await audioFlowing();
+  ok(healthy.growing, "audio flowing before the outage", healthy.detail);
+  const beforeCut = healthy.after;
+
+  console.log(`\n-- cutting Bob's network for ${OUTAGE_MS / 1000}s --`);
+  impair("lab-browser-2", "blackout");
+  await new Promise((r) => setTimeout(r, OUTAGE_MS));
+  impair("lab-browser-2", "clean");
+  console.log("-- network restored --\n");
+
+  let recovered = { growing: false, detail: null, after: beforeCut };
+  const deadline = Date.now() + RECOVER_MS;
+  while (Date.now() < deadline) {
+    recovered = await audioFlowing();
+    if (recovered.growing) break;
+  }
+  ok(recovered.growing, "audio came back on its own after the outage", recovered.detail);
+
+  // A rebuild is expected. An unbounded one is the bug: the rejoin ladder that
+  // forked ran a full join per rung, and a tab that reaches Chrome's 500
+  // connection cap loses voice, the SFU and libp2p on the same line.
+  const after = recovered.after;
+  ok(
+    after.a.pcs < PC_CEILING && after.b.pcs < PC_CEILING,
+    "connection count stayed sane through the repair",
+    {
+      aliceTotal: after.a.pcs, aliceLive: after.a.live,
+      bobTotal: after.b.pcs, bobLive: after.b.live,
+      builtDuringRepair: after.b.pcs - beforeCut.b.pcs,
+    }
+  );
+
+  for (const peer of [alice, bob]) {
+    const errs = await peer
+      .eval(`JSON.stringify((window.__labErrs || []).slice(0, 5))`)
+      .then(JSON.parse);
+    ok(errs.length === 0, `${peer.name}: no uncaught errors`, errs);
+  }
+} catch (err) {
+  if (/UNREACHABLE/.test(err.message)) {
+    console.log(`ENVIRONMENT ${err.message}`);
+    alice.close();
+    bob.close();
+    impair("lab-browser-2", "clean");
+    process.exit(EXIT_ENVIRONMENT);
+  }
+  ok(false, `aborted: ${err.message}`);
+} finally {
+  alice.close();
+  bob.close();
+  impair("lab-browser-2", "clean");
+}
+
+console.log(fail.length === 0 ? "\nSCENARIO PASSED" : `\nSCENARIO FAILED: ${fail.join(", ")}`);
+process.exit(fail.length === 0 ? 0 : 1);

--- a/lab/scenarios/call-video.mjs
+++ b/lab/scenarios/call-video.mjs
@@ -19,6 +19,7 @@ import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { LabPeer } from "../peer.mjs";
 import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
+import { captureOnFailure } from "../capture.mjs";
 
 function appUrl() {
   if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
@@ -153,6 +154,8 @@ try {
   }
   ok(false, `aborted: ${err.message}`);
 } finally {
+  // Before the tabs are closed: the recorder lives in the page.
+  await captureOnFailure("video", [alice, bob], fail);
   alice.close();
   bob.close();
   impair("lab-browser-2", "clean");

--- a/lab/scenarios/call-video.mjs
+++ b/lab/scenarios/call-video.mjs
@@ -1,0 +1,149 @@
+/**
+ * One peer turns a camera on, and the other actually receives the video.
+ *
+ * The first test in this repo that asserts the SFU forwards anything. Voice is
+ * peer to peer and never touches it, so `call-audio.mjs` passing says nothing
+ * about camera or screen share - and the SFU is half of what breaks in
+ * production.
+ *
+ * It is also the only test of the SFU's TCP candidates. mediasoup announces
+ * both UDP and TCP in its RTC port range; the TCP half exists exactly for the
+ * users who cannot send UDP, and it is invisible until one of them shows up.
+ * Under LAB_IMPAIR=udp-block the receiving peer has no UDP at all, so a pass
+ * means the TCP path is open and working end to end.
+ *
+ *   node scenarios/call-video.mjs
+ *   LAB_IMPAIR=udp-block LAB_APP_URL=https://dev.awful.chat node scenarios/call-video.mjs
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { LabPeer } from "../peer.mjs";
+
+function appUrl() {
+  if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
+  try {
+    return readFileSync(new URL("../.app-url", import.meta.url), "utf8").trim();
+  } catch {
+    console.error(
+      "No app to drive. Either run ./stack.sh for the lab's own stack, or set\n" +
+        "LAB_APP_URL=https://your-instance to drive a deployed one."
+    );
+    process.exit(2);
+  }
+}
+
+const APP = appUrl();
+const PORTS = (process.env.LAB_PORTS ?? "9331,9332").split(",").map(Number);
+const IMPAIR = process.env.LAB_IMPAIR ?? "clean";
+const VIDEO_DEADLINE_MS = Number(process.env.LAB_VIDEO_DEADLINE_MS ?? 60_000);
+
+const impair = (container, profile) =>
+  execFileSync(new URL("../impair.sh", import.meta.url).pathname, [container, profile], {
+    encoding: "utf8",
+  }).trim();
+
+const fail = [];
+const ok = (cond, label, extra) => {
+  console.log(`${cond ? "PASS" : "FAIL"} ${label}${extra === undefined ? "" : ` ${JSON.stringify(extra)}`}`);
+  if (!cond) fail.push(label);
+};
+
+// The WATCHER is the impaired one: receiving is the harder direction, and it
+// is the direction a viewer complains about.
+impair("lab-browser-1", "clean");
+impair("lab-browser-2", IMPAIR === "clean" ? "clean" : IMPAIR);
+console.log(`network: sharer=clean watcher=${IMPAIR}`);
+
+const alice = new LabPeer(PORTS[0], "Alice", APP);
+const bob = new LabPeer(PORTS[1], "Bob", APP);
+
+try {
+  await alice.start();
+  await bob.start();
+  await alice.signUp("Alice");
+  await bob.signUp("Bob");
+
+  const room = await alice.createRoom("lab-video");
+  console.log(`room: ${room}`);
+  await bob.joinRoom(room);
+
+  for (const [peer, otherName] of [[alice, "Bob"], [bob, "Alice"]]) {
+    await peer.waitFor(
+      `${peer.name} sees ${otherName} in the user list`,
+      `(() => {
+        const txt = document.body.innerText;
+        if (/\\bUSERS\\b/.test(txt)) return txt.includes(${JSON.stringify(otherName)}) || null;
+        const b = [...document.querySelectorAll('button')]
+          .find((x) => (x.getAttribute('aria-label') || '') === 'Toggle user list');
+        if (b) b.click();
+        return null;
+      })()`,
+      { timeout: 90_000 }
+    );
+  }
+  ok(true, "mesh formed");
+
+  await alice.joinCall();
+  await bob.joinCall();
+  ok(true, "both in the call");
+
+  await alice.startCamera();
+  ok(true, "Alice's camera is on");
+
+  // Video has to ARRIVE at Bob, and keep arriving. Everything up to here can
+  // be true while the SFU forwards nothing: the transport connects, the
+  // producer is announced, the tile appears, and no frame ever lands.
+  const first = await bob.media();
+  let seen = first;
+  const deadline = Date.now() + VIDEO_DEADLINE_MS;
+  for (;;) {
+    seen = await bob.media();
+    if (seen.videoBytes > first.videoBytes + 5000 || Date.now() > deadline) break;
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  ok(seen.videoBytes > first.videoBytes + 5000, "Bob receives Alice's camera", {
+    videoBytes: seen.videoBytes,
+    videoPath: seen.videoPath,
+    videoProto: seen.videoProto,
+    videoRelayed: seen.videoRelayed,
+  });
+
+  // With no UDP at all, media that arrives can only have come over ICE-TCP.
+  // Asserting the protocol rather than inferring it from "it worked": the
+  // candidate TYPE does not name the transport, and a pass that assumed one
+  // would be a claim this lab had not measured.
+  if (IMPAIR === "udp-block") {
+    ok(seen.videoProto === "tcp", "the SFU leg used TCP, as it must here", {
+      videoProto: seen.videoProto,
+    });
+  }
+
+  // Which path the SFU leg took. Under udp-block a pass here means the SFU's
+  // TCP candidate range is reachable, which nothing else in this repo checks.
+  console.log(
+    `sfu path: ${seen.videoPath} over ${seen.videoProto}  relayed: ${seen.videoRelayed}  ` +
+      `video bytes: ${first.videoBytes} -> ${seen.videoBytes}  pcs: ${seen.live}/${seen.pcs}`
+  );
+
+  // Voice should still be up alongside it; a camera must not cost the call.
+  ok(seen.audioBytes > 0, "voice still flowing alongside video", {
+    audioBytes: seen.audioBytes,
+  });
+
+  for (const peer of [alice, bob]) {
+    const errs = await peer
+      .eval(`JSON.stringify((window.__labErrs || []).slice(0, 5))`)
+      .then(JSON.parse);
+    ok(errs.length === 0, `${peer.name}: no uncaught errors`, errs);
+  }
+} catch (err) {
+  ok(false, `aborted: ${err.message}`);
+} finally {
+  alice.close();
+  bob.close();
+  impair("lab-browser-2", "clean");
+}
+
+console.log(fail.length === 0 ? "\nSCENARIO PASSED" : `\nSCENARIO FAILED: ${fail.join(", ")}`);
+process.exit(fail.length === 0 ? 0 : 1);

--- a/lab/scenarios/call-video.mjs
+++ b/lab/scenarios/call-video.mjs
@@ -18,6 +18,7 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { LabPeer } from "../peer.mjs";
+import { EXIT_ENVIRONMENT, requireReachableTarget } from "../preflight.mjs";
 
 function appUrl() {
   if (process.env.LAB_APP_URL) return process.env.LAB_APP_URL;
@@ -53,6 +54,10 @@ const ok = (cond, label, extra) => {
 impair("lab-browser-1", "clean");
 impair("lab-browser-2", IMPAIR === "clean" ? "clean" : IMPAIR);
 console.log(`network: sharer=clean watcher=${IMPAIR}`);
+
+// Before anything is impaired or asserted: if the target is not serving the
+// app, this run has no claim to make about it.
+await requireReachableTarget(PORTS[0], APP);
 
 const alice = new LabPeer(PORTS[0], "Alice", APP);
 const bob = new LabPeer(PORTS[1], "Bob", APP);
@@ -138,6 +143,14 @@ try {
     ok(errs.length === 0, `${peer.name}: no uncaught errors`, errs);
   }
 } catch (err) {
+  // An unreachable target mid-run is the environment, not the app.
+  if (/UNREACHABLE/.test(err.message)) {
+    console.log(`ENVIRONMENT ${err.message}`);
+    alice.close();
+    bob.close();
+    impair("lab-browser-2", "clean");
+    process.exit(EXIT_ENVIRONMENT);
+  }
   ok(false, `aborted: ${err.message}`);
 } finally {
   alice.close();

--- a/lab/selfcheck.mjs
+++ b/lab/selfcheck.mjs
@@ -1,0 +1,133 @@
+/**
+ * Can this lab carry media at all?
+ *
+ * Ask before trusting any result the lab produces. The e2e harness next door
+ * cannot: Firefox headless never completes an ICE handshake there, so its
+ * call tests asserts counters and no test in this repo has ever asserted that
+ * audio arrived. If the lab has the same hole, every green run it prints is
+ * worthless, and worse than worthless - it looks like proof.
+ *
+ * So: two real browsers, a real offer/answer carried by this script, a real
+ * ICE handshake between two container network namespaces, and a real Opus
+ * stream. It passes only when bytes actually arrive at the far end.
+ *
+ * No app, no relay, no SFU. A failure here is the lab, never the product.
+ */
+import { Cdp } from "./cdp.mjs";
+
+const ORIGIN = process.env.LAB_ORIGIN ?? "http://lab-page:8000/blank.html";
+const PORTS = (process.env.LAB_PORTS ?? "9331,9332").split(",").map(Number);
+
+const a = await new Cdp(PORTS[0]).open();
+const b = await new Cdp(PORTS[1]).open();
+
+try {
+  await a.goto(ORIGIN);
+  await b.goto(ORIGIN);
+
+  // A synthetic tone, not getUserMedia: it needs no permission and no fake
+  // device, and it proves the same path - an encoder, SRTP, and a decoder.
+  const makePc = (extra = "") => `(async () => {
+    const ctx = new AudioContext();
+    const osc = ctx.createOscillator();
+    const dest = ctx.createMediaStreamDestination();
+    osc.connect(dest); osc.start();
+    window.__lab = { pc: new RTCPeerConnection(${JSON.stringify({ iceServers: [] })}), cands: [] };
+    const pc = window.__lab.pc;
+    for (const track of dest.stream.getAudioTracks()) pc.addTrack(track, dest.stream);
+    pc.onicecandidate = (e) => { if (e.candidate) window.__lab.cands.push(e.candidate.toJSON()); };
+    pc.ontrack = (e) => { window.__lab.remote = e.streams[0] ?? null; };
+    ${extra}
+    return true;
+  })()`;
+
+  await a.eval(makePc());
+  await b.eval(makePc());
+
+  const offer = await a.eval(`(async () => {
+    const pc = window.__lab.pc;
+    const o = await pc.createOffer();
+    await pc.setLocalDescription(o);
+    return pc.localDescription.sdp;
+  })()`);
+
+  const answer = await b.eval(`(async () => {
+    const pc = window.__lab.pc;
+    await pc.setRemoteDescription({ type: "offer", sdp: ${JSON.stringify(offer)} });
+    const ans = await pc.createAnswer();
+    await pc.setLocalDescription(ans);
+    return pc.localDescription.sdp;
+  })()`);
+
+  await a.eval(`window.__lab.pc.setRemoteDescription({ type: "answer", sdp: ${JSON.stringify(answer)} }).then(() => true)`);
+
+  // Trickle both ways. Host candidates are container IPs on one bridge, so
+  // there is a real path here without STUN.
+  const drain = async (from, to) => {
+    const cands = await from.eval(`window.__lab.cands.splice(0)`);
+    for (const c of cands) {
+      await to.eval(`window.__lab.pc.addIceCandidate(${JSON.stringify(c)}).then(() => true).catch(() => false)`);
+    }
+    return cands.length;
+  };
+
+  const deadline = Date.now() + 30_000;
+  let connected = false;
+  while (Date.now() < deadline) {
+    await drain(a, b);
+    await drain(b, a);
+    const [sa, sb] = await Promise.all([
+      a.eval(`window.__lab.pc.connectionState`),
+      b.eval(`window.__lab.pc.connectionState`),
+    ]);
+    if (sa === "connected" && sb === "connected") { connected = true; break; }
+    if (sa === "failed" || sb === "failed") break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  const state = await Promise.all([
+    a.eval(`window.__lab.pc.connectionState`),
+    b.eval(`window.__lab.pc.connectionState`),
+  ]);
+  console.log(`ice: a=${state[0]} b=${state[1]}`);
+  if (!connected) throw new Error("ICE never completed - the lab cannot carry media");
+
+  // The assertion the e2e harness could never make: bytes, at the far end,
+  // growing.
+  const bytesAt = async (peer) => peer.eval(`(async () => {
+    const stats = await window.__lab.pc.getStats();
+    for (const r of stats.values()) {
+      if (r.type === "inbound-rtp" && r.kind === "audio") return r.bytesReceived ?? 0;
+    }
+    return 0;
+  })()`);
+
+  const first = await bytesAt(b);
+  await new Promise((r) => setTimeout(r, 3000));
+  const second = await bytesAt(b);
+  console.log(`inbound audio bytes at b: ${first} -> ${second}`);
+  if (!(second > first && second > 0)) {
+    throw new Error("ICE connected but no audio arrived - a green lab run would be a lie");
+  }
+
+  // Dereference the candidate ids rather than reading a type off the pair:
+  // Chrome puts no candidate type there, which is the bug this lab found in
+  // the app itself on its first run. The wrong pattern must not live here.
+  const pair = await a.eval(`(async () => {
+    const stats = await window.__lab.pc.getStats();
+    const cands = {}; let best = null;
+    for (const r of stats.values()) {
+      if (r.type === "local-candidate" || r.type === "remote-candidate") cands[r.id] = r;
+      if (r.type === "candidate-pair" && r.state === "succeeded" && (!best || r.nominated)) best = r;
+    }
+    if (!best) return "none";
+    const t = (inline, id) => inline ?? cands[id]?.candidateType ?? "?";
+    return t(best.localCandidateType, best.localCandidateId) + "/" +
+           t(best.remoteCandidateType, best.remoteCandidateId);
+  })()`);
+  console.log(`path: ${pair}`);
+  console.log("LAB SELF-CHECK PASSED: two browsers, real ICE, real RTP");
+} finally {
+  a.close();
+  b.close();
+}

--- a/lab/stack.sh
+++ b/lab/stack.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Bring up the app for the lab, then the browsers that will drive it.
+#
+# The relay's peer id is not knowable before it boots and is not guessable, so
+# this starts the relay first, reads the identity it prints, and only then
+# starts the frontend that has to dial it. The id is stable across restarts
+# because the key lives in a volume.
+set -eu
+cd "$(dirname "$0")"
+COMPOSE="docker compose -f docker-compose.lab.yml"
+
+echo "== relay"
+LAB_RELAY_MULTIADDR=placeholder $COMPOSE up -d relay sfu >/dev/null
+
+PEER_ID=""
+for _ in $(seq 1 60); do
+  PEER_ID=$(docker logs awful-lab-relay-1 2>&1 | grep -oE 'PeerID: [A-Za-z0-9]+' | tail -1 | cut -d' ' -f2)
+  [ -n "$PEER_ID" ] && break
+  sleep 1
+done
+[ -n "$PEER_ID" ] || { echo "relay never printed a PeerID"; exit 1; }
+echo "   relay peer id: $PEER_ID"
+
+# /dns4/relay, not an IP: the browsers resolve service names on this network,
+# and an address that survives a subnet change is one less thing to fix later.
+export LAB_RELAY_MULTIADDR="/dns4/relay/tcp/8080/ws/p2p/$PEER_ID"
+echo "$LAB_RELAY_MULTIADDR" > .relay-multiaddr
+
+# Not http://frontend:5173: Vite 7 answers 403 for a Host header that is not
+# in `server.allowedHosts`, and changing the app's vite config to please the
+# lab would be the wrong way round. "localhost" is allowed by Vite AND
+# trusted by Chrome, which the readiness probe below reaches by IP.
+# localhost, resolved to the frontend container by each browser (see up.sh):
+# it is the only way to get a secure context without terminating TLS.
+APP_URL="http://localhost:5173"
+
+echo "== frontend"
+$COMPOSE up -d frontend >/dev/null
+# Vite has to answer before a browser is pointed at it, or the first
+# navigation lands on a connection refused and the run reads as an app fault.
+for _ in $(seq 1 90); do
+  docker run --rm --network awful-lab curlimages/curl:latest -sf http://172.30.0.12:5173 >/dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "== browsers"
+LAB_NET=awful-lab LAB_APP_IP=172.30.0.12 ./up.sh
+echo
+echo "$APP_URL" > .app-url
+echo "app:   $APP_URL (inside the lab network)"
+echo "relay: http://127.0.0.1:18081 (operator endpoints, from the host)"

--- a/lab/super.mjs
+++ b/lab/super.mjs
@@ -1,0 +1,246 @@
+/**
+ * Run everything, repeatedly, and write down exactly what happened.
+ *
+ * The single-run scenarios answer "does this work right now". This answers the
+ * question that actually matters for fixing things: WHICH combinations fail,
+ * HOW OFTEN, and what the app itself recorded while failing. Intermittent
+ * faults are the whole problem here - the late-join replay fails perhaps half
+ * the time - and a harness that runs each case once cannot tell an intermittent
+ * bug from a flaky test.
+ *
+ * Every run captures the app's own flight recorder, passes included, because a
+ * failing bundle means little without a healthy one beside it.
+ *
+ *   node super.mjs                                  # the default plan
+ *   LAB_APP_URL=https://dev.awful.chat node super.mjs
+ *   LAB_REPEATS=3 node super.mjs
+ */
+import { spawn, execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { EXIT_ENVIRONMENT } from "./preflight.mjs";
+
+const HERE = new URL(".", import.meta.url).pathname;
+const REPEATS = Number(process.env.LAB_REPEATS ?? 2);
+const APP = process.env.LAB_APP_URL ?? "(lab stack)";
+
+/**
+ * What to run. Profiles are chosen per scenario rather than as a full cross
+ * product: running late-join on six networks costs an hour and tells you less
+ * than running it three times on one, because its failure is not
+ * network-dependent.
+ */
+const PLAN = [
+  { scenario: "call-audio", profiles: ["clean", "jitter", "loss15", "udp-block"] },
+  { scenario: "call-video", profiles: ["clean", "udp-block"] },
+  { scenario: "call-late-join", profiles: ["clean"], repeats: 4 },
+  { scenario: "call-recovery", profiles: ["clean"] },
+];
+
+function restartBrowsers() {
+  try {
+    execFileSync(`${HERE}up.sh`, [], { stdio: "ignore", timeout: 120_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runOnce(scenario, profile) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const child = spawn(process.execPath, [`scenarios/${scenario}.mjs`], {
+      cwd: HERE,
+      env: { ...process.env, LAB_IMPAIR: profile, LAB_CAPTURE_ALWAYS: "1" },
+    });
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (out += d));
+    child.on("close", (code) => {
+      resolve({
+        scenario,
+        profile,
+        code,
+        environment: code === EXIT_ENVIRONMENT,
+        ok: code === 0,
+        seconds: Math.round((Date.now() - started) / 1000),
+        failures: [...out.matchAll(/^FAIL (.+?)(?: \{|$)/gm)].map((m) => m[1]),
+        detail: [...out.matchAll(/^(?:PASS|FAIL) .+$/gm)].map((m) => m[0]),
+        captures: [...out.matchAll(/^ {2}(\/.+\.json)$/gm)].map((m) => m[1]),
+        tail: out.trim().split("\n").slice(-25).join("\n"),
+      });
+    });
+  });
+}
+
+/** The handful of facts from a bundle that explain a call failure. */
+function readBundle(file) {
+  try {
+    const b = JSON.parse(readFileSync(file, "utf8"));
+    const events = b.events ?? [];
+    const kind = (k) => events.filter((e) => e.kind === k);
+    const consume = events.filter((e) => e.kind.startsWith("sfu.consume"));
+    const phases = {};
+    for (const e of consume) {
+      const p = e.kind === "sfu.consume.failed" ? "failed" : (e.d?.phase ?? "?");
+      phases[p] = (phases[p] ?? 0) + 1;
+    }
+    const media = kind("voice.media.sample");
+    return {
+      file: file.split("/").pop(),
+      self: (b.self?.peerId ?? "?").slice(-8),
+      events: events.length,
+      roomPeerCount: kind("sfu.caps").map((e) => e.d?.roomPeerCount ?? null),
+      consumePhases: phases,
+      consumeFailures: events
+        .filter((e) => e.kind === "sfu.consume.failed")
+        .map((e) => String(e.d?.err ?? "").slice(0, 120)),
+      produced: kind("sfu.produce").map((e) => `${e.d?.source}/${e.d?.kind}`),
+      transports: kind("sfu.transport.state").map((e) => `${e.d?.direction}:${e.d?.state}`),
+      sfuErrors: kind("sfu.error").map((e) => String(e.d?.message ?? "").slice(0, 120)),
+      rejoins: kind("sfu.rejoin").length,
+      wsCloses: kind("sfu.ws.close").length,
+      uncaught: kind("runtime.error").map((e) => String(e.d?.err ?? "").slice(0, 120)),
+      turn: [...kind("ice.turn.ok"), ...kind("ice.turn.fail")].map(
+        (e) => `${e.kind}:${e.d?.branch ?? "creds"}`
+      ),
+      lastMediaSample: media.length ? media[media.length - 1].d : null,
+      relayedVoice: media.some((e) => String(e.d?.path ?? "").includes("relay")),
+    };
+  } catch (err) {
+    return { file, error: err.message.slice(0, 120) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+const started = new Date();
+const results = [];
+let plannedTotal = 0;
+for (const step of PLAN) plannedTotal += step.profiles.length * (step.repeats ?? REPEATS);
+
+console.log(`super test: ${plannedTotal} runs against ${APP}\n`);
+let n = 0;
+for (const step of PLAN) {
+  const repeats = step.repeats ?? REPEATS;
+  for (const profile of step.profiles) {
+    for (let i = 1; i <= repeats; i++) {
+      n++;
+      process.stdout.write(`[${n}/${plannedTotal}] ${step.scenario} ${profile} #${i} ... `);
+      restartBrowsers();
+      const r = await runOnce(step.scenario, profile);
+      r.attempt = i;
+      results.push(r);
+      console.log(
+        `${r.environment ? "ENV" : r.ok ? "pass" : "FAIL"} (${r.seconds}s)` +
+          (r.failures.length ? ` :: ${r.failures.join(", ")}` : "")
+      );
+    }
+  }
+}
+
+// Attach bundle evidence, pairing each run with the captures it produced.
+const capturesDir = `${HERE}captures/`;
+let allCaptures = [];
+try {
+  allCaptures = readdirSync(capturesDir).filter((f) => f.endsWith(".json"));
+} catch {
+  allCaptures = [];
+}
+for (const r of results) {
+  r.evidence = (r.captures.length ? r.captures : []).map(readBundle);
+}
+
+// ---------------------------------------------------------------------------
+// The report
+// ---------------------------------------------------------------------------
+
+const tested = results.filter((r) => !r.environment);
+const byCase = new Map();
+for (const r of tested) {
+  const key = `${r.scenario} / ${r.profile}`;
+  const cur = byCase.get(key) ?? { runs: 0, failed: 0, reasons: new Map(), seconds: [] };
+  cur.runs++;
+  cur.seconds.push(r.seconds);
+  if (!r.ok) {
+    cur.failed++;
+    for (const f of r.failures) cur.reasons.set(f, (cur.reasons.get(f) ?? 0) + 1);
+  }
+  byCase.set(key, cur);
+}
+
+const lines = [];
+lines.push(`# Lab super test`);
+lines.push("");
+lines.push(`- target: \`${APP}\``);
+lines.push(`- started: ${started.toISOString()}`);
+lines.push(`- runs: ${results.length} (${tested.length} tested, ${results.length - tested.length} environment)`);
+lines.push("");
+lines.push(`## Failure rate by case`);
+lines.push("");
+lines.push(`| case | runs | failed | rate | median s | reasons |`);
+lines.push(`| --- | --- | --- | --- | --- | --- |`);
+for (const [key, c] of byCase) {
+  const median = c.seconds.sort((a, b) => a - b)[Math.floor(c.seconds.length / 2)];
+  const reasons = [...c.reasons.entries()].map(([r, k]) => `${r} (${k}x)`).join("; ") || "-";
+  lines.push(
+    `| ${key} | ${c.runs} | ${c.failed} | ${Math.round((c.failed / c.runs) * 100)}% | ${median} | ${reasons} |`
+  );
+}
+lines.push("");
+
+const failures = tested.filter((r) => !r.ok);
+lines.push(`## Failures in detail (${failures.length})`);
+lines.push("");
+if (failures.length === 0) lines.push("None.");
+for (const [i, r] of failures.entries()) {
+  lines.push(`### ${i + 1}. ${r.scenario} / ${r.profile} (attempt ${r.attempt}, ${r.seconds}s)`);
+  lines.push("");
+  lines.push(`**Assertions that failed:** ${r.failures.join(", ") || "(aborted before asserting)"}`);
+  lines.push("");
+  lines.push("What the run printed:");
+  lines.push("");
+  lines.push("```");
+  lines.push(r.tail);
+  lines.push("```");
+  lines.push("");
+  if (r.evidence.length === 0) {
+    lines.push("_No diagnostic bundle captured for this run._");
+  } else {
+    lines.push("What the app itself recorded:");
+    lines.push("");
+    for (const e of r.evidence) {
+      lines.push("```json");
+      lines.push(JSON.stringify(e, null, 1));
+      lines.push("```");
+    }
+  }
+  lines.push("");
+}
+
+const passes = tested.filter((r) => r.ok && r.evidence.length > 0);
+lines.push(`## A healthy run, for comparison`);
+lines.push("");
+if (passes.length === 0) lines.push("None captured.");
+else {
+  const p = passes[passes.length - 1];
+  lines.push(`\`${p.scenario} / ${p.profile}\`, which passed:`);
+  lines.push("");
+  for (const e of p.evidence) {
+    lines.push("```json");
+    lines.push(JSON.stringify(e, null, 1));
+    lines.push("```");
+  }
+}
+lines.push("");
+
+mkdirSync(`${HERE}reports/`, { recursive: true });
+const stamp = started.toISOString().replace(/[:.]/g, "-");
+const md = `${HERE}reports/${stamp}-super.md`;
+const json = `${HERE}reports/${stamp}-super.json`;
+writeFileSync(md, lines.join("\n"));
+writeFileSync(json, JSON.stringify({ started, app: APP, results }, null, 2));
+
+console.log(`\nreport: ${md}`);
+console.log(`raw:    ${json}`);
+console.log(`\n${failures.length} failure(s) across ${tested.length} tested runs.`);
+process.exit(0);

--- a/lab/up.sh
+++ b/lab/up.sh
@@ -14,6 +14,13 @@ IMAGE="${LAB_BROWSER_IMAGE:-zenika/alpine-chrome:latest}"
 # "http://localhost:5173" - see the resolver rule below.
 APP_IP="${LAB_APP_IP:-172.30.0.12}"
 
+# --disable-features=AsyncDns: Chrome's built-in resolver cannot reliably use
+# Docker's embedded DNS, which is a NAT'd loopback listener at 127.0.0.11.
+# When it gives up, every external name fails with ERR_NAME_NOT_RESOLVED while
+# nslookup and curl in the SAME container resolve fine - so the app looks
+# unreachable and the run looks like a product failure. This forces the OS
+# resolver, which is what those tools already use.
+#
 # Why the resolver rule: WebRTC and WebCrypto need a SECURE CONTEXT, and
 # http://<container-ip>:5173 is not one - crypto.subtle and
 # navigator.mediaDevices are simply absent there, so the app cannot even
@@ -58,6 +65,7 @@ for i in $(seq 1 "$COUNT"); do
       --use-fake-device-for-media-stream --use-fake-ui-for-media-stream \
       --autoplay-policy=no-user-gesture-required \
       --host-resolver-rules="MAP localhost $APP_IP" \
+      --disable-features=AsyncDns \
       --user-data-dir="/tmp/prof-$i" \
       about:blank >/dev/null
 done

--- a/lab/up.sh
+++ b/lab/up.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Start (or restart) the lab's browsers and the origin they load from.
+#
+# The page server exists only to give Chrome a real http:// origin: a
+# WebRTC page must be a secure context, and `about:blank` is not one. Every
+# browser trusts that one origin explicitly rather than running with web
+# security off, so what the lab measures is still what a user's browser does.
+set -u
+cd "$(dirname "$0")"
+NET="${LAB_NET:-awful-lab}"
+COUNT="${LAB_PEERS:-2}"
+IMAGE="${LAB_BROWSER_IMAGE:-zenika/alpine-chrome:latest}"
+# The address the app is served from. The browsers reach it as
+# "http://localhost:5173" - see the resolver rule below.
+APP_IP="${LAB_APP_IP:-172.30.0.12}"
+
+# Why the resolver rule: WebRTC and WebCrypto need a SECURE CONTEXT, and
+# http://<container-ip>:5173 is not one - crypto.subtle and
+# navigator.mediaDevices are simply absent there, so the app cannot even
+# create an identity, let alone open a microphone.
+# --unsafely-treat-insecure-origin-as-secure did not take effect in this
+# Chromium. Chrome always trusts "localhost", so the browsers resolve
+# localhost to the frontend's address instead: a real secure context, no
+# security switches disabled, and the app runs exactly as it does for a user.
+#
+# `--headless`, not `--headless=new`: the new headless shell ignores
+# --remote-debugging-address and binds the debug port to loopback INSIDE the
+# container, where nothing can reach it (Chromium 124). Checked, not assumed.
+docker network create "$NET" >/dev/null 2>&1
+
+docker rm -f lab-page >/dev/null 2>&1
+docker run -d --name lab-page --network "$NET" \
+  -v "$PWD/pages:/www:ro" -w /www node:22-slim \
+  node -e '
+    const http = require("http"), fs = require("fs"), path = require("path");
+    http.createServer((req, res) => {
+      const file = path.join("/www", path.normalize(req.url.split("?")[0]).replace(/^\/+/, "") || "blank.html");
+      fs.readFile(file, (err, body) => {
+        if (err) { res.writeHead(404); res.end("no"); return; }
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end(body);
+      });
+    }).listen(8000);
+  ' >/dev/null
+
+for i in $(seq 1 "$COUNT"); do
+  name="lab-browser-$i"
+  port=$((9330 + i))
+  docker rm -f "$name" >/dev/null 2>&1
+  # NET_ADMIN is what lets `impair.sh` shape this browser's own uplink from
+  # inside its namespace, so one peer can be on a bad network while the
+  # others are not - which is the whole point of the matrix.
+  docker run -d --name "$name" --network "$NET" --cap-add=NET_ADMIN \
+    --shm-size=1g -p "127.0.0.1:$port:9222" \
+    --entrypoint chromium-browser "$IMAGE" \
+      --headless --no-sandbox --disable-dev-shm-usage \
+      --remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 \
+      --use-fake-device-for-media-stream --use-fake-ui-for-media-stream \
+      --autoplay-policy=no-user-gesture-required \
+      --host-resolver-rules="MAP localhost $APP_IP" \
+      --user-data-dir="/tmp/prof-$i" \
+      about:blank >/dev/null
+done
+
+for i in $(seq 1 "$COUNT"); do
+  port=$((9330 + i))
+  for _ in $(seq 1 60); do
+    curl -sf "http://127.0.0.1:$port/json/version" >/dev/null && break
+    sleep 0.5
+  done
+  curl -sf "http://127.0.0.1:$port/json/version" >/dev/null \
+    || { echo "lab-browser-$i never opened its debug port"; exit 1; }
+done
+echo "lab up: $COUNT browsers on ports $((9331))..$((9330 + COUNT))"


### PR DESCRIPTION
`frontend/e2e` drives real browsers and finds real bugs, and it cannot test the two things that break in production. Its own note says why:

> NOT `v.links`: headless ICE never completes, so a link object is torn down within a second of being built - `scenarios/call-join-speed.mjs`

Every call test there asserts a counter: an offer was sent, a roster holds two names. A counter cannot tell a working call from a pair who cannot hear each other, and that pair is what gets reported. Nothing in this repo had ever asserted that audio arrived.

## Ask the lab first

`selfcheck.mjs` runs against no app at all: two browsers, a real offer/answer, a real ICE handshake across two container network namespaces, real Opus. It passes only when bytes arrive at the far end. If it fails, the lab is broken and every green run it prints is a lie - worse than a lie, because it looks like proof.

## Two modes

```sh
./stack.sh                                              # Mode A: the lab's own relay, SFU, coturn, frontend
node matrix.mjs

./up.sh                                                 # Mode B: browsers only
LAB_APP_URL=https://dev.awful.chat node matrix.mjs      #         a deployed instance, real internet
```

Mode A synthesises the network with `tc netem`, which makes a finding reproducible. Mode B tests real DNS, TLS, TURN and routing. A failure in B that passes in A is the deployment or the path to it.

## The question it answers

`matrix.mjs` runs one scenario across every network and reads the answer off the table:

| result | reading |
| --- | --- |
| fails everywhere | the code - the network was never the reason |
| fails only when impaired | the network, and the profile names which one |
| passes everywhere | nothing to chase |

## How it reads media

A shim installed before any page script captures every `RTCPeerConnection` the app builds, and `getStats()` is read across all of them. `window.__awful` cannot be the source: it is `import.meta.env.DEV` only, so it does not exist on a deployed build - exactly where the interesting failures are. The same shim records uncaught throws, and a scenario fails on any.

## What it found on its first day

- **TURN was dead on dev for every user who needed it.** Three independent breaks, none visible from inside the app - fixed in #37, #38 and a firewall rule. Verified after: a browser with all UDP blocked now holds a call, `relayed: true` on both sides, `path: srflx/relay`.
- **Every Chromium user in a relayed call was told it was direct.** `RTCIceCandidatePairStats` carries no candidate type in Chrome. Fixed on #35, where a telemetry field depended on it.
- **`frontend/e2e` could not join a room** - six references to a placeholder the UI had renamed. Second commit here.

Two of those three were in code with passing tests.

## Not in scope yet

No SFU scenario: this asserts voice, which is p2p. Camera and screen share through the SFU are the obvious next one, and would exercise the SFU's TCP candidate range the same way `udp-block` exercises TURN.