### PR TITLE
files: cap the WebRTC links a room's backlog can open

### DIFF
--- a/frontend/src/lib/telemetry/taps.ts
+++ b/frontend/src/lib/telemetry/taps.ts
@@ -403,7 +403,23 @@ function onWindowError(e: ErrorEvent): void {
   rec(errorEvent("uncaught", e.error ?? e.message));
 }
 
+/**
+ * Gossipsub writing GRAFT/PRUNE to a stream a departing peer just closed.
+ * The transport suppresses it as known-benign noise and records it as
+ * `stream.reset`; without this the same rejection was also logged as a
+ * `runtime.error`, and a bundle from a perfectly healthy session opened on
+ * two dozen "errors" that were one harmless race counted twice.
+ */
+export function isBenignStreamRejection(reason: unknown): boolean {
+  const r = reason as { name?: string; message?: string } | undefined;
+  return (
+    r?.name === "StreamStateError" &&
+    /stream that is closed/i.test(r?.message ?? "")
+  );
+}
+
 function onRejection(e: PromiseRejectionEvent): void {
+  if (isBenignStreamRejection(e.reason)) return;
   rec(errorEvent("rejection", e.reason));
 }
 

--- a/frontend/src/lib/transport/file/webtorrent.test.ts
+++ b/frontend/src/lib/transport/file/webtorrent.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const HASH = "a".repeat(40);
 const addedPeers: Array<{ id?: string }> = [];
+const livePeers: Array<unknown> = [];
+const addCalls: string[] = [];
 
 class FakeTorrent extends EventEmitter {
   infoHash = "";
@@ -21,6 +23,10 @@ const torrents = new Map<string, FakeTorrent>();
 vi.mock("simple-peer", () => {
   class FakePeer extends EventEmitter {
     destroyed = false;
+    constructor() {
+      super();
+      livePeers.push(this as never);
+    }
     signal(): void {}
     destroy(): void {
       this.destroyed = true;
@@ -36,9 +42,13 @@ vi.mock("webtorrent", () => {
       return torrents.get(infoHash) ?? null;
     }
     add(infoHash: string) {
+      addCalls.push(infoHash);
       const torrent = new FakeTorrent();
       torrent.infoHash = infoHash;
-      torrents.set(infoHash, torrent);
+      // webtorrent parses the torrent id asynchronously, so client.get() does
+      // not find a just-added torrent on the same tick - the window a second
+      // add() lands in and gets destroyed with "Cannot add duplicate torrent".
+      setTimeout(() => torrents.set(infoHash, torrent), 0);
       return torrent;
     }
     seed(_file: File, _opts: unknown, cb: (t: FakeTorrent) => void) {
@@ -72,7 +82,33 @@ const tick = () => new Promise((r) => setTimeout(r, 0));
 describe("WebTorrentFileTransport", () => {
   beforeEach(() => {
     addedPeers.length = 0;
+    livePeers.length = 0;
+    addCalls.length = 0;
     torrents.clear();
+  });
+
+  it("caps the WebRTC links a roomful of files can open at once", async () => {
+    const t = new WebTorrentFileTransport(() => "me");
+    // One file, more seeders for it than the cap allows.
+    for (let i = 0; i < 50; i++) {
+      const peerId = `peer${i}`;
+      t.onPeerConnect(peerId);
+      t.registerSeeder(file, peerId);
+    }
+    t.ensureDownload(file);
+    await tick();
+    expect(livePeers.length).toBeLessThanOrEqual(32);
+    expect(livePeers.length).toBe(32);
+  });
+
+  it("adds a torrent once when the same file is requested twice at once", async () => {
+    const t = new WebTorrentFileTransport(() => "me");
+    // A message arriving and a seeder announcing both ask for the same file.
+    t.ensureDownload(file);
+    t.ensureDownload(file);
+    await tick();
+    await tick();
+    expect(addCalls).toEqual([HASH]);
   });
 
   it("gives every wire a distinct id so webtorrent can hold more than one", async () => {
@@ -82,6 +118,7 @@ describe("WebTorrentFileTransport", () => {
     t.registerSeeder(file, "alice");
     t.registerSeeder(file, "bob");
     t.ensureDownload(file);
+    await tick();
     await tick();
 
     const peers = (t as never as { wtPeers: Map<string, EventEmitter> }).wtPeers;

--- a/frontend/src/lib/transport/file/webtorrent.ts
+++ b/frontend/src/lib/transport/file/webtorrent.ts
@@ -32,6 +32,21 @@ type TorrentLike = {
 const WT_RECONCILE_MS = 5_000;
 /** Ceiling on the per-pair retry wait. */
 const WT_RETRY_MAX_MS = 60_000;
+/**
+ * Live WebRTC links for file transfer, across every (file, peer) pair.
+ *
+ * Each pair gets its own RTCPeerConnection, and the pairs multiply: joining a
+ * room replays its whole history, every image in it starts downloading, and
+ * each one dials every seeder that has it. A room with a few hundred images
+ * and a roomful of people asked for thousands of connections at once - Chrome
+ * caps a tab at 500 and throws "Cannot create so many PeerConnections", which
+ * took the call down with it because voice could no longer get one either.
+ * Capped here rather than at any one caller: reconcile, registerSeeder,
+ * ensureDownload and handleSignal all build links through createWTPeer. Pairs
+ * over the cap are not dropped, just deferred - the reconcile tick dials them
+ * as transfers finish and slots come free.
+ */
+const MAX_WT_PEERS = 32;
 /** Distinct infoHashes a single peer may have registered with us at once. */
 const MAX_INFOHASHES_PER_PEER = 64;
 /** Distinct infoHashes tracked in total, across every peer. */
@@ -92,6 +107,15 @@ export class WebTorrentFileTransport implements FileTransferTransport {
   private wtBackoff = new Map<string, number>();
   private wtReconcileTimer: ReturnType<typeof setInterval> | null = null;
   private attachedTorrents = new Set<string>();
+  /**
+   * infoHashes whose torrent is being added right now. ensureDownload reads
+   * client.get() and calls client.add() on the far side of an await, so two
+   * calls for the same file - and there are always two, because a message
+   * arriving and a seeder announcing both trigger one - each saw no torrent
+   * and each added it. webtorrent answers the second with "A torrent with the
+   * same id is already being seeded" on an unhandled rejection.
+   */
+  private addingTorrents = new Set<string>();
   private seedingByHash = new Map<string, boolean>();
 
   private localFileLookup: ((infoHash: string) => Promise<File | null>) | null =
@@ -136,13 +160,16 @@ export class WebTorrentFileTransport implements FileTransferTransport {
         const key = wtKey(infoHash, peerId);
         if (this.wtPeers.has(key)) continue;
         if (now < (this.wtNextTry.get(key) ?? 0)) continue;
+        // Backoff is for a peer that will not answer. A pair held back by the
+        // cap has not been tried at all, so it keeps its place at the front of
+        // the queue instead of being pushed out to the next retry window.
+        if (!this.createWTPeer(infoHash, peerId, true)) continue;
         const wait = Math.min(
           Math.max((this.wtBackoff.get(key) ?? 0) * 2, WT_RECONCILE_MS),
           WT_RETRY_MAX_MS
         );
         this.wtBackoff.set(key, wait);
         this.wtNextTry.set(key, now + wait);
-        this.createWTPeer(infoHash, peerId, true);
       }
     }
   }
@@ -276,19 +303,25 @@ export class WebTorrentFileTransport implements FileTransferTransport {
       return;
     }
 
-    void this.client().then((client) => {
-      const torrent = client.get(
-        file.infoHash
-      ) as unknown as TorrentLike | null;
-      if (!torrent) {
-        const added = client.add(file.infoHash, {
-          announce: [],
-        }) as TorrentLike;
-        this.attachTorrent(added, false, file);
-      } else {
-        this.attachTorrent(torrent, false, file);
-      }
-    });
+    if (!this.addingTorrents.has(file.infoHash)) {
+      this.addingTorrents.add(file.infoHash);
+      void this.client()
+        .then((client) => {
+          const torrent = client.get(
+            file.infoHash
+          ) as unknown as TorrentLike | null;
+          if (torrent) {
+            this.attachTorrent(torrent, false, file);
+            return;
+          }
+          const added = client.add(file.infoHash, {
+            announce: [],
+          }) as TorrentLike;
+          this.attachTorrent(added, false, file);
+        })
+        .catch(() => {})
+        .finally(() => this.addingTorrents.delete(file.infoHash));
+    }
 
     this.upsertTransfer({
       ...file,
@@ -555,9 +588,10 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     infoHash: string,
     peerId: string,
     initiator: boolean
-  ): void {
+  ): boolean {
     const key = wtKey(infoHash, peerId);
-    if (this.wtPeers.has(key)) return;
+    if (this.wtPeers.has(key)) return false;
+    if (this.wtPeers.size >= MAX_WT_PEERS) return false;
 
     const peer = new SimplePeer({
       initiator,
@@ -605,6 +639,7 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     peer.on("close", () => {
       this.wtPeers.delete(key);
     });
+    return true;
   }
 
   private attachTorrent(

--- a/frontend/src/lib/transport/libp2p/transport.ts
+++ b/frontend/src/lib/transport/libp2p/transport.ts
@@ -14,7 +14,7 @@ import type { Connection, Stream } from "@libp2p/interface";
 import type { StreamMessageEvent, StreamCloseEvent } from "@libp2p/interface";
 import { errText, ev } from "$lib/telemetry/event";
 import { beginSession, rec, refs } from "$lib/telemetry/recorder";
-import { recTransportEvent } from "$lib/telemetry/taps";
+import { isBenignStreamRejection, recTransportEvent } from "$lib/telemetry/taps";
 
 // js-libp2p exposes no public "reserve a relay slot now" API. Listening on a
 // `<relay>/p2p-circuit` address is what triggers a reservation, and we need to
@@ -348,11 +348,7 @@ export class LibP2PTransport implements PeerTransport {
     if (typeof window === "undefined" || this.noiseFilterInstalled) return;
     this.noiseFilterInstalled = true;
     window.addEventListener("unhandledrejection", (e) => {
-      const r = e.reason as { name?: string; message?: string } | undefined;
-      if (
-        r?.name === "StreamStateError" &&
-        /stream that is closed/i.test(r?.message ?? "")
-      ) {
+      if (isBenignStreamRejection(e.reason)) {
         this.debugStats.suppressedStreamErrors++;
         rec(
           ev("stream.reset", {


### PR DESCRIPTION
## What the bundle showed

A diagnostic bundle from prod (`cbeeb19`), taken right after "Failed to construct 'RTCPeerConnection': Cannot create so many PeerConnections":

```
t=4.7s    pcLive: 0    pcCreated: 0
t=15.2s   pcLive: 73   pcCreated: 73     <- 73 in ten seconds
t=24.7s   pcLive: 75   pcCreated: 75
t=34.7s   pcLive: 2    pcCreated: 75
t=44.7s   pcLive: 30   pcCreated: 104
t=134.7s  pcLive: 72   pcCreated: 155
t=244.7s  pcLive: 46   pcCreated: 205
```

None of them belonged to the call. The timeline puts the burst between `app.join` and the first `sfu.join`, interleaved with `file.request` for `f1` through `f171` and a suppression counter reporting a further 613 in one second.

## Why

Joining replays the room's whole history. Every image in it goes through `ensureDownload`, and `reconcileWtPeers` dials every seeder of every still-downloading file every five seconds: one `RTCPeerConnection` per (file, peer) pair, with nothing bounding the product. A couple of hundred images and twenty people in the room asks for thousands at once. Chrome caps a tab at 500.

Voice was collateral. `sfu.error` at t=21.9s is the same constructor failing, and the WebRTC peer dials that time out just after it are the same shortage. The call looked broken; the fault was in file transfer.

## Changes

- Cap live file-transfer links at 32, in `createWTPeer`, where `reconcileWtPeers`, `registerSeeder`, `ensureDownload` and `handleSignal` all route. Pairs over the cap are deferred rather than dropped: the reconcile tick dials them as transfers finish. It also no longer spends a pair's retry backoff on a dial it never attempted, so a pair held back by the cap keeps its place in the queue.
- Close the duplicate-add race behind "A torrent with the same id is already being seeded". `ensureDownload` reads `client.get()` and calls `client.add()` across an await, and webtorrent does not publish a torrent's infoHash until it has parsed the id, so two calls for the same file both found nothing and both added it. The second was destroyed with "Cannot add duplicate torrent", taking the transfer with it.
- The bundle's 25 uncaught rejections were the gossipsub close race the transport already suppresses as benign, counted a second time by the telemetry tap. One shared predicate now, so a healthy session stops reporting two dozen errors that are not there.

## Tests

Two new cases in `webtorrent.test.ts`, both failing on `dev`:

```
AssertionError: expected 50 to be less than or equal to 32
AssertionError: expected [ ...(2) ] to deeply equal [ Array(1) ]
```

The fake client now mirrors webtorrent in registering a torrent's infoHash a tick after the add, which is the window the race lands in.

Full suite: 1297 passing, typecheck clean.