### PR TITLE
Dev to main: publish-build accepts the verifier's 'nothing verified' exit

### DIFF
--- a/.github/workflows/publish-build.yml
+++ b/.github/workflows/publish-build.yml
@@ -93,12 +93,27 @@ jobs:
       # drift, and the drift would look like a failed verification.
       - name: fingerprint it
         run: |
+          # awful-verify's exit code is a verdict: 0 only when the digest
+          # matches a published record. Here there cannot be one - this job is
+          # what publishes it - so "nothing verified" (1) is the expected
+          # answer, and the JSON it wrote is what gets judged below. Anything
+          # above 1 is a usage or fetch failure and still fails the job.
+          # --no-published skips the lookup that would only ever miss.
+          set +e
           npx --yes github:awful-org/awful-verify http://localhost:8123 \
-            --no-rebuild --json > /tmp/fingerprint.json
+            --no-rebuild --no-published --json > /tmp/fingerprint.json
+          code=$?
+          set -e
+          if [ "$code" -gt 1 ]; then
+            echo "::error::awful-verify failed (exit $code)"
+            cat /tmp/fingerprint.json
+            exit "$code"
+          fi
           node -e '
             const fs = require("fs");
             const fp = JSON.parse(fs.readFileSync("/tmp/fingerprint.json", "utf8"));
             if (!fp.claim) throw new Error("the image served no build declaration");
+            if (!Array.isArray(fp.files) || fp.files.length === 0) throw new Error("the fingerprint lists no files");
             if (fp.files.some((f) => !f.hash)) throw new Error("some files could not be read");
             const record = {
               schema: "awful-build-record/1",


### PR DESCRIPTION
The publish-build workflow failed on main at the fingerprint step with no output: awful-verify's latest version exits 1 in fingerprint mode unless the digest matches a published record, and in this job the record cannot exist yet because this job is what publishes it. Verified against the live instance: the fingerprint itself is complete (335 files, all hashed, build declaration present), only the exit code is 1 with `published.status: no-record`.

The step now accepts exit 1, passes `--no-published` so the lookup that can only miss is skipped, and judges the JSON it wrote: a claim, a non-empty file list, every file hashed. Exit codes above 1 (usage or fetch failure) still fail the job.

After this merges, the run on the new main commit publishes that commit's record. The previous main commit never got one.