### PR TITLE
deploy: keep the SFU off the shared network, where its name is not its own

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,14 @@ TURN_SECRET=
 # TURN realm. Defaults to DOMAIN.
 #TURN_REALM=
 
+# Running more than one stack on one host: every service name is also a DNS
+# alias on whatever network it joins, so two stacks that share a network both
+# answer to "sfu", "relay" and so on. Docker returns all of them and rotates,
+# which splits a single call across two SFUs and shows as empty video tiles
+# while voice keeps working. The compose keeps the SFU on a per-project
+# network for that reason. If you add a service the frontend reaches BY NAME,
+# put it on `internal` too rather than on dokploy-network.
+
 # The two ports coturn LISTENS on. Both matter when a host runs more than one
 # stack: coturn is network_mode: host, so these are host-wide, and a second
 # stack that leaves either at its default collides with the first. The loser

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -201,8 +201,19 @@ services:
       # Floor between one peer's ms:diag requests. Default 10000. Too low and
       # a client can make the mediasoup worker sample stats continuously.
       SFU_DIAG_MIN_INTERVAL_MS: ${SFU_DIAG_MIN_INTERVAL_MS:-}
+    # NOT dokploy-network. Nothing routes to this service by hostname from
+    # outside - it has no traefik labels, and its media ports are published
+    # straight to the host - so the only thing the shared network bought was
+    # a name collision. Every stack on that network registers the alias "sfu"
+    # for its own container, docker's DNS then returns all of them and rotates,
+    # and the frontend's /sfu proxy re-resolves per request. Two people in one
+    # call land on two different SFUs about half the time, each gets a room
+    # holding only themselves, and no camera or screen share can cross. Voice
+    # is peer to peer, so it keeps working and the failure looks like nothing
+    # at all. Measured on the dev host: six lookups of "sfu" from the frontend
+    # returned 10.0.1.129 four times and 10.0.1.118 twice.
     networks:
-      - dokploy-network
+      - internal
 
   # For TLS TURN (turns: - strongly recommended for mobile-carrier users):
   # put fullchain.pem + privkey.pem for the domain in a directory, set
@@ -352,7 +363,10 @@ services:
     depends_on:
       - relay
     networks:
+      # dokploy-network for traefik; internal to reach the SFU it proxies /sfu
+      # to. It is the only service that needs both.
       - dokploy-network
+      - internal
     labels:
       - traefik.enable=true
       - traefik.http.routers.${STACK:-awful}-awful2-http.rule=Host(`${DOMAIN}`)
@@ -384,3 +398,9 @@ volumes:
 networks:
   dokploy-network:
     external: true
+  # Created per project, so its real name carries the compose project prefix
+  # and the "sfu" alias inside it belongs to THIS stack alone. That is the
+  # whole fix: two stacks on one host stop sharing a namespace they were never
+  # meant to share.
+  internal:
+    driver: bridge


### PR DESCRIPTION
Root cause of the empty video tiles on dev, proven on the host.

## What happens

A compose service name is also a DNS alias on every network it joins. Two stacks on one box both put their SFU on `dokploy-network`, so **both answer to `sfu`**. Docker's embedded DNS returns both addresses and rotates them, and the frontend's `/sfu` proxy re-resolves per request - deliberately, so a redeployed SFU is picked up. Every WebSocket is therefore a coin flip between two servers.

Six lookups of `sfu` from the frontend that is supposed to own it:

```
10.0.1.129  10.0.1.129  10.0.1.129  10.0.1.118  10.0.1.118  10.0.1.129
```

```
awful-all-jqrkmb-sfu-1    aliases=[awful-all-jqrkmb-sfu-1 sfu]
awful-awful-eq1zme-sfu-1  aliases=[awful-awful-eq1zme-sfu-1 sfu]
```

And one call whose peers drew differently, logged on both servers with the same room code, one member each:

```
020d72d6c117:  peer ...SS4fMmfD joined room XPA2CG8MPKE3Z
016b9bb5650a:  peer ...QtBZmMbR joined room XPA2CG8MPKE3Z
```

Each server holds its own copy of the room, so each peer is told `roomPeerCount: 0`, no producer is announced across the gap, and the watcher never builds a receive transport. Voice is peer to peer and keeps working - which is exactly what made this so hard to see. The roster is right, every status reads connected, the tiles are just empty forever.

## The change

The SFU had no reason to be on the shared network: nothing routes to it by hostname from outside, it has no traefik labels, and its media ports are published straight to the host. A per-project network gives it a namespace of its own. The frontend keeps both - `dokploy-network` for traefik, `internal` to reach what it proxies.

`.env.example` explains the trap so the next service added by name does not walk into it.

## Why not a dedicated SFU hostname

That is the better end state - it also fills `sfuUrls` so `sfuForRoom()` can hash rooms across several SFUs - but it needs a DNS record, a certificate and a traefik route, and it puts signalling through traefik. This PR is the bug fix; that is an architecture change worth doing on its own when there is a second SFU to place.

## Measured impact

Before, against dev: `call-video` failed 4 of 4, `call-late-join` 1 of 4, voice 8 of 8 passed. The lab (#39) reproduces it on demand, and #40 makes it visible to users while it exists.