### PR TITLE
call: the tile context menu belongs to the stream it is on

### DIFF
--- a/docs/plugin-surface.md
+++ b/docs/plugin-surface.md
@@ -24,6 +24,10 @@ this file and the README disagree, the README wins. What has grown since:
   targeted), a now-playing media surface (`setNowPlaying`), and call-view
   plugin TILES with join presence - the "no surfaces outside chat" non-goal
   fell (waffle-party exercises all of it).
+- Call tiles gained a per-plugin RIGHT-CLICK menu (`callTileMenu`): the
+  stage's menu is per stream now - a camera, a screen share, an offered
+  share and a plugin tile each get their own rows - and a plugin adds its
+  own (float the video, mute it here, skip) beside the host's.
 - A server-side component exists after all: the relay's plugin proxy
   (`PLUGIN_PROXY_HOSTS` / `PLUGIN_PROXY_SECRETS`) so plugins can call
   allowlisted third-party APIs without leaking client IPs or shipping keys.

--- a/frontend/plugins/README.md
+++ b/frontend/plugins/README.md
@@ -262,9 +262,10 @@ and other users are unaffected.
 
 ### Surfaces
 
-A plugin can render in more places than the chat. All are optional
-components on the definition. `widget` and `callTile` receive the card
-props (`{ card, cardState, host }`); `localCard` has its own (below):
+A plugin can render in more places than the chat. All are optional entries
+on the definition - components, except `callTileMenu`, which returns menu
+rows. `widget` and `callTile` receive the card props (`{ card, cardState,
+host }`); `localCard` has its own (below):
 
 - `localCard` - a private, session-only surface opened with
   `host.showLocalCard(data)`. It FLOATS over the invoking client's
@@ -317,6 +318,45 @@ props (`{ card, cardState, host }`); `localCard` has its own (below):
   mouse moves over the call section, hidden on idle in fullscreen); gate
   your control overlays on it so all chrome moves together.
 
+- `callTileMenu` - extra rows for your call tile's RIGHT-CLICK menu, so a
+  viewer finds the controls of a stream where they expect them. The host
+  menu is per stream: a camera offers a per-person volume, a screen share
+  offers picture-in-picture and "stop watching", and your tile offers
+  focus, fullscreen and "Leave" plus whatever you return here. Not a pure
+  hook - it is called on each right-click of a JOINED tile and receives
+  `{ card, cardState, host, joined }`, so close over the host and read
+  your live state:
+
+  ```ts
+  callTileMenu: ({ card, cardState, host }) => [
+    {
+      id: "pip",
+      label: "Picture in picture",
+      icon: "lucide:picture-in-picture-2",
+      run: () => video && host.pictureInPicture(video),
+    },
+    {
+      id: "mute",
+      label: "Mute for me",
+      checked: muted,
+      run: () => (muted = !muted),
+    },
+  ],
+  ```
+
+  Picture-in-picture is YOURS to offer, because the host cannot float
+  media it does not render (and nobody but the browser can float a video
+  inside a cross-origin iframe - there the browser's own menu stays
+  reachable). `run` fires on the client that clicked, inside the click's
+  own gesture, which is what `host.pictureInPicture` needs. Say in the
+  label which side an action lands on: "Mute for me" is this device,
+  "Pause" through `sendUpdate` pauses the party for everyone. `icon`
+  takes the manifest's emoji or `lucide:<kebab-name>` form; `checked`
+  draws a check mark, `disabled` greys the row and `danger` colours it
+  destructive. The host caps the list at eight items, trims labels to 40
+  characters, and drops the whole list (never the menu) if the hook or an
+  item throws.
+
 - `settings` - app-level configuration, opened from a gear on this
   plugin's row in Settings > Plugins. Announce it with `hasSettings:
   true` in the MANIFEST so the host can draw the gear without loading
@@ -348,8 +388,8 @@ to load the plugin with a clear "needs a newer awful.chat" line instead
 of mounting code that crashes. Current feature names: `room-context`,
 `resolve-room-image`, `open-message`, `confirm`, `plugin-settings`,
 `call-audio`, `call-capture`, `clock-sample`, `local-card`,
-`now-playing`, `plugin-stream`, `picture-in-picture`. Declare only what
-you truly cannot function without. A feature that only adds a button is
+`now-playing`, `plugin-stream`, `picture-in-picture`, `call-tile-menu`.
+Declare only what you truly cannot function without. A feature that only adds a button is
 better guarded at the call site (`typeof host.pictureInPicture ===
 "function"`) so the plugin still loads on an older app and just hides the
 button. Only `$lib/plugins/api`, `$lib/plugins/ui` and `$lib/plugins/watch`

--- a/frontend/src/lib/call-tile-menu.test.ts
+++ b/frontend/src/lib/call-tile-menu.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildTileMenu,
+  tileMenuHeight,
+  tileMenuState,
+  tileMenuTitle,
+  PLUGIN_MENU_MAX_ITEMS,
+  type TileMenuAction,
+  type TileMenuRow,
+} from "./call-tile-menu";
+
+/** The action names of a menu, in order - what a click can actually do. */
+function actions(rows: TileMenuRow[]): TileMenuAction["kind"][] {
+  return rows
+    .filter((r) => r.type === "item")
+    .map((r) => (r as { action: TileMenuAction }).action.kind);
+}
+
+function labels(rows: TileMenuRow[]): string[] {
+  return rows
+    .filter((r) => r.type === "item")
+    .map((r) => (r as { label: string }).label);
+}
+
+describe("buildTileMenu", () => {
+  it("offers a remote camera the person, not the stream", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "camera",
+        label: "Ada",
+        hasVideo: true,
+        pipSupported: true,
+        canMessage: true,
+      })
+    );
+    expect(actions(rows)).toEqual(["focus", "pip", "fullscreen", "message"]);
+    // The per-peer slider is the app's only real per-person mute.
+    expect(rows).toContainEqual({ type: "volume", target: "peer" });
+    expect(rows[0]).toEqual({ type: "label", text: "Ada" });
+  });
+
+  it("drops Message for a peer with no DM route", () => {
+    const rows = buildTileMenu(
+      tileMenuState({ kind: "camera", label: "Ada", canMessage: false })
+    );
+    expect(actions(rows)).not.toContain("message");
+    expect(rows).toContainEqual({ type: "volume", target: "peer" });
+  });
+
+  it("gives the local camera its own devices and never a volume slider", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "camera",
+        label: "You",
+        isLocal: true,
+        hasVideo: true,
+        pipSupported: true,
+        cameraOff: false,
+        micMuted: true,
+      })
+    );
+    expect(actions(rows)).toEqual([
+      "focus",
+      "pip",
+      "fullscreen",
+      "toggle-camera",
+      "toggle-mic",
+    ]);
+    expect(labels(rows)).toContain("Turn off camera");
+    expect(labels(rows)).toContain("Unmute microphone");
+    expect(rows.some((r) => r.type === "volume")).toBe(false);
+  });
+
+  it("labels the local camera toggles by the state they move to", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "camera",
+        label: "You",
+        isLocal: true,
+        cameraOff: true,
+        micMuted: false,
+      })
+    );
+    expect(labels(rows)).toContain("Turn on camera");
+    expect(labels(rows)).toContain("Mute microphone");
+  });
+
+  it("lets you end only your OWN share", () => {
+    const mine = buildTileMenu(
+      tileMenuState({
+        kind: "screen",
+        label: "You",
+        isLocal: true,
+        hasVideo: true,
+        pipSupported: true,
+      })
+    );
+    expect(actions(mine)).toEqual(["focus", "pip", "fullscreen", "stop-sharing"]);
+    expect(mine.find((r) => r.type === "label")).toEqual({
+      type: "label",
+      text: "Your screen",
+    });
+
+    const theirs = buildTileMenu(
+      tileMenuState({ kind: "screen", label: "Ada", hasVideo: true })
+    );
+    expect(actions(theirs)).not.toContain("stop-sharing");
+  });
+
+  it("offers a watched share its audio and the way out", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "transmission",
+        label: "Ada",
+        hasVideo: true,
+        isWatched: true,
+        pipSupported: true,
+        shareAudio: true,
+      })
+    );
+    expect(actions(rows)).toEqual([
+      "focus",
+      "pip",
+      "fullscreen",
+      "mute-share",
+      "stop-watching",
+    ]);
+    expect(rows).toContainEqual({ type: "volume", target: "share" });
+    // Stop watching is destructive and must be last, never where Focus was.
+    const last = rows[rows.length - 1];
+    expect(last).toMatchObject({ danger: true, label: "Stop watching" });
+  });
+
+  it("flips the share-audio item once it is silenced", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "transmission",
+        label: "Ada",
+        isWatched: true,
+        shareAudio: true,
+        shareMuted: true,
+      })
+    );
+    expect(actions(rows)).toContain("unmute-share");
+    expect(actions(rows)).not.toContain("mute-share");
+  });
+
+  it("hides share-audio rows when the share carries no audio", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "transmission",
+        label: "Ada",
+        isWatched: true,
+        shareAudio: false,
+      })
+    );
+    expect(actions(rows)).not.toContain("mute-share");
+    expect(rows.some((r) => r.type === "volume")).toBe(false);
+  });
+
+  it("reduces an offered share to the one thing it can do", () => {
+    const rows = buildTileMenu(
+      tileMenuState({ kind: "transmission", label: "Ada", isPending: true })
+    );
+    expect(actions(rows)).toEqual(["watch"]);
+    expect(labels(rows)).toEqual(["Watch Ada's screen"]);
+  });
+
+  it("keeps picture-in-picture off a tile with no track to float", () => {
+    const noTrack = buildTileMenu(
+      tileMenuState({ kind: "camera", label: "Ada", pipSupported: true })
+    );
+    expect(actions(noTrack)).not.toContain("pip");
+
+    const noSupport = buildTileMenu(
+      tileMenuState({ kind: "camera", label: "Ada", hasVideo: true })
+    );
+    expect(actions(noSupport)).not.toContain("pip");
+  });
+
+  it("offers to leave picture-in-picture only for the tile that is floating", () => {
+    const floating = buildTileMenu(
+      tileMenuState({
+        kind: "screen",
+        label: "Ada",
+        hasVideo: true,
+        pipSupported: true,
+        pipOpen: true,
+        isFocused: true,
+      })
+    );
+    expect(actions(floating)).toContain("exit-pip");
+
+    const other = buildTileMenu(
+      tileMenuState({
+        kind: "screen",
+        label: "Ada",
+        hasVideo: true,
+        pipSupported: true,
+        pipOpen: true,
+        isFocused: false,
+      })
+    );
+    expect(actions(other)).toContain("pip");
+    expect(actions(other)).not.toContain("exit-pip");
+  });
+
+  it("mirrors focus and fullscreen state in the labels", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "camera",
+        label: "Ada",
+        isFocused: true,
+        isFullscreen: true,
+      })
+    );
+    expect(actions(rows)).toContain("unfocus");
+    expect(actions(rows)).toContain("exit-fullscreen");
+    expect(actions(rows)).not.toContain("focus");
+  });
+
+  it("asks an unjoined plugin tile for nothing but consent", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "plugin",
+        label: "Waffle party",
+        pluginItems: [{ label: "Pause" }],
+      })
+    );
+    // Opt-in is the invariant: no plugin item runs before the user joins.
+    expect(actions(rows)).toEqual(["join-plugin"]);
+    expect(labels(rows)).toEqual(["Join Waffle party"]);
+  });
+
+  it("puts a joined plugin's own items between the host's rows", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "plugin",
+        label: "Waffle party",
+        joined: true,
+        pluginItems: [
+          { label: "Picture in picture" },
+          { label: "Mute", checked: true },
+          { label: "Skip", disabled: true },
+        ],
+      })
+    );
+    expect(actions(rows)).toEqual([
+      "focus",
+      "fullscreen",
+      "plugin",
+      "plugin",
+      "plugin",
+      "leave-plugin",
+    ]);
+    expect(labels(rows)).toEqual([
+      "Focus",
+      "Fullscreen",
+      "Picture in picture",
+      "Mute",
+      "Skip",
+      "Leave Waffle party",
+    ]);
+    const items = rows.filter((r) => r.type === "item") as Array<{
+      action: TileMenuAction;
+      checked?: boolean;
+      disabled?: boolean;
+    }>;
+    // Indices address the plugin's own array, in its own order.
+    expect(items[2].action).toEqual({ kind: "plugin", index: 0 });
+    expect(items[3]).toMatchObject({ checked: true });
+    expect(items[4]).toMatchObject({ disabled: true });
+  });
+
+  it("never offers host picture-in-picture on a plugin tile", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "plugin",
+        label: "Waffle party",
+        joined: true,
+        // A plugin tile has no track; even claiming one must not add the row,
+        // because the host cannot float media it does not render.
+        hasVideo: true,
+        pipSupported: true,
+      })
+    );
+    expect(actions(rows)).not.toContain("pip");
+  });
+
+  it("caps and trims what a plugin may put in the menu", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "plugin",
+        label: "Loud plugin",
+        joined: true,
+        pluginItems: Array.from({ length: 40 }, (_, i) => ({
+          label: `${"x".repeat(200)}${i}`,
+        })),
+      })
+    );
+    const pluginItems = rows.filter(
+      (r) => r.type === "item" && r.action.kind === "plugin"
+    ) as Array<{ label: string }>;
+    expect(pluginItems).toHaveLength(PLUGIN_MENU_MAX_ITEMS);
+    for (const item of pluginItems) expect(item.label.length).toBeLessThanOrEqual(40);
+    // The host's own way out survives a flood.
+    expect(actions(rows).at(-1)).toBe("leave-plugin");
+  });
+
+  it("has a heading and no double separators for every kind", () => {
+    const kinds = ["camera", "screen", "transmission", "plugin"] as const;
+    for (const kind of kinds) {
+      for (const isLocal of [false, true]) {
+        const rows = buildTileMenu(
+          tileMenuState({ kind, label: "Ada", isLocal, joined: true })
+        );
+        expect(rows[0].type).toBe("label");
+        expect(rows.at(-1)!.type).not.toBe("separator");
+        rows.forEach((row, i) => {
+          if (row.type === "separator") {
+            expect(rows[i + 1]?.type).not.toBe("separator");
+          }
+        });
+      }
+    }
+  });
+});
+
+describe("tileMenuTitle", () => {
+  it("names a share by its owner", () => {
+    expect(
+      tileMenuTitle(tileMenuState({ kind: "transmission", label: "Ada" }))
+    ).toBe("Ada's screen");
+    expect(
+      tileMenuTitle(
+        tileMenuState({ kind: "screen", label: "Me", isLocal: true })
+      )
+    ).toBe("Your screen");
+  });
+
+  it("marks your own camera the way the tile badge does", () => {
+    expect(
+      tileMenuTitle(
+        tileMenuState({ kind: "camera", label: "Ada", isLocal: true })
+      )
+    ).toBe("Ada (You)");
+  });
+});
+
+describe("tileMenuHeight", () => {
+  it("grows with the rows so the clamp keeps a long menu on screen", () => {
+    const short = buildTileMenu(
+      tileMenuState({ kind: "transmission", label: "Ada", isPending: true })
+    );
+    const long = buildTileMenu(
+      tileMenuState({
+        kind: "plugin",
+        label: "Waffle party",
+        joined: true,
+        pluginItems: Array.from({ length: 8 }, (_, i) => ({ label: `i${i}` })),
+      })
+    );
+    expect(tileMenuHeight(short)).toBeLessThan(tileMenuHeight(long));
+    expect(tileMenuHeight([])).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/lib/call-tile-menu.ts
+++ b/frontend/src/lib/call-tile-menu.ts
@@ -1,0 +1,383 @@
+/**
+ * What the right-click menu of ONE call tile offers.
+ *
+ * Pure and unit-tested, for the same reason `call-tiles.ts` is: the rules
+ * are "which controls does this stream have", not "how does a menu paint".
+ * A right-click on a screen share, on your own camera, and on a plugin's
+ * tile are three different questions, and before this module the stage
+ * answered all three with one peer menu (message plus a volume slider) that
+ * plugin and local tiles were excluded from outright - so right-clicking a
+ * watch-together tile configured the whole grid instead.
+ *
+ * The rows carry an ACTION NAME, never a callback: the store calls live in
+ * the stage, so this module stays free of transport, Svelte and the DOM.
+ */
+
+export type TileMenuKind = "camera" | "screen" | "transmission" | "plugin";
+
+/** Icon keys the stage maps to lucide components. */
+export type TileMenuIcon =
+  | "pin"
+  | "pin-off"
+  | "pip"
+  | "fullscreen"
+  | "fullscreen-exit"
+  | "message"
+  | "watch"
+  | "stop-watching"
+  | "screen-off"
+  | "camera"
+  | "camera-off"
+  | "mic"
+  | "mic-off"
+  | "volume"
+  | "volume-off"
+  | "join"
+  | "leave"
+  | "plugin";
+
+export type TileMenuAction =
+  /** Spotlight this tile / release the pin. */
+  | { kind: "focus" }
+  | { kind: "unfocus" }
+  /** The browser's own floating window, following the pinned tile. */
+  | { kind: "pip" }
+  | { kind: "exit-pip" }
+  | { kind: "fullscreen" }
+  | { kind: "exit-fullscreen" }
+  | { kind: "message" }
+  /** Subscribe to an offered SFU share / drop the one being watched. */
+  | { kind: "watch" }
+  | { kind: "stop-watching" }
+  | { kind: "stop-sharing" }
+  | { kind: "toggle-camera" }
+  | { kind: "toggle-mic" }
+  /** Silence the share's own audio, not the sharer's voice. */
+  | { kind: "mute-share" }
+  | { kind: "unmute-share" }
+  | { kind: "join-plugin" }
+  | { kind: "leave-plugin" }
+  /** Run the plugin's own item, by its index in `pluginItems`. */
+  | { kind: "plugin"; index: number };
+
+export type TileMenuRow =
+  | { type: "label"; text: string }
+  | { type: "separator" }
+  | {
+      type: "item";
+      label: string;
+      icon: TileMenuIcon;
+      action: TileMenuAction;
+      /** Rendered as a check mark, i.e. `role="menuitemcheckbox"`. */
+      checked?: boolean;
+      disabled?: boolean;
+      /** Destructive: leaves, stops, hangs up. */
+      danger?: boolean;
+      /** A plugin's own emoji or "lucide:<name>" string. */
+      pluginIcon?: string;
+    }
+  /** A slider, not an item: `peer` is a person's voice, `share` a share's audio. */
+  | { type: "volume"; target: "peer" | "share" };
+
+/**
+ * One item a plugin declared for its own call tile. The host validates and
+ * caps these (see PLUGIN_MENU_MAX_ITEMS) before they reach the builder, so
+ * this module only positions them.
+ */
+export interface TileMenuPluginItem {
+  label: string;
+  /** Emoji, or "lucide:<kebab-name>" like a manifest icon. */
+  icon?: string;
+  checked?: boolean;
+  disabled?: boolean;
+  danger?: boolean;
+}
+
+/** Everything the menu needs to know about one tile, resolved by the stage. */
+export interface TileMenuState {
+  kind: TileMenuKind;
+  /** Display name of the tile, already resolved (the peer, or the plugin). */
+  label: string;
+  isLocal: boolean;
+  /** A video track is attached right now - what PiP needs to have something to float. */
+  hasVideo: boolean;
+  /** An SFU share offered to the room but not subscribed to. */
+  isPending: boolean;
+  /** This SFU share is the one being watched. */
+  isWatched: boolean;
+  /** This tile holds the spotlight. */
+  isFocused: boolean;
+  isFullscreen: boolean;
+  pipSupported: boolean;
+  /** The browser's PiP window is open. */
+  pipOpen: boolean;
+  /** A remote peer with a real peer id, so a DM can be opened. */
+  canMessage: boolean;
+  cameraOff: boolean;
+  micMuted: boolean;
+  /** The share carries audio at all. */
+  shareAudio: boolean;
+  /** Share audio is silenced (output volume 0). */
+  shareMuted: boolean;
+  /** Plugin tiles: has this user opted in. */
+  joined: boolean;
+  /** Plugin tiles: the plugin's own items, host-validated. */
+  pluginItems: readonly TileMenuPluginItem[];
+}
+
+/** Defaults so a caller states only what its tile actually is. */
+export function tileMenuState(
+  partial: Partial<TileMenuState> & Pick<TileMenuState, "kind" | "label">
+): TileMenuState {
+  return {
+    isLocal: false,
+    hasVideo: false,
+    isPending: false,
+    isWatched: false,
+    isFocused: false,
+    isFullscreen: false,
+    pipSupported: false,
+    pipOpen: false,
+    canMessage: false,
+    cameraOff: false,
+    micMuted: false,
+    shareAudio: false,
+    shareMuted: false,
+    joined: false,
+    pluginItems: [],
+    ...partial,
+  };
+}
+
+/** A plugin's tile menu is a short list of controls, not a second UI. */
+export const PLUGIN_MENU_MAX_ITEMS = 8;
+export const PLUGIN_MENU_MAX_LABEL = 40;
+
+function focusRow(s: TileMenuState): TileMenuRow {
+  return s.isFocused
+    ? { type: "item", label: "Unfocus", icon: "pin-off", action: { kind: "unfocus" } }
+    : { type: "item", label: "Focus", icon: "pin", action: { kind: "focus" } };
+}
+
+function pipRows(s: TileMenuState): TileMenuRow[] {
+  // The host can only float a real video track. A plugin renders its own
+  // media (and a cross-origin iframe cannot be floated by anyone but the
+  // browser), so a plugin tile's PiP is the plugin's own menu item.
+  if (!s.pipSupported || !s.hasVideo) return [];
+  return s.pipOpen && s.isFocused
+    ? [
+        {
+          type: "item",
+          label: "Exit picture in picture",
+          icon: "pip",
+          action: { kind: "exit-pip" },
+        },
+      ]
+    : [
+        {
+          type: "item",
+          label: "Picture in picture",
+          icon: "pip",
+          action: { kind: "pip" },
+        },
+      ];
+}
+
+function fullscreenRow(s: TileMenuState): TileMenuRow {
+  return s.isFullscreen
+    ? {
+        type: "item",
+        label: "Exit fullscreen",
+        icon: "fullscreen-exit",
+        action: { kind: "exit-fullscreen" },
+      }
+    : {
+        type: "item",
+        label: "Fullscreen",
+        icon: "fullscreen",
+        action: { kind: "fullscreen" },
+      };
+}
+
+function shareAudioRows(s: TileMenuState): TileMenuRow[] {
+  if (!s.shareAudio) return [];
+  return [
+    s.shareMuted
+      ? {
+          type: "item",
+          label: "Unmute share audio",
+          icon: "volume",
+          action: { kind: "unmute-share" },
+        }
+      : {
+          type: "item",
+          label: "Mute share audio",
+          icon: "volume-off",
+          action: { kind: "mute-share" },
+        },
+    { type: "volume", target: "share" },
+  ];
+}
+
+function pluginRows(s: TileMenuState): TileMenuRow[] {
+  return s.pluginItems.slice(0, PLUGIN_MENU_MAX_ITEMS).map((item, index) => ({
+    type: "item" as const,
+    label: item.label.slice(0, PLUGIN_MENU_MAX_LABEL),
+    icon: "plugin" as const,
+    pluginIcon: item.icon,
+    action: { kind: "plugin" as const, index },
+    checked: item.checked,
+    disabled: item.disabled,
+    danger: item.danger,
+  }));
+}
+
+/**
+ * The rows for one tile's context menu, top to bottom.
+ *
+ * Ordering rule: what this tile IS first (focus, float, fullscreen), then
+ * who or what it belongs to (message the person, the plugin's own controls),
+ * and the way out last (stop watching, stop sharing, leave) - so the
+ * destructive row never lands where the previous menu's first item was.
+ */
+export function buildTileMenu(s: TileMenuState): TileMenuRow[] {
+  const rows: TileMenuRow[] = [
+    { type: "label", text: tileMenuTitle(s) },
+  ];
+
+  if (s.kind === "plugin") {
+    if (!s.joined) {
+      rows.push({
+        type: "item",
+        label: `Join ${s.label}`,
+        icon: "join",
+        action: { kind: "join-plugin" },
+      });
+      return rows;
+    }
+    rows.push(focusRow(s), fullscreenRow(s));
+    const plugin = pluginRows(s);
+    if (plugin.length) rows.push({ type: "separator" }, ...plugin);
+    rows.push({ type: "separator" }, {
+      type: "item",
+      label: `Leave ${s.label}`,
+      icon: "leave",
+      action: { kind: "leave-plugin" },
+      danger: true,
+    });
+    return rows;
+  }
+
+  // An offered share nobody subscribed to has one thing to offer.
+  if (s.kind === "transmission" && s.isPending) {
+    rows.push({
+      type: "item",
+      label: `Watch ${s.label}'s screen`,
+      icon: "watch",
+      action: { kind: "watch" },
+    });
+    return rows;
+  }
+
+  rows.push(focusRow(s), ...pipRows(s), fullscreenRow(s));
+
+  if (s.kind === "camera" && s.isLocal) {
+    rows.push(
+      { type: "separator" },
+      s.cameraOff
+        ? {
+            type: "item",
+            label: "Turn on camera",
+            icon: "camera",
+            action: { kind: "toggle-camera" },
+          }
+        : {
+            type: "item",
+            label: "Turn off camera",
+            icon: "camera-off",
+            action: { kind: "toggle-camera" },
+          },
+      s.micMuted
+        ? {
+            type: "item",
+            label: "Unmute microphone",
+            icon: "mic",
+            action: { kind: "toggle-mic" },
+          }
+        : {
+            type: "item",
+            label: "Mute microphone",
+            icon: "mic-off",
+            action: { kind: "toggle-mic" },
+          }
+    );
+    return rows;
+  }
+
+  if (s.isLocal) {
+    // Your own screen share: the only stream you can end for everyone.
+    rows.push({ type: "separator" }, {
+      type: "item",
+      label: "Stop sharing",
+      icon: "screen-off",
+      action: { kind: "stop-sharing" },
+      danger: true,
+    });
+    return rows;
+  }
+
+  const tail: TileMenuRow[] = [];
+  if (s.kind === "camera") {
+    if (s.canMessage) {
+      tail.push({
+        type: "item",
+        label: "Message",
+        icon: "message",
+        action: { kind: "message" },
+      });
+    }
+    // The per-person listening volume, the app's only real "mute them".
+    tail.push({ type: "volume", target: "peer" });
+  } else {
+    tail.push(...shareAudioRows(s));
+    if (s.isWatched) {
+      tail.push({
+        type: "item",
+        label: "Stop watching",
+        icon: "stop-watching",
+        action: { kind: "stop-watching" },
+        danger: true,
+      });
+    }
+  }
+  if (tail.length) rows.push({ type: "separator" }, ...tail);
+  return rows;
+}
+
+/** The menu's heading: whose stream this is, in the words the tiles use. */
+export function tileMenuTitle(s: TileMenuState): string {
+  if (s.kind === "plugin") return s.label;
+  if (s.kind === "screen" || s.kind === "transmission") {
+    return s.isLocal ? "Your screen" : `${s.label}'s screen`;
+  }
+  return s.isLocal ? `${s.label} (You)` : s.label;
+}
+
+/**
+ * How tall the menu will be, for the viewport clamp.
+ *
+ * Estimated from the row classes rather than measured: the menu is
+ * positioned in the same frame the right-click arrives in, and a measured
+ * height would need a paint first (which is the jump this avoids). The
+ * numbers are the rendered heights of the rows in the stage.
+ */
+export function tileMenuHeight(rows: readonly TileMenuRow[]): number {
+  let height = 8; // py-1 on the menu itself
+  for (const row of rows) {
+    if (row.type === "item") height += 32;
+    else if (row.type === "label") height += 22;
+    else if (row.type === "separator") height += 9;
+    else height += 62;
+  }
+  return height;
+}

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -71,14 +71,29 @@
     Puzzle,
     X as XIcon,
     Tv2,
+    Pin,
+    PinOff,
+    LogIn,
   } from "@lucide/svelte";
   import { Check, Columns2, MessageSquare, MonitorIcon, PictureInPicture2, Rows2, SlidersHorizontal, Users as UsersIcon, UserX } from "@lucide/svelte";
 import { profileStore, loadProfile } from "$lib/profile.svelte";
 import { displayPrefs, setCallChatBeside, setCallPip } from "$lib/display-prefs.svelte";
 import { cn } from "$lib/utils";
 import { callTilesState, refreshCallTiles } from "$lib/plugins/call-tiles.svelte";
-import { getManifest } from "$lib/plugins/registry";
-import { onCardStateChange } from "$lib/plugins/state.svelte";
+import { getManifest, getPlugin } from "$lib/plugins/registry";
+import { getCardState, onCardStateChange } from "$lib/plugins/state.svelte";
+import { makeHostApi } from "$lib/plugins/host";
+import { getMessage } from "$lib/storage";
+import type { CallTileMenuItem } from "$lib/plugins/api";
+import {
+  buildTileMenu,
+  tileMenuHeight,
+  tileMenuState,
+  type TileMenuAction,
+  type TileMenuIcon,
+  type TileMenuRow,
+  type TileMenuState,
+} from "$lib/call-tile-menu";
 import PluginCallTileView from "./PluginCallTileView.svelte";
 import PluginIcon from "$lib/plugins/PluginIcon.svelte";
 import { peerQualityState } from "$lib/call-peer-quality.svelte";
@@ -204,78 +219,6 @@ import {
       (did ? transportState.peerColors.get(did) : undefined) ??
       null
     );
-  }
-
-  // ── Context menus ─────────────────────────────────────────────────────────
-
-  let peerMenu = $state<{
-    peerId: string;
-    label: string;
-    x: number;
-    y: number;
-  } | null>(null);
-  /** Right-click on the call background: picks what the grid shows. */
-  let viewMenu = $state<{ x: number; y: number } | null>(null);
-  let peerVolumeSlider = $state(UNITY_STOP);
-
-  const peerVolumePercent = $derived(formatGain(sliderToGain(peerVolumeSlider)));
-
-  /**
-   * Keep a menu of this size inside the viewport. Both menus live inside the
-   * panel so they survive fullscreen, and a fixed child of a fullscreen
-   * element still measures against the viewport - so these coordinates hold
-   * either way.
-   */
-  function clampMenu(
-    e: MouseEvent,
-    width: number,
-    height: number
-  ): { x: number; y: number } {
-    const pad = 8;
-    return {
-      x: Math.max(pad, Math.min(e.clientX, window.innerWidth - width - pad)),
-      y: Math.max(pad, Math.min(e.clientY, window.innerHeight - height - pad)),
-    };
-  }
-
-  function openPeerMenu(e: MouseEvent, tile: TileData): void {
-    // The local tile has nothing to offer here, so the event is left to bubble
-    // to the panel and open the view menu instead. Plugin tiles are not
-    // peers - volume/profile entries would dereference a synthetic id.
-    if (tile.isLocal || !tile.peerId || tile.kind === "plugin") return;
-    e.preventDefault();
-    e.stopPropagation();
-    peerVolumeSlider = gainToSlider(getVoicePeerVolume(tile.peerId));
-    viewMenu = null;
-    peerMenu = { peerId: tile.peerId, label: tile.label, ...clampMenu(e, 224, 132) };
-  }
-
-  function openViewMenu(e: MouseEvent): void {
-    e.preventDefault();
-    peerMenu = null;
-    viewMenu = clampMenu(e, 224, 320);
-  }
-
-  function closeMenus(): void {
-    peerMenu = null;
-    viewMenu = null;
-  }
-
-  function onPeerVolume(value: number): void {
-    peerVolumeSlider = value;
-    if (peerMenu) setVoicePeerVolume(peerMenu.peerId, sliderToGain(value));
-  }
-
-  /**
-   * The floating panel, not the chat pane. Pointing the pane at the DM unmounts
-   * this call stage - the stage is gated on the pane showing the call's room -
-   * and the pane filters messages by the room the VIEW is on, so the DM
-   * rendered as an empty conversation you could send into but never see.
-   */
-  async function dmFromPeerMenu(): Promise<void> {
-    const peerId = peerMenu?.peerId;
-    closeMenus();
-    if (peerId) await openDmPanel(peerId);
   }
 
   // Peers whose voice ICE actually completed - a roster tile without a
@@ -657,6 +600,274 @@ import {
     }
     return tracks;
   });
+
+  // ── Context menus ─────────────────────────────────────────────────────────
+
+  /**
+   * Right-click on a tile. The menu is PER STREAM: what you can do to your
+   * own camera, to somebody's screen share, to an offered share you have not
+   * joined, and to a plugin's tile are four different lists - and this used
+   * to be one "peer menu" (message plus a volume slider) that local and
+   * plugin tiles were excluded from outright, so right-clicking a
+   * watch-together tile configured the whole grid instead.
+   *
+   * The tile id, not the tile: the rows resolve against `tiles` on every
+   * read, so a menu left open while the share ends or the party closes
+   * disappears with its tile instead of acting on something gone.
+   */
+  let tileMenu = $state<{ tileId: string; x: number; y: number } | null>(null);
+  /** Right-click on the call background: picks what the grid shows. */
+  let viewMenu = $state<{ x: number; y: number } | null>(null);
+  let peerVolumeSlider = $state(UNITY_STOP);
+
+  const peerVolumePercent = $derived(formatGain(sliderToGain(peerVolumeSlider)));
+
+  const tileMenuTile = $derived(
+    tileMenu ? (tiles.find((t) => t.id === tileMenu!.tileId) ?? null) : null
+  );
+
+  /** The open menu's plugin-declared rows, in the plugin's own order. */
+  let pluginMenuItems = $state<CallTileMenuItem[]>([]);
+  let pluginMenuSeq = 0;
+
+  const tileMenuRows = $derived(
+    tileMenuTile ? buildTileMenu(tileMenuStateFor(tileMenuTile)) : []
+  );
+
+  // Clamped from the ROW COUNT, so a plugin's items landing a tick after the
+  // menu opened still cannot push it off the bottom edge.
+  const tileMenuPos = $derived(
+    tileMenu
+      ? clampMenu(tileMenu.x, tileMenu.y, 224, tileMenuHeight(tileMenuRows))
+      : { x: 0, y: 0 }
+  );
+
+  /** Everything the menu builder asks about one tile, read live. */
+  function tileMenuStateFor(tile: TileData): TileMenuState {
+    const isShare = tile.kind === "screen" || tile.kind === "transmission";
+    return tileMenuState({
+      kind: tile.kind,
+      label: tile.label,
+      isLocal: tile.isLocal,
+      hasVideo: tile.videoTrack !== null,
+      isPending: !!tile.isPending,
+      isWatched:
+        tile.kind === "transmission" &&
+        watchingTransmissionPeerId === tile.peerId,
+      isFocused: callFocus.pinnedTileId === tile.id,
+      isFullscreen,
+      pipSupported: browserPipSupported(),
+      pipOpen: callPipPanel.browserPip,
+      canMessage: !tile.isLocal && !!tile.peerId,
+      cameraOff,
+      micMuted: muted,
+      // Screen-share audio, not the sharer's voice: it arrives as its own
+      // track and plays through the audio[data-remote] elements.
+      shareAudio:
+        isShare &&
+        !tile.isLocal &&
+        !!participants.get(tile.peerId)?.screenAudioTrack,
+      shareMuted: transmissionOutputVolume === 0,
+      joined: joinedPluginTiles.has(tile.id),
+      pluginItems: pluginMenuItems,
+    });
+  }
+
+  /**
+   * Keep a menu of this size inside the viewport. Every menu lives inside the
+   * panel so it survives fullscreen, and a fixed child of a fullscreen
+   * element still measures against the viewport - so these coordinates hold
+   * either way.
+   */
+  function clampMenu(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): { x: number; y: number } {
+    const pad = 8;
+    return {
+      x: Math.max(pad, Math.min(x, window.innerWidth - width - pad)),
+      y: Math.max(pad, Math.min(y, window.innerHeight - height - pad)),
+    };
+  }
+
+  function openTileMenu(e: MouseEvent, tile: TileData): void {
+    e.preventDefault();
+    e.stopPropagation();
+    // The remembered per-identity volume, so the slider is right even before
+    // this peer's first track arrives.
+    if (!tile.isLocal && tile.peerId && tile.kind === "camera") {
+      peerVolumeSlider = gainToSlider(getVoicePeerVolume(tile.peerId));
+    }
+    viewMenu = null;
+    pluginMenuItems = [];
+    tileMenu = { tileId: tile.id, x: e.clientX, y: e.clientY };
+    void loadPluginMenuItems(tile);
+  }
+
+  /**
+   * A plugin's own menu rows, asked for at right-click time.
+   *
+   * Not cached and not pure: the plugin builds them against its current
+   * state, closing over the host, which is what lets a watch-together tile
+   * offer "Picture in picture" for the video only it holds a reference to.
+   * The menu opens with the host's rows immediately and these append when
+   * the (already loaded, since the tile is mounted) definition, card row and
+   * folded state resolve. Seq-guarded: a second right-click always wins.
+   */
+  async function loadPluginMenuItems(tile: TileData): Promise<void> {
+    const seq = ++pluginMenuSeq;
+    if (tile.kind !== "plugin" || !tile.pluginId || !tile.cardId) return;
+    // Opt-in first: an unjoined tile runs no plugin action.
+    if (!joinedPluginTiles.has(tile.id)) return;
+    const roomCode = tile.pluginRoomCode ?? "";
+    try {
+      const plugin = await getPlugin(tile.pluginId);
+      if (!plugin?.callTileMenu) return;
+      const card = await getMessage(tile.cardId);
+      if (!card) return;
+      const cardState = await getCardState(tile.cardId, roomCode, plugin);
+      const items = plugin.callTileMenu({
+        card,
+        cardState,
+        host: makeHostApi(tile.pluginId, roomCode),
+        joined: true,
+      });
+      if (seq !== pluginMenuSeq) return;
+      pluginMenuItems = (Array.isArray(items) ? items : []).filter(
+        (item) =>
+          !!item &&
+          typeof item.label === "string" &&
+          typeof item.run === "function"
+      );
+    } catch (err) {
+      // A broken hook loses its rows, never the host's.
+      console.warn("[plugins] call tile menu failed:", err);
+    }
+  }
+
+  /**
+   * Run one row of the tile menu.
+   *
+   * Every branch is an existing store action - the menu is a second surface
+   * for controls the tile overlay already has, plus the ones it had no room
+   * for. The menu closes first, and the action runs in the SAME task as the
+   * click, because picture-in-picture needs the user gesture.
+   */
+  async function runTileAction(
+    tile: TileData,
+    action: TileMenuAction
+  ): Promise<void> {
+    const item =
+      action.kind === "plugin" ? pluginMenuItems[action.index] : undefined;
+    closeMenus();
+    switch (action.kind) {
+      case "focus":
+        callFocus.pinnedTileId = tile.id;
+        break;
+      case "unfocus":
+        callFocus.pinnedTileId = null;
+        break;
+      case "pip":
+        // Pin first: the browser's window follows the spotlight, which is
+        // the recipe the per-share overlay button already uses.
+        callFocus.pinnedTileId = tile.id;
+        await enterBrowserPip(() => void requestReturnToCall());
+        break;
+      case "exit-pip":
+        await exitBrowserPip();
+        break;
+      case "fullscreen":
+      case "exit-fullscreen":
+        toggleFullscreen();
+        break;
+      case "message":
+        // The floating panel, not the chat pane: pointing the pane at the DM
+        // unmounts this stage - it is gated on the pane showing the call's
+        // room - and the pane filters by the room the VIEW is on, so the DM
+        // rendered as an empty conversation you could send into but never see.
+        if (tile.peerId) await openDmPanel(tile.peerId);
+        break;
+      case "watch":
+        if (tile.producerId) watchTransmission(tile.peerId, tile.producerId);
+        break;
+      case "stop-watching":
+        stopWatchingTransmission();
+        break;
+      case "stop-sharing":
+        await stopScreenShare();
+        break;
+      case "toggle-camera":
+        await toggleCamera();
+        break;
+      case "toggle-mic":
+        await toggleMute();
+        break;
+      case "mute-share":
+        setTransmissionOutputVolume(0);
+        break;
+      case "unmute-share":
+        setTransmissionOutputVolume(1);
+        break;
+      case "join-plugin":
+        joinedPluginTiles = new Set([...joinedPluginTiles, tile.id]);
+        break;
+      case "leave-plugin":
+        joinedPluginTiles = new Set(
+          [...joinedPluginTiles].filter((id) => id !== tile.id)
+        );
+        break;
+      case "plugin":
+        try {
+          await item?.run();
+        } catch (err) {
+          console.warn("[plugins] call tile menu item failed:", err);
+        }
+        break;
+    }
+  }
+
+  function openViewMenu(e: MouseEvent): void {
+    e.preventDefault();
+    tileMenu = null;
+    viewMenu = clampMenu(e.clientX, e.clientY, 224, 320);
+  }
+
+  function closeMenus(): void {
+    tileMenu = null;
+    viewMenu = null;
+    pluginMenuItems = [];
+  }
+
+  function onPeerVolume(value: number): void {
+    peerVolumeSlider = value;
+    const peerId = tileMenuTile?.peerId;
+    if (peerId) setVoicePeerVolume(peerId, sliderToGain(value));
+  }
+
+  /** Which lucide glyph a menu row's icon key names. */
+  const TILE_MENU_ICONS: Record<TileMenuIcon, typeof Pin> = {
+    pin: Pin,
+    "pin-off": PinOff,
+    pip: PictureInPicture2,
+    fullscreen: Maximize,
+    "fullscreen-exit": Minimize,
+    message: MessageSquare,
+    watch: Eye,
+    "stop-watching": Radio,
+    "screen-off": MonitorOff,
+    camera: Camera,
+    "camera-off": CameraOff,
+    mic: Mic,
+    "mic-off": MicOff,
+    volume: Volume2,
+    "volume-off": VolumeX,
+    join: LogIn,
+    leave: CopyX,
+    plugin: Puzzle,
+  };
+
 
   // What the grid shows. "streaming" keeps anything worth watching - a camera
   // as much as a share - while "screens" narrows to shares alone, which is
@@ -1104,6 +1315,7 @@ import {
       role="button"
       tabindex={0}
       aria-label={isFocused ? "Minimize tile" : `Focus ${tile.label}`}
+      oncontextmenu={(e) => openTileMenu(e, tile)}
       onclick={() => {
         if (isOnlyOne) return;
         if (isFocused) onUnfocus();
@@ -1182,6 +1394,8 @@ import {
          opted you into loading a plugin's content, which is the one thing
          opt-in exists to prevent. -->
     <div
+      role="none"
+      oncontextmenu={(e) => openTileMenu(e, tile)}
       class="relative flex items-center justify-center overflow-hidden rounded-lg bg-muted/30 {isFocused
         ? 'w-full h-full'
         : ''} {compact ? 'aspect-video' : ''}"
@@ -1224,13 +1438,14 @@ import {
        one overlay. The layout classes live on the wrapper; the button fills
        it. -->
   <div
+    role="none"
+    oncontextmenu={(e) => openTileMenu(e, tile)}
     class="relative {isFocused ? 'w-full h-full' : ''} {compact
       ? 'aspect-video'
       : ''}"
   >
   <button
     type="button"
-    oncontextmenu={(e) => openPeerMenu(e, tile)}
     class="group relative flex h-full w-full items-center justify-center overflow-hidden rounded-lg bg-muted/30 cursor-pointer transition-shadow duration-200
       {tile.connecting ? 'connecting-wave' : ''}
       {isSpeaking
@@ -1647,7 +1862,15 @@ import {
          plugin controls re-enable their own. -->
     {#each joinedPluginTileData as pt (pt.id)}
       {@const rect = pluginRects[pt.id]}
+      <!-- The layer ignores the pointer, so a right-click over the plugin's
+           CONTENT already reaches the placeholder below. This handler is for
+           the plugin's own controls, which re-enable pointer events: without
+           it, a right-click on those bubbled to the panel and opened the
+           grid menu. Content inside a cross-origin iframe never reaches
+           either - the browser keeps its own menu there, by design. -->
       <div
+        role="none"
+        oncontextmenu={(e) => openTileMenu(e, pt)}
         class="pointer-events-none absolute z-10 overflow-hidden rounded-lg"
         style={rect
           ? `left:${rect.x}px; top:${rect.y}px; width:${rect.w}px; height:${rect.h}px;`
@@ -2255,54 +2478,91 @@ import {
       </div>
     {/if}
 
-    {#if peerMenu}
+    {#if tileMenu && tileMenuTile}
+      {@const menuTile = tileMenuTile}
       <!-- svelte-ignore a11y_click_events_have_key_events -->
       <div
         role="menu"
         tabindex="-1"
         class="fixed z-50 w-56 rounded-md border border-border bg-popover py-1 shadow-xl font-mono"
-        style="top: {peerMenu.y}px; left: {peerMenu.x}px"
+        style="top: {tileMenuPos.y}px; left: {tileMenuPos.x}px"
         onkeydown={() => {}}
         onclick={(e) => e.stopPropagation()}
         oncontextmenu={(e) => e.preventDefault()}
       >
-        <p class="truncate px-3 pb-1 pt-0.5 text-xs text-muted-foreground">
-          {peerMenu.label}
-        </p>
-
-        <button
-          type="button"
-          class="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted"
-          onclick={dmFromPeerMenu}
-        >
-          <MessageSquare class="size-4" />
-          Message
-        </button>
-
-        <div class="mt-1 border-t border-border px-3 pb-2 pt-2">
-          <div class="flex items-center justify-between pb-1.5">
-            <span class="text-xs text-muted-foreground">Volume</span>
-            <span
-              class="text-xs tabular-nums {peerVolumeSlider <= 0
-                ? 'text-destructive'
-                : 'text-primary'}">{peerVolumePercent}</span
+        {#each tileMenuRows as row, index (index)}
+          {#if row.type === "label"}
+            <p class="truncate px-3 pb-1 pt-0.5 text-xs text-muted-foreground">
+              {row.text}
+            </p>
+          {:else if row.type === "separator"}
+            <div class="my-1 border-t border-border"></div>
+          {:else if row.type === "volume"}
+            {@const isPeer = row.target === "peer"}
+            {@const percent = isPeer
+              ? peerVolumeSlider
+              : Math.round(transmissionOutputVolume * 100)}
+            <!-- A raw range input, deliberately: it is the one control in a
+                 menu that a pointer drags rather than clicks, and the e2e
+                 peer-volume scenario asserts on exactly this element. -->
+            <div class="mt-1 border-t border-border px-3 pb-2 pt-2">
+              <div class="flex items-center justify-between pb-1.5">
+                <span class="text-xs text-muted-foreground">
+                  {isPeer ? "Volume" : "Share volume"}
+                </span>
+                <span
+                  class="text-xs tabular-nums {percent <= 0
+                    ? 'text-destructive'
+                    : 'text-primary'}"
+                  >{isPeer ? peerVolumePercent : `${percent}%`}</span
+                >
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="100"
+                step="1"
+                value={percent}
+                aria-label={isPeer
+                  ? `Volume for ${menuTile.label}`
+                  : `Volume for ${menuTile.label}'s screen`}
+                oninput={(e) =>
+                  isPeer
+                    ? onPeerVolume(Number(e.currentTarget.value))
+                    : handleTransmissionVolumeChange(
+                        Number(e.currentTarget.value) / 100
+                      )}
+                class="h-1 w-full cursor-pointer appearance-none rounded-full accent-primary"
+                style={`background: linear-gradient(to right, var(--primary) ${percent}%, var(--muted) ${percent}%)`}
+              />
+              <p class="pt-1 text-[10px] text-muted-foreground">
+                Only changes what you hear
+              </p>
+            </div>
+          {:else}
+            {@const Icon = TILE_MENU_ICONS[row.icon]}
+            <button
+              type="button"
+              role={row.checked === undefined ? "menuitem" : "menuitemcheckbox"}
+              aria-checked={row.checked}
+              disabled={row.disabled}
+              class="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 {row.disabled
+                ? ''
+                : 'cursor-pointer'} {row.danger ? 'text-destructive' : ''}"
+              onclick={() => void runTileAction(menuTile, row.action)}
             >
-          </div>
-          <input
-            type="range"
-            min="0"
-            max="100"
-            step="1"
-            value={peerVolumeSlider}
-            aria-label={`Volume for ${peerMenu.label}`}
-            oninput={(e) => onPeerVolume(Number(e.currentTarget.value))}
-            class="h-1 w-full cursor-pointer appearance-none rounded-full accent-primary"
-            style={`background: linear-gradient(to right, var(--primary) ${peerVolumeSlider}%, var(--muted) ${peerVolumeSlider}%)`}
-          />
-          <p class="pt-1 text-[10px] text-muted-foreground">
-            Only changes what you hear
-          </p>
-        </div>
+              {#if row.pluginIcon}
+                <PluginIcon icon={row.pluginIcon} class="size-4 shrink-0" />
+              {:else}
+                <Icon class="size-4 shrink-0" />
+              {/if}
+              <span class="flex-1 truncate text-left">{row.label}</span>
+              {#if row.checked}
+                <Check class="size-3.5 shrink-0 text-primary" />
+              {/if}
+            </button>
+          {/if}
+        {/each}
       </div>
     {/if}
   </div>

--- a/frontend/src/lib/plugins/api.ts
+++ b/frontend/src/lib/plugins/api.ts
@@ -68,6 +68,7 @@ export const HOST_FEATURES: ReadonlySet<string> = new Set([
   "plugin-settings",
   "plugin-stream",
   "picture-in-picture",
+  "call-tile-menu",
 ]);
 
 export interface UpdateCtx {
@@ -355,6 +356,47 @@ export interface CallTileProps<State = unknown> extends CardProps<State> {
   chromeVisible: boolean;
 }
 
+/**
+ * One entry a plugin adds to its call tile's right-click menu.
+ *
+ * The host draws it in ITS menu chrome, beside the rows every tile has
+ * (focus, fullscreen, leave), so a watch-together tile offers "Picture in
+ * picture" and "Mute" in the same place a screen share offers them.
+ *
+ * `run` is called on the click, on the client that clicked: use it for the
+ * local surface (float the video, mute this device) or for a SYNCED action
+ * through `sendUpdate`, exactly as an in-tile button would. The host caps
+ * the list at eight items and trims labels to 40 characters, and an item
+ * that throws is logged, never fatal.
+ */
+export interface CallTileMenuItem {
+  /** Stable across rebuilds; the host keys the row on it. */
+  id: string;
+  label: string;
+  /** An emoji, or a lucide icon as "lucide:<kebab-name>". */
+  icon?: string;
+  /** Draws a check mark - for a toggle whose state you already know. */
+  checked?: boolean;
+  disabled?: boolean;
+  /** Destructive, drawn in the host's danger colour. */
+  danger?: boolean;
+  run(): void | Promise<void>;
+}
+
+/**
+ * What `callTileMenu` is given: the same card, state and host the tile
+ * itself has, plus whether this user has joined the tile.
+ */
+export interface CallTileMenuCtx<State = unknown> {
+  card: CardMessage;
+  cardState: State;
+  host: HostApi;
+  /** The tile is only asked for items once joined, so this is always true
+   *  today - it exists so an unjoined menu can grow items without a
+   *  signature change. */
+  joined: boolean;
+}
+
 /** Props of the `localCard` surface. `localCard.data` is what `showLocalCard` was given. */
 export interface LocalCardProps {
   localCard: LocalPluginCardEntry;
@@ -422,6 +464,18 @@ export interface PluginDefinition<State = unknown, CardData = unknown> {
    * same audience chip screen-share transmissions get.
    */
   callTileViewers?(cardState: State): string[];
+  /**
+   * Extra rows for the tile's right-click menu, built on demand when the
+   * user opens it - so this one is NOT pure: read whatever the controls need
+   * and close over the host. It is asked per right-click, never cached.
+   *
+   * Put here what the tile's own overlay has no room for, and what a viewer
+   * expects a stream to offer: float this video (`host.pictureInPicture`),
+   * mute it on this device, skip, stop. Say in the label which side the
+   * action lands on - "Mute for me" is local, "Pause" pauses the party for
+   * everyone.
+   */
+  callTileMenu?(ctx: CallTileMenuCtx<State>): CallTileMenuItem[];
   /**
    * @deprecated Pins are one-per-plugin by construction now (a pin names
    * the plugin, not a card), which is all this flag ever bought. Accepted


### PR DESCRIPTION
Right-clicking a call tile opened one "peer menu" — Message plus a volume slider — and local and plugin tiles were excluded from it outright (`openPeerMenu` early-returned on `tile.isLocal` and `tile.kind === "plugin"`), so a right-click there fell through to the panel handler and configured the whole **grid**. A watch-together tile answered "pip this, mute it, stop watching" with a people filter.

The menu is per stream now.

| Tile | Rows |
|---|---|
| Remote camera | Focus · Picture in picture · Fullscreen — Message · per-person volume |
| Your camera | Focus · Picture in picture · Fullscreen — Turn camera on/off · Mute/unmute microphone |
| Your screen | Focus · Picture in picture · Fullscreen — **Stop sharing** |
| Someone's screen | Focus · Picture in picture · Fullscreen — Mute/unmute share audio · share volume |
| Watched SFU share | …the above — **Stop watching** |
| Offered share (not joined) | Watch *Name*'s screen |
| Plugin tile (not joined) | Join *Plugin* |
| Plugin tile (joined) | Focus · Fullscreen — *the plugin's own rows* — **Leave *Plugin*** |

Every branch calls a store function the tile overlay already had. This is a second surface for controls that had no room in the chrome, not new plumbing.

## Shape

- **The rules are pure.** `frontend/src/lib/call-tile-menu.ts` turns a tile descriptor into rows carrying *action names*, never callbacks, so "what does this stream offer" is unit-tested without Svelte, the DOM or the transport (20 tests: one per kind, the ordering rule that keeps a destructive row off the position Focus used to hold, and the plugin caps).
- **The stage keeps the tile ID, not the tile,** and resolves it against `tiles` on every read. An open menu follows live state — Focus becomes Unfocus, Mute share audio becomes Unmute — and disappears with its tile when the share ends, instead of acting on something gone.
- **Menu height is computed from the rows.** The four hard-coded clamp sizes (`224x132`, `224x320`, …) are gone, and rows arriving a tick later cannot push the menu off the bottom edge.
- Both menus still render inside `panelEl`, which is the `requestFullscreen` element — a sibling menu is invisible for as long as the call is fullscreen.
- The per-person volume row stays a raw `input[type=range]` inside `[role=menu]`: `e2e/scenarios/peer-volume.mjs` asserts exactly that element.

## Plugin surface

`callTileMenu({ card, cardState, host, joined })` returns rows the host draws beside its own:

```ts
callTileMenu: ({ card, cardState, host }) => [
  { id: "pip", label: "Picture in picture", icon: "lucide:picture-in-picture-2",
    run: () => video && host.pictureInPicture(video) },
  { id: "mute", label: "Mute for me", checked: muted, run: () => (muted = !muted) },
]
```

Deliberately **not** pure, unlike `callTileActive`: it is asked on each right-click so it can close over the host and read live state. The host caps it at eight items and 40-character labels, never asks an unjoined tile (opt-in is the invariant), and drops a throwing hook's rows rather than the menu. `HOST_FEATURES` gains `call-tile-menu`.

Picture-in-picture on a plugin tile is the plugin's row to offer, through `host.pictureInPicture`: the host cannot float media it does not render, and nobody but the browser can float a video inside a cross-origin iframe — there the browser's own menu stays reachable.

## Verification

Driven in a real browser against a local relay with an injected call (camera, screen share with audio, offered share) and a throwaway plugin shipping a call tile plus three menu items:

- Every menu in the table above rendered as listed, with the right heading (`Grace's screen`, `MenuTester (You)`).
- Picture in picture correctly absent on an avatar-only tile and on a plugin tile.
- Clicked through: Mute share audio → volume 0 and the row flipped to Unmute · Focus → spotlight, reopened menu says Unfocus · Leave → tile back to Join · a local plugin item (this device only) · a synced plugin item (`sendUpdate` → reducer folded → the tile text and the row's check mark both changed) · a `disabled` row is inert.
- `checked` renders as `role="menuitemcheckbox"` + `aria-checked`, `danger` as destructive colour.
- No regression: the grid view menu still opens on the background, Escape still closes.

`svelte-check` 0 errors / 0 warnings, `tsc` clean, 1302 vitest tests pass (the two `files-*.test.ts` failures reproduce on a clean checkout of this branch's base).

Not clickable headless, so worth one pass in a real call: picture-in-picture, fullscreen, stop sharing, the camera/mic toggles, watch/stop-watching. Each is a one-line call to a store function the tile overlay already used.

One known gap, unchanged by this PR: there is still no long-press path to any context menu, so the tile overlays remain the phone answer.