### PR TITLE
sfu: notice when the SFU room does not hold the people we are in a call with

### DIFF
--- a/dashboard/src/lib/analysis/findings.test.ts
+++ b/dashboard/src/lib/analysis/findings.test.ts
@@ -128,8 +128,8 @@ function expectEvidenceValid(capture: Capture, findings: Finding[]): void {
 // ---------------------------------------------------------------------------
 
 describe("RULES", () => {
-  it("has exactly 33 entries, one per FindingId", () => {
-    expect(Object.keys(RULES).length).toBe(33);
+  it("has exactly 34 entries, one per FindingId", () => {
+    expect(Object.keys(RULES).length).toBe(34);
   });
 
   it("every rule has a matching id and non-empty prose", () => {
@@ -992,5 +992,31 @@ describe("turn-unreachable", () => {
       ev({ kind: "ice.turn.ok", at: 100, d: { branch: "allocate", ms: 120 } }),
     ]);
     expect(idsOf(runFindings(capture))).not.toContain("turn-unreachable");
+  });
+});
+
+describe("sfu-misplaced", () => {
+  it("fires when the client reports a room the server thinks is empty", () => {
+    const capture = makeCapture([
+      ev({
+        kind: "sfu.misplaced",
+        at: 4000,
+        sev: "error",
+        d: { expectedOthers: 1, reportedByServer: 0 },
+      }),
+    ]);
+    const findings = runFindings(capture);
+    expect(idsOf(findings)).toContain("sfu-misplaced");
+    expectEvidenceValid(capture, findings);
+  });
+
+  it("stays quiet on an ordinary session", () => {
+    // The client only emits when the disagreement is unambiguous, so the
+    // absence of the event is itself the healthy signal.
+    const capture = makeCapture([
+      ev({ kind: "sfu.caps", at: 100, d: { roomPeerCount: 1 } }),
+      ev({ kind: "sfu.join", at: 120 }),
+    ]);
+    expect(idsOf(runFindings(capture))).not.toContain("sfu-misplaced");
   });
 });

--- a/dashboard/src/lib/analysis/findings.ts
+++ b/dashboard/src/lib/analysis/findings.ts
@@ -998,6 +998,9 @@ export function runFindings(c: Capture): Finding[] {
     ...peerConnectionLeak(timeline),
     ...producerNeverConsumed(c, timeline),
     ...turnUnreachable(timeline),
+    // One event, one finding: the client only emits it when the disagreement
+    // is unambiguous, so there is nothing left to threshold here.
+    ...thresholdByObserver(timeline, "sfu.misplaced", 1, "sfu-misplaced"),
     ...thresholdByObserver(timeline, "runtime.error", 1, "uncaught-error"),
   ];
 

--- a/dashboard/src/lib/analysis/rules.ts
+++ b/dashboard/src/lib/analysis/rules.ts
@@ -45,7 +45,8 @@ export type FindingId =
   | "peerconnection-leak"
   | "uncaught-error"
   | "producer-never-consumed"
-  | "turn-unreachable";
+  | "turn-unreachable"
+  | "sfu-misplaced";
 
 export interface Rule {
   id: FindingId;
@@ -291,6 +292,17 @@ export const RULES: Readonly<Record<FindingId, Rule>> = {
     meaning: "Some events were dropped or throttled before capture. Findings before the first surviving event can be wrong.",
     remedy: "Raise the ring capacity or the throttle budget for the noisy kind.",
     aiHint: "Check the suppressed kind counts to find which signal was lost.",
+  },
+  "sfu-misplaced": {
+    id: "sfu-misplaced",
+    title: "Call split across SFU nodes",
+    severity: "block",
+    meaning:
+      "This peer joined an SFU room the server says is empty, while presence placed other people in it. The call is spread over two nodes, which keep separate rooms, so no camera or screen share can cross between them.",
+    remedy:
+      "Put one SFU behind each hostname. Rooms live in one process and do not cascade, so several instances behind one name cannot serve one room - list each instance in VITE_SFU_URLS and let the room code choose.",
+    aiHint:
+      "Compare expectedOthers against reportedByServer on the sfu.misplaced event, then check sfu.pick host across the vantages - a split behind ONE hostname is a load balancer, not a misconfigured pool.",
   },
   "turn-unreachable": {
     id: "turn-unreachable",

--- a/dashboard/src/lib/analysis/topology.ts
+++ b/dashboard/src/lib/analysis/topology.ts
@@ -443,6 +443,9 @@ function applyEvent(state: FoldState, e: MergedEvent): boolean {
     case "meta.suppressed":
     // Local to one tab: an uncaught throw, the connection gauge and a media
     // sample say nothing about who can reach whom.
+    // A placement fault is about which SERVER this tab reached, not about who
+    // can reach whom, so the graph is unchanged by it.
+    case "sfu.misplaced":
     case "voice.media.sample":
     case "runtime.error":
     case "runtime.resources":

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -152,6 +152,7 @@ export type DiagKind =
   | "sfu.consume.failed"
   | "sfu.error"
   | "sfu.rejoin"
+  | "sfu.misplaced"
   | "sfu.track.added"
   | "sfu.track.stalled"
   | "sfu.diag"
@@ -175,7 +176,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 115;
+export const DIAG_KIND_COUNT = 116;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:
@@ -308,6 +309,7 @@ export const KIND_SEV = {
   "sfu.consume.failed": "error",
   "sfu.error": "error",
   "sfu.rejoin": "info",
+  "sfu.misplaced": "error",
   "sfu.track.added": "info",
   "sfu.track.stalled": "warn",
   "sfu.diag": "debug",

--- a/frontend/src/lib/telemetry/schema.ts
+++ b/frontend/src/lib/telemetry/schema.ts
@@ -152,6 +152,7 @@ export type DiagKind =
   | "sfu.consume.failed"
   | "sfu.error"
   | "sfu.rejoin"
+  | "sfu.misplaced"
   | "sfu.track.added"
   | "sfu.track.stalled"
   | "sfu.diag"
@@ -175,7 +176,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 115;
+export const DIAG_KIND_COUNT = 116;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:
@@ -308,6 +309,7 @@ export const KIND_SEV = {
   "sfu.consume.failed": "error",
   "sfu.error": "error",
   "sfu.rejoin": "info",
+  "sfu.misplaced": "error",
   "sfu.track.added": "info",
   "sfu.track.stalled": "warn",
   "sfu.diag": "debug",

--- a/frontend/src/lib/transport/call.svelte.ts
+++ b/frontend/src/lib/transport/call.svelte.ts
@@ -32,10 +32,58 @@ import {
   describeMediaError,
   setErrorWithAutoClear,
 } from "./call-error";
+import { ev } from "$lib/telemetry/event";
+import { rec } from "$lib/telemetry/recorder";
+import { isMisplaced, SFU_MISPLACED_MESSAGE } from "./sfu-placement";
 
 let _voiceOutputBeforeDeafen = 1;
 let _videoOutputBeforeDeafen = 1;
 let _mutedBeforeDeafen = false;
+/**
+ * How many OTHER people presence already places in this call's room.
+ *
+ * Read at the moment we join the SFU, because that is the only moment its
+ * answer can be checked against anything: `roomPeerCount` is a snapshot taken
+ * at join and never updated, so comparing it against a roster that grew since
+ * would flag the peer who legitimately arrived first.
+ */
+function othersInCallRoom(room: string | null): number {
+  if (!room) return 0;
+  // Defensive on purpose: this runs inside the join path, and a diagnostic
+  // that throws there would break the very call it exists to explain. A
+  // roster that is not there yet reads as "nobody known", which makes the
+  // check below silent rather than wrong.
+  const rooms = transportState.callPeerRooms;
+  if (!rooms || typeof (rooms as { forEach?: unknown }).forEach !== "function") {
+    return 0;
+  }
+  let n = 0;
+  rooms.forEach((theirRoom) => {
+    if (theirRoom === room) n++;
+  });
+  return n;
+}
+
+/**
+ * Report a call whose SFU room does not hold the people presence says are in
+ * it. See sfu-placement.ts for why that is unrecoverable from here, and why
+ * it stays silent in every ambiguous case.
+ */
+function checkSfuPlacement(expectedOthers: number): void {
+  const reportedByServer = _video.roomPeerCount();
+  if (
+    !isMisplaced({
+      expectedOthers,
+      sessionLive: _video.isConnected(),
+      reportedByServer,
+    })
+  ) {
+    return;
+  }
+  rec(ev("sfu.misplaced", { d: { expectedOthers, reportedByServer } }));
+  setErrorWithAutoClear(transportState, SFU_MISPLACED_MESSAGE);
+}
+
 export function _sendCallState(peerId?: string): void {
   const payload = encode({
     type: MessageType.CallState,
@@ -204,8 +252,12 @@ async function _joinCall(): Promise<void> {
     // Awaiting this unguarded meant a media server that was down (or a VPS
     // whose DNS had moved) failed the whole join, taking out calls that never
     // needed it. Keep the call, say what is missing, heal in the background.
+    // Sampled BEFORE the join: this is what the SFU's own count has to agree
+    // with, and only at this instant.
+    const othersAtJoin = othersInCallRoom(transportState.callRoomCode);
     try {
       await _video.join(transportState.roomCode ?? "", _transport.selfId());
+      checkSfuPlacement(othersAtJoin);
     } catch {
       // The error event already put a readable message on transportState;
       // all that is left is to keep trying in the background.

--- a/frontend/src/lib/transport/sfu-placement.test.ts
+++ b/frontend/src/lib/transport/sfu-placement.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isMisplaced, SFU_MISPLACED_MESSAGE } from "./sfu-placement";
+
+describe("isMisplaced", () => {
+  it("fires when we know somebody is here and the server says nobody is", () => {
+    // The measured shape: presence has two peers in the call room, the SFU
+    // hands the joiner roomPeerCount 0, announces no producer, and the
+    // receive transport is never built.
+    expect(
+      isMisplaced({ expectedOthers: 1, sessionLive: true, reportedByServer: 0 })
+    ).toBe(true);
+  });
+
+  it("stays silent for the first person in the call", () => {
+    // Zero is the correct answer for whoever arrives first, and this check
+    // runs on their join too.
+    expect(
+      isMisplaced({ expectedOthers: 0, sessionLive: true, reportedByServer: 0 })
+    ).toBe(false);
+  });
+
+  it("stays silent when the server agrees somebody is there", () => {
+    expect(
+      isMisplaced({ expectedOthers: 1, sessionLive: true, reportedByServer: 1 })
+    ).toBe(false);
+  });
+
+  it("stays silent on an undercount, which can just be a peer mid-join", () => {
+    // Crying wolf on a transient disagreement would make the real signal
+    // worthless, so only an empty room counts.
+    expect(
+      isMisplaced({ expectedOthers: 3, sessionLive: true, reportedByServer: 2 })
+    ).toBe(false);
+  });
+
+  it("stays silent when the SFU session is not usable", () => {
+    // A session that never came up has its own error path; reporting a
+    // placement fault on top would send the reader somewhere useless.
+    expect(
+      isMisplaced({ expectedOthers: 2, sessionLive: false, reportedByServer: 0 })
+    ).toBe(false);
+  });
+
+  it("says what the person should do about it", () => {
+    // The one thing that helps is hanging up and starting again, so the
+    // message has to say so rather than name a component.
+    expect(SFU_MISPLACED_MESSAGE).toMatch(/voice works/i);
+    expect(SFU_MISPLACED_MESSAGE).toMatch(/rejoining/i);
+  });
+});

--- a/frontend/src/lib/transport/sfu-placement.ts
+++ b/frontend/src/lib/transport/sfu-placement.ts
@@ -1,0 +1,45 @@
+/**
+ * Are we on the same SFU node as the people we are in a call with?
+ *
+ * The SFU keeps its rooms in an in-process map and does not cascade between
+ * instances (see sfu-pool.ts: "a room has to live ENTIRELY on one SFU"). A
+ * room split across two nodes is therefore two rooms, and no camera or screen
+ * share can ever cross between them.
+ *
+ * The client has always been able to see this - the server reports how many
+ * peers its copy of the room holds - and has never looked. That makes it the
+ * worst kind of failure: voice still works (it is peer to peer), the roster is
+ * correct, every status reads connected, and the tiles stay empty forever.
+ *
+ * The comparison is only valid at ONE instant. `roomPeerCount` is a snapshot
+ * taken during the join handshake and never updated, so checking it against a
+ * roster that has grown since would accuse the peer who simply arrived first.
+ */
+
+export const SFU_MISPLACED_MESSAGE =
+  "Video server put this call on a different node - voice works, camera and screen share will not. Leaving and rejoining usually lands everyone together.";
+
+export interface PlacementReading {
+  /** Peers presence already placed in this call room, when we joined the SFU. */
+  expectedOthers: number;
+  /** Whether the SFU session is actually usable; a dead one proves nothing. */
+  sessionLive: boolean;
+  /** What the SFU said its room held, in the same breath. */
+  reportedByServer: number;
+}
+
+/**
+ * True only when the two disagree in the one direction that can mean nothing
+ * else: we know somebody is here, and the server that is supposed to be
+ * carrying their media says its room is empty.
+ *
+ * Deliberately silent in every ambiguous case. The first person into a call
+ * legitimately sees zero. A server that reports FEWER than we expect - two of
+ * three, say - can be a peer mid-join rather than a split, and crying wolf on
+ * that would make the real signal worthless.
+ */
+export function isMisplaced(r: PlacementReading): boolean {
+  if (r.expectedOthers < 1) return false;
+  if (!r.sessionLive) return false;
+  return r.reportedByServer === 0;
+}


### PR DESCRIPTION
## Root cause, confirmed on dev

Two peers in one call, same room code, land on **two different SFU containers**:

```
020d72d6c117 (awful-all-jqrkmb):    peer ...SS4fMmfD joined room XPA2CG8MPKE3Z   <- sharer
016b9bb5650a (awful-awful-eq1zme):  peer ...QtBZmMbR joined room XPA2CG8MPKE3Z   <- watcher
```

Each process holds its own copy of that room with one member in it. So each peer is told `roomPeerCount: 0`, no producer is announced across the gap, and the watcher never builds a receive transport. Voice is unaffected because it is peer to peer.

Measured shape, from the client's own recorder:

```
watcher, PASSING:  roomPeerCount=[1]  consume={announced:2, ok:1}  transports=[recv:connecting, recv:connected]
watcher, FAILING:  roomPeerCount=[0]  consume={}                   transports=[]
```

`sfu-pool.ts` already states why this cannot work: *"a room has to live ENTIRELY on one SFU. The server keeps its rooms in an in-process map and does no router cascading between instances, so two participants on different SFUs would each see an empty room."*

## The fix is not in this PR

One hostname must reach exactly one SFU. Either give each instance its own hostname and list them in `VITE_SFU_URLS` so `sfuForRoom()` places rooms by hashing the code, or route the hostname to a single service. Both dev runs observed had `poolSize: 0`, so the hashing had nothing to choose from.

## What this PR does

It makes the failure visible. Today it is silent: voice keeps working, the roster is right, every status reads connected, and the tiles stay empty forever.

The roster is sampled immediately before the SFU join and compared with what the server answers in the same breath. The timing matters - `roomPeerCount` is a snapshot from the join handshake that is never updated, so comparing it against a roster that has grown since would accuse the peer who simply arrived first.

`isMisplaced()` stays silent in every ambiguous case: the first person in a call legitimately sees zero, and a server reporting two of three can be a peer mid-join. Six cases cover it, in a module of its own because `call.svelte.ts` builds a libp2p node at import and cannot load under vitest.

`sfu-misplaced` fires on the new event in the console. Neither existing rule catches this: `sfu-placement-disagreement` compares the hostname each client picked, and both picked the same one; `sfu-room-split` reads `sfu.diag`, which the container serving dev does not even implement - it answers `unknown message type: ms:diag`, because it predates that work.

## Verification

frontend: 1167 tests, `svelte-check` 0 errors. dashboard: 233 tests, 0 errors.