### PR TITLE
Dev to main: one node per browser profile, bounded file redials, a tile menu that offers the person

### DIFF
--- a/dashboard/src/lib/analysis/topology.ts
+++ b/dashboard/src/lib/analysis/topology.ts
@@ -370,6 +370,7 @@ function applyEvent(state: FoldState, e: MergedEvent): boolean {
     case "session.config":
     case "session.unlock":
     case "session.visibility":
+    case "session.node":
     case "session.online":
     case "session.end":
     case "relay.dial.attempt":

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -47,6 +47,7 @@ export type DiagKind =
   | "session.config"
   | "session.unlock"
   | "session.visibility"
+  | "session.node"
   | "session.online"
   | "session.end"
   // relay
@@ -204,6 +205,7 @@ export const KIND_SEV = {
   "session.config": "info",
   "session.unlock": "info",
   "session.visibility": "info",
+  "session.node": "info",
   "session.online": "info",
   "session.end": "info",
   // relay

--- a/dashboard/src/lib/schema.ts
+++ b/dashboard/src/lib/schema.ts
@@ -177,7 +177,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 116;
+export const DIAG_KIND_COUNT = 117;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:

--- a/frontend/e2e/driver.mjs
+++ b/frontend/e2e/driver.mjs
@@ -107,6 +107,25 @@ export class Peer {
     await this.bidi.send("browsingContext.setViewport", params);
   }
 
+  /**
+   * A second tab of this same browser profile: same identity, same libp2p
+   * seed, same Lock Manager. Drives a browsing context of this session, so
+   * it must be created (browsingContext.create) and closed by the caller.
+   */
+  tab(context) {
+    const other = Object.create(Peer.prototype);
+    other.port = this.port;
+    other.name = `${this.name}#2`;
+    other.mobile = this.mobile;
+    other.bidi = {
+      port: this.port,
+      context,
+      send: (method, params) => this.bidi.send(method, params),
+      close: async () => {},
+    };
+    return other;
+  }
+
   async go(path) {
     await this.bidi.send("browsingContext.navigate", {
       context: this.bidi.context,

--- a/frontend/e2e/scenarios/large-file.mjs
+++ b/frontend/e2e/scenarios/large-file.mjs
@@ -1,0 +1,37 @@
+/**
+ * A file over the inline limit (512 KB) still arrives over WebTorrent after
+ * the dial cap: one announce, one request, one link, and the transfer
+ * completes on the receiver.
+ */
+import { bootPeers, closeAll } from "../driver.mjs";
+import { Check, waitForMesh, waitForBinding } from "../assert.mjs";
+
+const check = new Check("large file still arrives over webtorrent");
+const [alice, bob] = await bootPeers(["Alice", "Bob"], { ports: [9307, 9308] });
+
+try {
+  const room = await alice.createRoom("FileLab");
+  await bob.joinRoom(room);
+  await waitForMesh([alice, bob], 1);
+  await waitForBinding([alice, bob], 1);
+
+  await alice.eval(`(() => {
+    const bytes = new Uint8Array(700 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31) & 0xff;
+    const file = new File([bytes], 'big.png', { type: 'image/png' });
+    window.__awful.sendFiles([file], 'big one');
+    return true;
+  })()`);
+
+  // A finished download turns into a seed, so "seeding" is the end state.
+  const snap = await bob.waitFor("bob completes the download", () =>
+    bob.json(`(() => {
+      const t = [...window.__awful.state.fileTransfers.values()][0];
+      if (!t || (t.status !== 'seeding' && t.status !== 'complete' && t.status !== 'failed')) return null;
+      return JSON.stringify({ status: t.status, progress: t.progress, error: t.error ?? null });
+    })()`), { timeout: 90_000 });
+  check.ok(snap.status !== "failed" && snap.progress >= 1, "receiver's transfer completes", snap);
+} finally {
+  check.finish();
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/peer-volume.mjs
+++ b/frontend/e2e/scenarios/peer-volume.mjs
@@ -31,6 +31,8 @@ const injectCall = async () => {
       videoTrack: null, screenTrack: null, screenAudioTrack: null,
     }]]);
     s.callPeerIds = new Set([${JSON.stringify(FAKE_PEER)}]);
+    // The stage shows only the call of the room on screen.
+    s.callPeerRooms = new Map([[${JSON.stringify(FAKE_PEER)}, s.roomCode]]);
     s.callRoomCode = s.roomCode; s.inCall = true;
     return true;
   })()`);

--- a/frontend/e2e/scenarios/tile-person-menu.mjs
+++ b/frontend/e2e/scenarios/tile-person-menu.mjs
@@ -1,0 +1,132 @@
+/**
+ * Right-click on a person's call tile offers the person, not just the
+ * stream: Mute (the slider at 0 with a name, Unmute brings the old level
+ * back), View profile, and Add to / Remove from phonebook.
+ *
+ * Headless cannot run a real call, so the tile is injected the way
+ * peer-volume.mjs does it.
+ */
+import { Peer } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("call tile menu offers the person");
+const p = new Peer(9307, "A");
+const FAKE_PEER = "12D3KooWFakeCallPeerAAA";
+const FAKE_DID = "did:key:z6MkFakeCallFriend";
+
+const injectCall = async () => {
+  await p.eval(`(() => {
+    const s = window.__awful.state;
+    const ctx = new AudioContext();
+    const osc = ctx.createOscillator();
+    const dest = ctx.createMediaStreamDestination();
+    osc.connect(dest); osc.start();
+    window.__awful.peerIdToDid.set(${JSON.stringify(FAKE_PEER)}, ${JSON.stringify(FAKE_DID)});
+    s.peerNames = new Map([[${JSON.stringify(FAKE_DID)}, "CallFriend"]]);
+    s.participants = new Map([[${JSON.stringify(FAKE_PEER)}, {
+      peerId: ${JSON.stringify(FAKE_PEER)},
+      audioTrack: dest.stream.getAudioTracks()[0],
+      videoTrack: null, screenTrack: null, screenAudioTrack: null,
+    }]]);
+    s.callPeerIds = new Set([${JSON.stringify(FAKE_PEER)}]);
+    // The stage shows only the call of the room on screen.
+    s.callPeerRooms = new Map([[${JSON.stringify(FAKE_PEER)}, s.roomCode]]);
+    s.callRoomCode = s.roomCode; s.inCall = true;
+    return true;
+  })()`);
+};
+
+const openMenu = () =>
+  p.waitFor("tile menu", async () => {
+    await p.eval(`(() => {
+      const tile = [...document.querySelectorAll('button')]
+        .find((b) => /CallFriend/.test(b.innerText) && b.className.includes('rounded-lg'));
+      tile?.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 400, clientY: 300 }));
+      return true;
+    })()`);
+    return p.eval(`!!document.querySelector('[role=menu] input[type=range]')`);
+  });
+
+const menuItems = () =>
+  p.json(`JSON.stringify([...document.querySelectorAll('[role=menu] button')].map((b) => b.textContent.trim()))`);
+
+const menuPercent = () =>
+  p.eval(`(() => {
+    const spans = [...document.querySelectorAll('[role=menu] span')].map((s) => s.textContent.trim());
+    return spans.find((t) => /%$|muted/.test(t)) ?? null;
+  })()`);
+
+/** Exact label: "Mute" must not hit "Unmute" or the bar's "Mute microphone". */
+const clickItem = (label) =>
+  p.eval(`(() => {
+    const b = [...document.querySelectorAll('[role=menu] button')]
+      .find((x) => x.textContent.trim() === ${JSON.stringify(label)});
+    if (b) b.click();
+    return !!b;
+  })()`);
+
+const setSlider = (value) =>
+  p.eval(`(() => {
+    const r = document.querySelector('[role=menu] input[type=range]');
+    const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    set.call(r, ${JSON.stringify(String(value))});
+    r.dispatchEvent(new Event('input', { bubbles: true }));
+    return true;
+  })()`);
+
+try {
+  await p.start();
+  await p.signUp("MenuTester");
+  await p.createRoom("MenuRoom");
+  await injectCall();
+
+  await openMenu();
+  const items = await menuItems();
+  check.ok(items.includes("Mute"), "offers Mute", items);
+  check.ok(items.includes("View profile"), "offers View profile", items);
+  check.ok(items.includes("Add to phonebook"), "offers Add to phonebook", items);
+
+  // Set 10%, then Mute: Unmute must bring the 10% back, not 100%.
+  await setSlider(30);
+  await p.waitFor("menu shows 10%", async () => (await menuPercent()) === "10%");
+  check.ok(await clickItem("Mute"), "clicked Mute");
+  await openMenu();
+  check.equal(await menuPercent(), "muted", "muted after Mute");
+  check.ok((await menuItems()).includes("Unmute"), "row flipped to Unmute");
+  check.ok(await clickItem("Unmute"), "clicked Unmute");
+  await openMenu();
+  check.equal(await menuPercent(), "10%", "Unmute restores the level from before");
+  // Dragging the slider to 0 flips the row in place, no reopen needed.
+  await setSlider(0);
+  await p.waitFor("row flips live", async () => (await menuItems()).includes("Unmute"));
+  check.ok(true, "slider at 0 flips the row to Unmute in place");
+  await clickItem("Unmute");
+
+  // Phonebook, both ways.
+  await openMenu();
+  check.ok(await clickItem("Add to phonebook"), "clicked Add to phonebook");
+  await p.waitFor("in phonebook", async () => {
+    await openMenu();
+    return (await menuItems()).includes("Remove from phonebook");
+  });
+  check.ok(true, "row flipped to Remove from phonebook");
+  await clickItem("Remove from phonebook");
+  await p.waitFor("out of phonebook", async () => {
+    await openMenu();
+    return (await menuItems()).includes("Add to phonebook");
+  });
+  check.ok(true, "and back to Add to phonebook");
+
+  // Profile card.
+  check.ok(await clickItem("View profile"), "clicked View profile");
+  await p.waitFor("profile card", () =>
+    p.eval(`(() => {
+      const d = document.querySelector('[role=dialog]');
+      return d && /CallFriend/.test(d.innerText) ? true : null;
+    })()`));
+  check.ok(true, "profile card opens for the person");
+} finally {
+  await p.close();
+}
+
+check.finish();

--- a/frontend/e2e/scenarios/two-tabs.mjs
+++ b/frontend/e2e/scenarios/two-tabs.mjs
@@ -1,0 +1,64 @@
+/**
+ * One libp2p node per browser profile (node-lock.ts).
+ *
+ * Two tabs of the same profile share the libp2p seed and so the peerId; two
+ * nodes with one peerId starve each other of pongs and reconnect every ~125 s
+ * (the 2026-09-04 and 2026-09-06 diag packs). The second tab must wait, say
+ * so, take the seat on "Use here", and hand it back when it closes.
+ */
+import { bootPeers, closeAll, sleep } from "../driver.mjs";
+import { Check, waitForMesh } from "../assert.mjs";
+
+const check = new Check("one node per browser profile");
+const [alice, bob] = await bootPeers(["Alice", "Bob"], { ports: [9307, 9308] });
+let tab2Context = null;
+
+try {
+  const room = await alice.createRoom("TabLab");
+  await bob.joinRoom(room);
+  await waitForMesh([alice, bob], 1);
+  const aliceId = await alice.selfId();
+
+  // A second tab of Alice's profile.
+  ({ context: tab2Context } = await alice.bidi.send("browsingContext.create", { type: "tab" }));
+  const tab2 = alice.tab(tab2Context);
+  await tab2.go("/app");
+  await tab2.waitFor("other-tab bar", () =>
+    tab2.eval(`/open in another tab/i.test(document.body.innerText) || null`));
+  check.ok(true, "second tab says the app is open in another tab");
+  await sleep(4000);
+  check.ok(
+    (await tab2.eval(`window.__awful.state.relayConnected`)) === false,
+    "second tab did not start a node"
+  );
+  let a = await alice.state();
+  let b = await bob.state();
+  check.ok(a.relay && a.peers === 1 && b.peers === 1, "first tab kept the node and the mesh");
+
+  // "Use here": the second tab takes the seat, the first steps down and waits.
+  await tab2.clickText("Use here");
+  await tab2.waitFor("tab2 connected", () =>
+    tab2.eval(`window.__awful.state.relayConnected || null`));
+  await alice.waitFor("tab1 waiting", () =>
+    alice.eval(`window.__awful.state.nodeHeldElsewhere || null`));
+  check.ok((await alice.eval(`window.__awful.state.relayConnected`)) === false,
+    "Use here moves the node to the second tab; the first waits");
+  check.ok((await tab2.selfId()) === aliceId, "same peerId in the second tab");
+  await tab2.openRoom(room);
+  await waitForMesh([tab2, bob], 1);
+  check.ok(true, "the second tab reaches Bob with that peerId");
+
+  // Closing the holder hands the seat back to the tab that waited.
+  await alice.bidi.send("browsingContext.close", { context: tab2Context });
+  tab2Context = null;
+  await alice.waitFor("tab1 back", () =>
+    alice.eval(`(window.__awful.state.relayConnected && !window.__awful.state.nodeHeldElsewhere) || null`));
+  await waitForMesh([alice, bob], 1);
+  check.ok(true, "closing the tab hands the node back and the mesh reforms");
+} finally {
+  if (tab2Context) {
+    await alice.bidi.send("browsingContext.close", { context: tab2Context }).catch(() => {});
+  }
+  check.finish();
+  await closeAll([alice, bob]);
+}

--- a/frontend/src/lib/call-tile-menu.test.ts
+++ b/frontend/src/lib/call-tile-menu.test.ts
@@ -33,18 +33,45 @@ describe("buildTileMenu", () => {
         canMessage: true,
       })
     );
-    expect(actions(rows)).toEqual(["focus", "pip", "fullscreen", "message"]);
-    // The per-peer slider is the app's only real per-person mute.
+    expect(actions(rows)).toEqual([
+      "focus",
+      "pip",
+      "fullscreen",
+      "message",
+      "profile",
+      "add-phonebook",
+      "mute-peer",
+    ]);
     expect(rows).toContainEqual({ type: "volume", target: "peer" });
     expect(rows[0]).toEqual({ type: "label", text: "Ada" });
   });
 
-  it("drops Message for a peer with no DM route", () => {
+  it("drops the person rows for a peer with no DM route, keeps the mute", () => {
     const rows = buildTileMenu(
       tileMenuState({ kind: "camera", label: "Ada", canMessage: false })
     );
-    expect(actions(rows)).not.toContain("message");
+    expect(actions(rows)).toEqual(["focus", "fullscreen", "mute-peer"]);
     expect(rows).toContainEqual({ type: "volume", target: "peer" });
+  });
+
+  it("flips Mute and the phonebook row by state", () => {
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "camera",
+        label: "Ada",
+        canMessage: true,
+        inPhonebook: true,
+        peerMuted: true,
+      })
+    );
+    expect(actions(rows)).toContain("remove-phonebook");
+    expect(actions(rows)).not.toContain("add-phonebook");
+    expect(actions(rows)).toContain("unmute-peer");
+    expect(actions(rows)).not.toContain("mute-peer");
+    const unmute = rows.find(
+      (r) => r.type === "item" && r.action.kind === "unmute-peer"
+    );
+    expect(unmute).toMatchObject({ label: "Unmute", icon: "volume" });
   });
 
   it("gives the local camera its own devices and never a volume slider", () => {

--- a/frontend/src/lib/call-tile-menu.ts
+++ b/frontend/src/lib/call-tile-menu.ts
@@ -32,6 +32,9 @@ export type TileMenuIcon =
   | "mic-off"
   | "volume"
   | "volume-off"
+  | "user"
+  | "user-plus"
+  | "user-minus"
   | "join"
   | "leave"
   | "plugin";
@@ -46,6 +49,13 @@ export type TileMenuAction =
   | { kind: "fullscreen" }
   | { kind: "exit-fullscreen" }
   | { kind: "message" }
+  /** The person's profile card. */
+  | { kind: "profile" }
+  | { kind: "add-phonebook" }
+  | { kind: "remove-phonebook" }
+  /** Silence this person for you alone (their volume to 0), and back. */
+  | { kind: "mute-peer" }
+  | { kind: "unmute-peer" }
   /** Subscribe to an offered SFU share / drop the one being watched. */
   | { kind: "watch" }
   | { kind: "stop-watching" }
@@ -113,6 +123,10 @@ export interface TileMenuState {
   pipOpen: boolean;
   /** A remote peer with a real peer id, so a DM can be opened. */
   canMessage: boolean;
+  /** That person is in the phonebook already. */
+  inPhonebook: boolean;
+  /** Their voice is at volume 0 for us. */
+  peerMuted: boolean;
   cameraOff: boolean;
   micMuted: boolean;
   /** The share carries audio at all. */
@@ -139,6 +153,8 @@ export function tileMenuState(
     pipSupported: false,
     pipOpen: false,
     canMessage: false,
+    inPhonebook: false,
+    peerMuted: false,
     cameraOff: false,
     micMuted: false,
     shareAudio: false,
@@ -329,15 +345,53 @@ export function buildTileMenu(s: TileMenuState): TileMenuRow[] {
   const tail: TileMenuRow[] = [];
   if (s.kind === "camera") {
     if (s.canMessage) {
-      tail.push({
-        type: "item",
-        label: "Message",
-        icon: "message",
-        action: { kind: "message" },
-      });
+      tail.push(
+        {
+          type: "item",
+          label: "Message",
+          icon: "message",
+          action: { kind: "message" },
+        },
+        {
+          type: "item",
+          label: "View profile",
+          icon: "user",
+          action: { kind: "profile" },
+        },
+        s.inPhonebook
+          ? {
+              type: "item",
+              label: "Remove from phonebook",
+              icon: "user-minus",
+              action: { kind: "remove-phonebook" },
+              danger: true,
+            }
+          : {
+              type: "item",
+              label: "Add to phonebook",
+              icon: "user-plus",
+              action: { kind: "add-phonebook" },
+            }
+      );
     }
-    // The per-person listening volume, the app's only real "mute them".
-    tail.push({ type: "volume", target: "peer" });
+    // Mute is the slider at 0 with a name: one click instead of a drag, and
+    // Unmute brings back the level they had. Only changes what you hear.
+    tail.push(
+      s.peerMuted
+        ? {
+            type: "item",
+            label: "Unmute",
+            icon: "volume",
+            action: { kind: "unmute-peer" },
+          }
+        : {
+            type: "item",
+            label: "Mute",
+            icon: "volume-off",
+            action: { kind: "mute-peer" },
+          },
+      { type: "volume", target: "peer" }
+    );
   } else {
     tail.push(...shareAudioRows(s));
     if (s.isWatched) {

--- a/frontend/src/lib/components/AppNotices.svelte
+++ b/frontend/src/lib/components/AppNotices.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { _transport, transportState } from "$lib/transport/transport.svelte";
   import type { TransportStatus } from "$lib/transport/types";
+  import { claimNodeLock } from "$lib/transport/node-lock";
   import { isConfigured } from "$lib/runtime-config";
-  import { CircleAlert, ServerOff, WifiOff, X } from "@lucide/svelte";
+  import { AppWindow, CircleAlert, ServerOff, WifiOff, X } from "@lucide/svelte";
   import { onDestroy, onMount } from "svelte";
 
   /**
@@ -58,6 +59,9 @@
   let configured = $state(true);
 
   const relayConnected = $derived(transportState.relayConnected);
+  // Another tab of this profile has the node; this one waits for it and can
+  // ask for it (node-lock.ts). Nothing else in this tab works until then.
+  const heldElsewhere = $derived(transportState.nodeHeldElsewhere);
 
   let cleanups: (() => void)[] = [];
   const timers = new Map<number, ReturnType<typeof setTimeout>>();
@@ -143,6 +147,7 @@
   });
 
   const barText = $derived.by(() => {
+    if (heldElsewhere) return "awful.chat is open in another tab.";
     if (!online) return "Offline. Messages send when you reconnect.";
     if (!configured) return "This instance has no relay configured.";
     return null;
@@ -179,12 +184,23 @@
       role="status"
       class="pointer-events-auto flex w-full max-w-md items-center justify-center gap-2 rounded-lg border border-border bg-background/95 px-3 py-1.5 text-xs text-muted-foreground shadow-lg backdrop-blur"
     >
-      {#if online}
+      {#if heldElsewhere}
+        <AppWindow class="size-3.5 shrink-0 text-amber-500" />
+      {:else if online}
         <ServerOff class="size-3.5 shrink-0 text-amber-500" />
       {:else}
         <WifiOff class="size-3.5 shrink-0 text-amber-500" />
       {/if}
       <span>{barText}</span>
+      {#if heldElsewhere}
+        <button
+          type="button"
+          onclick={claimNodeLock}
+          class="ml-1 rounded border border-border px-2 py-0.5 font-medium text-foreground hover:bg-accent"
+        >
+          Use here
+        </button>
+      {/if}
     </div>
   {/if}
 </div>

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -82,12 +82,13 @@
     resolveMentionDisplayName,
   } from "$lib/transport/transport.svelte";
   import { humanizeMentions } from "$lib/mentions";
-  import { roomsStore, refreshPhonebook } from "$lib/rooms.svelte";
+  import { refreshPhonebook } from "$lib/rooms.svelte";
   import { formatReactorNames } from "$lib/reaction-names";
   import {
     addToPhonebook,
     openDmPanel,
     removeFromPhonebook,
+    isInPhonebook,
   } from "$lib/transport/dm.svelte";
   import { joinCall } from "$lib/transport/call.svelte";
   import {
@@ -1517,16 +1518,6 @@
   // the reference came from, and a phonebook entry carries both. Compare
   // every form, or the header button shows "Add" for someone already saved
   // (and its toggle then silently removes them).
-  function isInPhonebook(peerId: string): boolean {
-    const did = peerIdToDid(peerId);
-    return roomsStore.phonebook.some(
-      (entry) =>
-        entry.peerId === peerId ||
-        entry.did === peerId ||
-        (!!did && (entry.peerId === did || entry.did === did))
-    );
-  }
-
   async function startDmFromMenu(peerId: string): Promise<void> {
     if (onOpenDm) {
       await onOpenDm(peerId);

--- a/frontend/src/lib/components/UserListSidebar.svelte
+++ b/frontend/src/lib/components/UserListSidebar.svelte
@@ -16,6 +16,7 @@
   import {
     openDmPanel,
     addToPhonebook,
+    isInPhonebook,
     removeFromPhonebook,
   } from "$lib/transport/dm.svelte";
   import { profileStore, loadProfile } from "$lib/profile.svelte";
@@ -29,7 +30,7 @@
     Users,
     Workflow,
   } from "@lucide/svelte";
-  import { roomsStore, refreshPhonebook } from "$lib/rooms.svelte";
+  import { refreshPhonebook } from "$lib/rooms.svelte";
   import { Badge } from "$lib/components/ui/badge";
   import { Tip } from "$lib/components/ui/tooltip";
   import { nameEffectStyle } from "$lib/name-effect";
@@ -319,17 +320,6 @@
 
   function closeUserMenu(): void {
     userMenu = null;
-  }
-
-  function isInPhonebook(peerId: string): boolean {
-    // An entry may be keyed by peerId or DID; compare every form.
-    const did = peerIdToDid(peerId);
-    return roomsStore.phonebook.some(
-      (entry) =>
-        entry.peerId === peerId ||
-        entry.did === peerId ||
-        (!!did && (entry.peerId === did || entry.did === did))
-    );
   }
 
   async function handleAddToPhonebook(peerId: string): Promise<void> {

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -4,7 +4,14 @@
   import GifImage from "./GifImage.svelte";
   import { RELAY_TIP } from "$lib/copy";
   import { applyVoiceLinkStatus } from "$lib/voice-link-status";
-  import { openDmPanel } from "$lib/transport/dm.svelte";
+  import {
+    addToPhonebook,
+    isInPhonebook,
+    openDmPanel,
+    removeFromPhonebook,
+  } from "$lib/transport/dm.svelte";
+  import { refreshPhonebook } from "$lib/rooms.svelte";
+  import UserProfileCard from "./UserProfileCard.svelte";
   import {
     getVoicePeerVolume,
     setVoicePeerVolume,
@@ -75,7 +82,7 @@
     PinOff,
     LogIn,
   } from "@lucide/svelte";
-  import { Check, Columns2, MessageSquare, MonitorIcon, PictureInPicture2, Rows2, SlidersHorizontal, Users as UsersIcon, UserX } from "@lucide/svelte";
+  import { Check, Columns2, MessageSquare, MonitorIcon, PictureInPicture2, Rows2, SlidersHorizontal, User as UserIcon, UserPlus, UserRoundMinus, Users as UsersIcon, UserX } from "@lucide/svelte";
 import { profileStore, loadProfile } from "$lib/profile.svelte";
 import { displayPrefs, setCallChatBeside, setCallPip } from "$lib/display-prefs.svelte";
 import { cn } from "$lib/utils";
@@ -619,6 +626,16 @@ import {
   /** Right-click on the call background: picks what the grid shows. */
   let viewMenu = $state<{ x: number; y: number } | null>(null);
   let peerVolumeSlider = $state(UNITY_STOP);
+  /** Whose profile card a tile menu opened. */
+  let profileCardFor = $state<{
+    peerId: string;
+    did: string;
+    name: string;
+    avatarUrl?: string;
+    color?: string;
+  } | null>(null);
+  /** The level a person had before Mute, so Unmute brings it back. */
+  const preMuteGain = new Map<string, number>();
 
   const peerVolumePercent = $derived(formatGain(sliderToGain(peerVolumeSlider)));
 
@@ -659,6 +676,13 @@ import {
       pipSupported: browserPipSupported(),
       pipOpen: callPipPanel.browserPip,
       canMessage: !tile.isLocal && !!tile.peerId,
+      inPhonebook: !tile.isLocal && !!tile.peerId && isInPhonebook(tile.peerId),
+      // Off the slider, which openTileMenu seeds from the live gain: it is
+      // reactive, so dragging it to 0 flips the row to Unmute in place.
+      peerMuted:
+        tile.kind === "camera" &&
+        !tile.isLocal &&
+        sliderToGain(peerVolumeSlider) <= 0,
       cameraOff,
       micMuted: muted,
       // Screen-share audio, not the sharer's voice: it arrives as its own
@@ -789,6 +813,37 @@ import {
         // rendered as an empty conversation you could send into but never see.
         if (tile.peerId) await openDmPanel(tile.peerId);
         break;
+      case "profile":
+        if (!tile.peerId) break;
+        // The card is a dialog portalled to the body, which a fullscreen
+        // panel does not show.
+        if (document.fullscreenElement) {
+          document.exitFullscreen().catch(() => {});
+        }
+        profileCardFor = {
+          peerId: tile.peerId,
+          did: peerIdToDid(tile.peerId),
+          name: tile.label,
+          avatarUrl: tile.avatarUrl ?? getPeerAvatar(tile.peerId) ?? undefined,
+          color: getPeerColor(tile.peerId) ?? undefined,
+        };
+        break;
+      case "add-phonebook":
+      case "remove-phonebook":
+        if (tile.peerId) await togglePhonebook(tile.peerId);
+        break;
+      case "mute-peer":
+        if (tile.peerId) {
+          const gain = getVoicePeerVolume(tile.peerId);
+          if (gain > 0) preMuteGain.set(tile.peerId, gain);
+          setVoicePeerVolume(tile.peerId, 0);
+        }
+        break;
+      case "unmute-peer":
+        if (tile.peerId) {
+          setVoicePeerVolume(tile.peerId, preMuteGain.get(tile.peerId) ?? 1);
+        }
+        break;
       case "watch":
         if (tile.producerId) watchTransmission(tile.peerId, tile.producerId);
         break;
@@ -840,6 +895,12 @@ import {
     pluginMenuItems = [];
   }
 
+  async function togglePhonebook(peerId: string): Promise<void> {
+    if (isInPhonebook(peerId)) await removeFromPhonebook(peerId);
+    else await addToPhonebook(peerId);
+    await refreshPhonebook();
+  }
+
   function onPeerVolume(value: number): void {
     peerVolumeSlider = value;
     const peerId = tileMenuTile?.peerId;
@@ -863,6 +924,9 @@ import {
     "mic-off": MicOff,
     volume: Volume2,
     "volume-off": VolumeX,
+    user: UserIcon,
+    "user-plus": UserPlus,
+    "user-minus": UserRoundMinus,
     join: LogIn,
     leave: CopyX,
     plugin: Puzzle,
@@ -2566,6 +2630,26 @@ import {
       </div>
     {/if}
   </div>
+{/if}
+
+{#if profileCardFor}
+  <UserProfileCard
+    open={!!profileCardFor}
+    onOpenChange={(open) => {
+      if (!open) profileCardFor = null;
+    }}
+    did={profileCardFor.did}
+    name={profileCardFor.name}
+    avatarUrl={profileCardFor.avatarUrl}
+    color={profileCardFor.color}
+    onMessage={() => {
+      const pid = profileCardFor!.peerId;
+      profileCardFor = null;
+      void openDmPanel(pid);
+    }}
+    onTogglePhonebook={() => void togglePhonebook(profileCardFor!.peerId)}
+    inPhonebook={isInPhonebook(profileCardFor.peerId)}
+  />
 {/if}
 
 <svelte:window

--- a/frontend/src/lib/telemetry/schema.ts
+++ b/frontend/src/lib/telemetry/schema.ts
@@ -47,6 +47,7 @@ export type DiagKind =
   | "session.config"
   | "session.unlock"
   | "session.visibility"
+  | "session.node"
   | "session.online"
   | "session.end"
   // relay
@@ -204,6 +205,7 @@ export const KIND_SEV = {
   "session.config": "info",
   "session.unlock": "info",
   "session.visibility": "info",
+  "session.node": "info",
   "session.online": "info",
   "session.end": "info",
   // relay

--- a/frontend/src/lib/telemetry/schema.ts
+++ b/frontend/src/lib/telemetry/schema.ts
@@ -177,7 +177,7 @@ export type DiagKind =
  * test time, so a kind added without a severity is a test failure rather than
  * an `undefined` severity on the wire.
  */
-export const DIAG_KIND_COUNT = 116;
+export const DIAG_KIND_COUNT = 117;
 
 /**
  * Default severity per kind. Classes, in the order they were decided:

--- a/frontend/src/lib/transport/dm.svelte.ts
+++ b/frontend/src/lib/transport/dm.svelte.ts
@@ -37,6 +37,7 @@ import {
   beginConversationOpen,
   _loadHistory,
   _peerIdToDid,
+  peerIdToDid,
   _transport,
   applyMessageStatus,
   transportState,
@@ -816,6 +817,18 @@ export async function addToPhonebook(peerIdOrDid: string): Promise<void> {
     favorite: keeper?.favorite,
   });
   _transport.joinRoom(roomCode);
+}
+
+/** Whether that person is in the phonebook, under any key an entry may carry. */
+export function isInPhonebook(peerId: string): boolean {
+  // An entry may be keyed by peerId or DID; compare every form.
+  const did = peerIdToDid(peerId);
+  return roomsStore.phonebook.some(
+    (entry) =>
+      entry.peerId === peerId ||
+      entry.did === peerId ||
+      (!!did && (entry.peerId === did || entry.did === did))
+  );
 }
 
 export async function removeFromPhonebook(peerIdOrDid: string): Promise<void> {

--- a/frontend/src/lib/transport/file/webtorrent.test.ts
+++ b/frontend/src/lib/transport/file/webtorrent.test.ts
@@ -170,6 +170,23 @@ describe("WebTorrentFileTransport", () => {
     }
   });
 
+  it("a seeded file stays seeding whatever the torrent's done flag says", async () => {
+    const t = new WebTorrentFileTransport(() => "me");
+    await t.seedFiles([new File([new Uint8Array(10)], "cat.png", { type: "image/png" })]);
+    expect(t.getTransfer(HASH)?.status).toBe("seeding");
+    // webtorrent leaves `done` false on a seed; a peer connecting fires "wire".
+    const torrent = torrents.get(HASH)!;
+    torrent.done = false;
+    torrent.emit("wire");
+    expect(t.getTransfer(HASH)?.status).toBe("seeding");
+    expect(t.getTransfer(HASH)?.done).toBe(true);
+    // ...so the reconcile tick has nothing to dial for it.
+    t.onPeerConnect("bob");
+    t.registerSeeder(file, "bob");
+    (t as never as { reconcileWtPeers: () => void }).reconcileWtPeers();
+    expect(livePeers.length).toBe(0);
+  });
+
   it("a real disconnect starts the count over", async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/lib/transport/file/webtorrent.test.ts
+++ b/frontend/src/lib/transport/file/webtorrent.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as iceServerList from "../ice-server-list";
 
 const HASH = "a".repeat(40);
 const addedPeers: Array<{ id?: string }> = [];
@@ -66,7 +67,22 @@ vi.mock("webtorrent", () => {
   return { default: FakeClient };
 });
 
-vi.mock("../ice-server-list", () => ({ getIceServers: () => [] }));
+vi.mock("../ice-server-list", () => {
+  // The real module notifies subscribers when TURN credentials land; the
+  // transport rebuilds unconnected file links on that event. Capture the
+  // subscriber so a test can fire it.
+  let onChange: (() => void) | null = null;
+  return {
+    getIceServers: () => [],
+    onIceServersChanged: (cb: () => void) => {
+      onChange = cb;
+      return () => {
+        if (onChange === cb) onChange = null;
+      };
+    },
+    __fireIceServersChanged: () => onChange?.(),
+  };
+});
 
 const { WebTorrentFileTransport } = await import("./webtorrent");
 
@@ -170,6 +186,44 @@ describe("WebTorrentFileTransport", () => {
 
     expect(torrents.has(HASH)).toBe(true);
     expect(addedPeers.map((p) => p.id)).toEqual(["alice"]);
+  });
+
+  it("redials an unconnected file link with TURN once the credentials land", async () => {
+    const t = new WebTorrentFileTransport(() => "me");
+    const desc = { infoHash: HASH, filename: "cat.png", mimeType: "image/png", size: 10 };
+    t.onPeerConnect("alice");
+    t.registerSeeder(desc as never, "alice");
+    // A dial that raced the credential fetch: built STUN-only, never connects.
+    t.ensureDownload(desc as never);
+    await tick();
+    const peers = (t as never as { wtPeers: Map<string, EventEmitter & { destroyed: boolean; connected?: boolean }> }).wtPeers;
+    expect(peers.size).toBe(1);
+    const stunOnly = [...peers.values()][0];
+    const dialsBefore = livePeers.length;
+
+    (iceServerList as never as { __fireIceServersChanged: () => void }).__fireIceServersChanged();
+    await tick();
+
+    // The stale link is gone and a fresh one was dialled in its place.
+    expect(stunOnly.destroyed).toBe(true);
+    expect(livePeers.length).toBe(dialsBefore + 1);
+    expect(peers.size).toBe(1);
+    expect([...peers.values()][0]).not.toBe(stunOnly);
+  });
+
+  it("leaves an established file link alone when the credentials land", async () => {
+    const t = new WebTorrentFileTransport(() => "me");
+    t.onPeerConnect("alice");
+    t.handleSignal("alice", { kind: "file-wt-signal", infoHash: HASH, signal: {} } as never);
+    const peers = (t as never as { wtPeers: Map<string, EventEmitter & { destroyed: boolean; connected?: boolean }> }).wtPeers;
+    const live = [...peers.values()][0];
+    live.connected = true;
+
+    (iceServerList as never as { __fireIceServersChanged: () => void }).__fireIceServersChanged();
+    await tick();
+
+    expect(live.destroyed).toBe(false);
+    expect([...peers.values()][0]).toBe(live);
   });
 
   it("caps the distinct infoHashes a single peer may register", async () => {

--- a/frontend/src/lib/transport/file/webtorrent.test.ts
+++ b/frontend/src/lib/transport/file/webtorrent.test.ts
@@ -84,6 +84,14 @@ vi.mock("../ice-server-list", () => {
   };
 });
 
+const recorded: string[] = [];
+vi.mock("../../telemetry/recorder", () => ({
+  rec: (e: { kind: string }) => {
+    recorded.push(e.kind);
+  },
+  refs: () => ({ fileRef: (h: string) => h }),
+}));
+
 const { WebTorrentFileTransport } = await import("./webtorrent");
 
 const file = {
@@ -100,7 +108,93 @@ describe("WebTorrentFileTransport", () => {
     addedPeers.length = 0;
     livePeers.length = 0;
     addCalls.length = 0;
+    recorded.length = 0;
     torrents.clear();
+  });
+
+  it("a re-announce of a file already downloading neither redials nor re-requests", async () => {
+    const t = new WebTorrentFileTransport(() => "me");
+    t.onPeerConnect("alice");
+    t.registerSeeder(file, "alice");
+    t.ensureDownload(file);
+    await tick();
+    expect(livePeers.length).toBe(1);
+    expect(recorded.filter((k) => k === "file.request")).toHaveLength(1);
+
+    // The sender reconnects three times without ever disconnecting (two
+    // tabs on one peerId): each time it announces its inventory again and
+    // the transport asks for the file again.
+    for (let i = 0; i < 3; i++) {
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      t.ensureDownload(file);
+    }
+    await tick();
+    expect(livePeers.length).toBe(1);
+    expect(recorded.filter((k) => k === "file.request")).toHaveLength(1);
+  });
+
+  it("gives a pair up after WT_MAX_ATTEMPTS and fails the transfer", async () => {
+    vi.useFakeTimers();
+    try {
+      const t = new WebTorrentFileTransport(() => "me");
+      const reconcile = () =>
+        (t as never as { reconcileWtPeers: () => void }).reconcileWtPeers();
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      t.ensureDownload(file);
+      // Every dial fails; the tick keeps redialling through the backoff.
+      for (let i = 0; i < 12; i++) {
+        (livePeers[livePeers.length - 1] as { destroy: () => void }).destroy();
+        vi.advanceTimersByTime(60_000);
+        reconcile();
+        // A re-announce mid-way changes nothing either.
+        t.registerSeeder(file, "alice");
+        t.ensureDownload(file);
+      }
+      expect(livePeers.length).toBe(6);
+      expect(t.getTransfer(HASH)?.status).toBe("failed");
+      // Nor does another announce once it has been given up on.
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      t.ensureDownload(file);
+      expect(livePeers.length).toBe(6);
+      expect(t.getTransfer(HASH)?.status).toBe("failed");
+
+      // The user clicks the file: the count starts over.
+      t.ensureDownload(file, { retry: true });
+      expect(livePeers.length).toBe(7);
+      expect(t.getTransfer(HASH)?.status).toBe("downloading");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a real disconnect starts the count over", async () => {
+    vi.useFakeTimers();
+    try {
+      const t = new WebTorrentFileTransport(() => "me");
+      const reconcile = () =>
+        (t as never as { reconcileWtPeers: () => void }).reconcileWtPeers();
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      t.ensureDownload(file);
+      for (let i = 0; i < 8; i++) {
+        (livePeers[livePeers.length - 1] as { destroy: () => void }).destroy();
+        vi.advanceTimersByTime(60_000);
+        reconcile();
+      }
+      expect(livePeers.length).toBe(6);
+      expect(t.getTransfer(HASH)?.status).toBe("failed");
+
+      t.onPeerDisconnect("alice");
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      expect(t.getTransfer(HASH)?.status).toBe("downloading");
+      expect(livePeers.length).toBe(7);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("caps the WebRTC links a roomful of files can open at once", async () => {

--- a/frontend/src/lib/transport/file/webtorrent.ts
+++ b/frontend/src/lib/transport/file/webtorrent.ts
@@ -10,7 +10,7 @@ import type {
   FileTransferSnapshot,
   FileTransferTransport,
 } from "../types";
-import { getIceServers } from "../ice-server-list";
+import { getIceServers, onIceServersChanged } from "../ice-server-list";
 import { ev, errText } from "../../telemetry/event";
 import { rec, refs } from "../../telemetry/recorder";
 
@@ -117,6 +117,7 @@ export class WebTorrentFileTransport implements FileTransferTransport {
   private wtNextTry = new Map<string, number>();
   private wtBackoff = new Map<string, number>();
   private wtReconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private iceUnsubscribe: (() => void) | null = null;
   private attachedTorrents = new Set<string>();
   /**
    * infoHashes whose torrent is being added right now. ensureDownload reads
@@ -144,6 +145,30 @@ export class WebTorrentFileTransport implements FileTransferTransport {
         WT_RECONCILE_MS
       );
     }
+    // ICE servers are snapshotted when a SimplePeer is built (createWTPeer),
+    // so a file link dialled before the TURN credentials landed is STUN-only
+    // for its whole life - and the first dials of a session happen exactly
+    // then: connect() kicks off the credential fetch and, in the same tick,
+    // opening a room auto-downloads its images and dials their seeders.
+    // Between two NATs (mobile, CGNAT, most home routers) a STUN-only link
+    // never connects, so the transfer sat at zero peers forever with only
+    // the skeleton showing, while voice kept working: it rides the SFU and
+    // rebuilds on this same event (libp2p/voice.ts). Mirror that here: when
+    // the list changes, tear down every link that has not connected yet,
+    // clear its backoff so the redial is immediate, and let the reconcile
+    // pass dial it again with TURN in hand. Established links are left alone.
+    this.iceUnsubscribe = onIceServersChanged(() => {
+      for (const [key, peer] of [...this.wtPeers]) {
+        if (peer.connected) continue;
+        // Delete before destroy: destroy() fires the close handler, which
+        // deletes too, and this keeps the redial below from racing it.
+        this.wtPeers.delete(key);
+        this.wtNextTry.delete(key);
+        this.wtBackoff.delete(key);
+        peer.destroy();
+      }
+      this.reconcileWtPeers();
+    });
   }
 
   /**
@@ -483,6 +508,8 @@ export class WebTorrentFileTransport implements FileTransferTransport {
   }
 
   destroy(): void {
+    this.iceUnsubscribe?.();
+    this.iceUnsubscribe = null;
     this.resetTransfers();
     this.connectedPeers.clear();
     this.clientP?.then((client) => client.destroy(() => {}));

--- a/frontend/src/lib/transport/file/webtorrent.ts
+++ b/frontend/src/lib/transport/file/webtorrent.ts
@@ -34,6 +34,17 @@ const WT_RECONCILE_MS = 5_000;
 /** Ceiling on the per-pair retry wait. */
 const WT_RETRY_MAX_MS = 60_000;
 /**
+ * Dials per (file, peer) pair before the pair is given up on.
+ *
+ * A peer that reconnects without ever disconnecting (a second tab of the
+ * same profile fighting over one peerId) re-announces its whole inventory
+ * every time, and every announce used to re-dial every stuck file with no
+ * ceiling: 520 file requests and 428 of Chrome's 500 PeerConnections in two
+ * minutes. The backoff already spaces the dials out; this bounds them. A
+ * real disconnect, or the user clicking the file, starts the count over.
+ */
+const WT_MAX_ATTEMPTS = 6;
+/**
  * Live WebRTC links for file transfer, across every (file, peer) pair.
  *
  * Each pair gets its own RTCPeerConnection, and the pairs multiply: joining a
@@ -116,6 +127,8 @@ export class WebTorrentFileTransport implements FileTransferTransport {
    */
   private wtNextTry = new Map<string, number>();
   private wtBackoff = new Map<string, number>();
+  /** Consecutive dials that never connected, per pair. See WT_MAX_ATTEMPTS. */
+  private wtAttempts = new Map<string, number>();
   private wtReconcileTimer: ReturnType<typeof setInterval> | null = null;
   private iceUnsubscribe: (() => void) | null = null;
   private attachedTorrents = new Set<string>();
@@ -163,8 +176,9 @@ export class WebTorrentFileTransport implements FileTransferTransport {
         // Delete before destroy: destroy() fires the close handler, which
         // deletes too, and this keeps the redial below from racing it.
         this.wtPeers.delete(key);
-        this.wtNextTry.delete(key);
-        this.wtBackoff.delete(key);
+        // A dial made without TURN was never going to land; it does not
+        // count against the pair either.
+        this.forgetRetryState(key);
         peer.destroy();
       }
       this.reconcileWtPeers();
@@ -183,31 +197,71 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     if (typeof document !== "undefined" && document.hidden) return;
     const now = Date.now();
     for (const [infoHash, snapshot] of this.transfers) {
-      // Only what we are still trying to fetch.
-      if (snapshot.status !== "downloading" && snapshot.status !== "pending") {
-        continue;
-      }
+      // Only what we are still trying to fetch. "pending" is a file nobody
+      // asked for yet; dialling those built links that attachToTorrent then
+      // dropped for having no torrent, over and over, for every file in the
+      // room.
+      if (snapshot.status !== "downloading") continue;
       const seeders = this.seedersByHash.get(infoHash);
       if (!seeders?.size) continue;
-      for (const peerId of seeders) {
-        if (peerId === this.selfId()) continue;
-        // A seeder we cannot currently reach at all is not worth dialling.
-        if (!this.connectedPeers.has(peerId)) continue;
-        const key = wtKey(infoHash, peerId);
-        if (this.wtPeers.has(key)) continue;
-        if (now < (this.wtNextTry.get(key) ?? 0)) continue;
-        // Backoff is for a peer that will not answer. A pair held back by the
-        // cap has not been tried at all, so it keeps its place at the front of
-        // the queue instead of being pushed out to the next retry window.
-        if (!this.createWTPeer(infoHash, peerId, true)) continue;
-        const wait = Math.min(
-          Math.max((this.wtBackoff.get(key) ?? 0) * 2, WT_RECONCILE_MS),
-          WT_RETRY_MAX_MS
-        );
-        this.wtBackoff.set(key, wait);
-        this.wtNextTry.set(key, now + wait);
+      for (const peerId of seeders) this.dial(infoHash, peerId, now);
+      // Every reachable seeder capped and no link left: stop pretending. The
+      // card shows its download button and a click starts the count over.
+      if (this.allExhausted(infoHash)) {
+        this.upsertTransfer({
+          ...snapshot,
+          status: "failed",
+          error: "Could not reach the sender",
+        });
       }
     }
+  }
+
+  /**
+   * Dial one pair through its backoff. Every initiator-side dial goes
+   * through here - the first request, a re-announce, the reconcile tick - so
+   * none of them can skip the wait the last failure earned. A seeder we
+   * cannot currently reach is not worth a link. False when nothing was built.
+   */
+  private dial(infoHash: string, peerId: string, now: number): boolean {
+    if (peerId === this.selfId()) return false;
+    if (!this.connectedPeers.has(peerId)) return false;
+    const key = wtKey(infoHash, peerId);
+    if (this.wtPeers.has(key)) return false;
+    if (now < (this.wtNextTry.get(key) ?? 0)) return false;
+    const attempts = this.wtAttempts.get(key) ?? 0;
+    if (attempts >= WT_MAX_ATTEMPTS) return false;
+    // Backoff is for a peer that will not answer. A pair held back by the
+    // cap has not been tried at all, so it keeps its place at the front of
+    // the queue instead of being pushed out to the next retry window.
+    if (!this.createWTPeer(infoHash, peerId, true)) return false;
+    const wait = Math.min(
+      Math.max((this.wtBackoff.get(key) ?? 0) * 2, WT_RECONCILE_MS),
+      WT_RETRY_MAX_MS
+    );
+    this.wtBackoff.set(key, wait);
+    this.wtNextTry.set(key, now + wait);
+    this.wtAttempts.set(key, attempts + 1);
+    return true;
+  }
+
+  /** Every reachable seeder of the file is capped and none has a link. */
+  private allExhausted(infoHash: string): boolean {
+    let reachable = 0;
+    for (const peerId of this.seedersByHash.get(infoHash) ?? []) {
+      if (peerId === this.selfId() || !this.connectedPeers.has(peerId)) continue;
+      reachable += 1;
+      const key = wtKey(infoHash, peerId);
+      if (this.wtPeers.has(key)) return false;
+      if ((this.wtAttempts.get(key) ?? 0) < WT_MAX_ATTEMPTS) return false;
+    }
+    return reachable > 0;
+  }
+
+  private forgetRetryState(key: string): void {
+    this.wtNextTry.delete(key);
+    this.wtBackoff.delete(key);
+    this.wtAttempts.delete(key);
   }
 
   async seedFiles(files: File[]): Promise<FileDescriptor[]> {
@@ -273,7 +327,7 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     }
 
     if (existing?.status === "downloading") {
-      this.createWTPeer(file.infoHash, seederPeerId, true);
+      this.dial(file.infoHash, seederPeerId, Date.now());
     } else if (existing?.status === "failed") {
       // The last seeder leaving fails the transfer; without this a seeder
       // coming back was recorded and then ignored, and the file stayed
@@ -327,7 +381,7 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     }
   }
 
-  ensureDownload(file: FileDescriptor): void {
+  ensureDownload(file: FileDescriptor, opts?: { retry?: boolean }): void {
     if (!isValidInfoHash(file.infoHash)) {
       console.warn(`Rejecting download with invalid infoHash: ${file.infoHash}`);
       return;
@@ -336,6 +390,18 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     this.knownFiles.set(file.infoHash, file);
     const existing = this.transfers.get(file.infoHash);
     if (existing?.status === "complete" || existing?.status === "seeding") {
+      return;
+    }
+    const seeders = this.seedersByHash.get(file.infoHash);
+    if (opts?.retry) {
+      // The user asked: whatever the pairs earned before is forgiven.
+      for (const peerId of seeders ?? []) {
+        this.forgetRetryState(wtKey(file.infoHash, peerId));
+      }
+    } else if (existing?.status === "failed" && this.allExhausted(file.infoHash)) {
+      // Given up on stays given up on. A re-announce from the same peer used
+      // to flip this back to "downloading" (skeleton, a fresh file.request,
+      // no dial because every pair is capped) and the tick flipped it back.
       return;
     }
 
@@ -371,21 +437,22 @@ export class WebTorrentFileTransport implements FileTransferTransport {
       blobURL: existing?.blobURL,
     });
 
-    const seeders = this.seedersByHash.get(file.infoHash);
-    rec(
-      ev("file.request", {
-        d: {
-          peers: seeders?.size ?? 0,
-          fileRef: refs().fileRef(file.infoHash),
-        },
-      })
-    );
+    // One request per download, not one per announce: this is called again
+    // for every file every time its sender reconnects.
+    if (existing?.status !== "downloading") {
+      rec(
+        ev("file.request", {
+          d: {
+            peers: seeders?.size ?? 0,
+            fileRef: refs().fileRef(file.infoHash),
+          },
+        })
+      );
+    }
     if (!seeders || seeders.size === 0) return;
 
-    for (const peerId of seeders) {
-      if (peerId === this.selfId()) continue;
-      this.createWTPeer(file.infoHash, peerId, true);
-    }
+    const now = Date.now();
+    for (const peerId of seeders) this.dial(file.infoHash, peerId, now);
   }
 
   handleSignal(fromPeerId: string, envelope: FileSignalEnvelope): void {
@@ -423,11 +490,8 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     this.peerSeeded.delete(peerId);
     // Their retry state goes with them, so a peer that reconnects is dialled
     // straight away rather than inheriting a wait from before it dropped.
-    for (const key of [...this.wtNextTry.keys()]) {
-      if (key.endsWith(`:${peerId}`)) {
-        this.wtNextTry.delete(key);
-        this.wtBackoff.delete(key);
-      }
+    for (const key of new Set([...this.wtNextTry.keys(), ...this.wtAttempts.keys()])) {
+      if (key.endsWith(`:${peerId}`)) this.forgetRetryState(key);
     }
 
     for (const [infoHash, seeders] of this.seedersByHash) {
@@ -670,8 +734,7 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     (peer as unknown as { id: string }).id = peerId;
 
     peer.on("connect", () => {
-      this.wtNextTry.delete(key);
-      this.wtBackoff.delete(key);
+      this.forgetRetryState(key);
       void this.attachToTorrent(infoHash, peer);
     });
 

--- a/frontend/src/lib/transport/file/webtorrent.ts
+++ b/frontend/src/lib/transport/file/webtorrent.ts
@@ -821,13 +821,17 @@ export class WebTorrentFileTransport implements FileTransferTransport {
         filename: descriptor.filename,
         mimeType: descriptor.mimeType,
         size: descriptor.size,
-        status: torrent.done
-          ? isSeeding
-            ? "seeding"
-            : "complete"
-          : "downloading",
+        // A torrent we seed is "seeding" whatever webtorrent's done flag
+        // says: it stays false for a seed here, and the first wire event
+        // used to rewrite the sender's own file to "downloading" - which
+        // then had the reconcile tick dialling peers for a file we hold.
+        status: isSeeding
+          ? "seeding"
+          : torrent.done
+            ? "complete"
+            : "downloading",
         progress: torrent.progress ?? existing?.progress ?? 0,
-        done: torrent.done,
+        done: isSeeding || torrent.done,
         seeding: isSeeding,
         peers: torrent.numPeers ?? existing?.peers ?? 0,
         seeders:

--- a/frontend/src/lib/transport/node-lock.test.ts
+++ b/frontend/src/lib/transport/node-lock.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Two "tabs" are two instances of the module (vi.resetModules between the
+ * imports), sharing one fake Lock Manager and one fake broadcast bus. The
+ * fakes follow the Web Locks rules the module leans on: FIFO grant, a lock
+ * held for as long as the callback's promise is pending, ifAvailable that
+ * hands the callback null instead of queueing, steal that rejects the
+ * holder's request with AbortError, and a signal that drops a queued
+ * request the same way.
+ */
+
+type Entry = {
+  cb: (lock: unknown) => unknown;
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
+};
+
+const abort = () => Object.assign(new Error("aborted"), { name: "AbortError" });
+
+class FakeLocks {
+  holder: Entry | null = null;
+  queue: Entry[] = [];
+
+  request(_name: string, a: unknown, b?: unknown): Promise<unknown> {
+    const opts = (typeof a === "function" ? {} : a) as {
+      ifAvailable?: boolean;
+      steal?: boolean;
+      signal?: AbortSignal;
+    };
+    const cb = (typeof a === "function" ? a : b) as Entry["cb"];
+    return new Promise((resolve, reject) => {
+      const entry = { cb, resolve, reject };
+      if (opts.steal) {
+        const h = this.holder;
+        this.holder = null;
+        h?.reject(abort());
+        this.grant(entry);
+        return;
+      }
+      if (!this.holder) {
+        this.grant(entry);
+        return;
+      }
+      if (opts.ifAvailable) {
+        Promise.resolve()
+          .then(() => cb(null))
+          .then(resolve, reject);
+        return;
+      }
+      opts.signal?.addEventListener("abort", () => {
+        this.queue = this.queue.filter((e) => e !== entry);
+        reject(abort());
+      });
+      this.queue.push(entry);
+    });
+  }
+
+  private grant(entry: Entry): void {
+    this.holder = entry;
+    const done = () => {
+      if (this.holder !== entry) return;
+      this.holder = null;
+      const next = this.queue.shift();
+      if (next) this.grant(next);
+    };
+    Promise.resolve()
+      .then(() => entry.cb({ name: "awful:node", mode: "exclusive" }))
+      .then(
+        (v) => {
+          done();
+          entry.resolve(v);
+        },
+        (e) => {
+          done();
+          entry.reject(e);
+        }
+      );
+  }
+}
+
+class FakeChannel {
+  static all = new Set<FakeChannel>();
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  /** A frozen tab keeps its channel but never gets to read it. */
+  frozen = false;
+  constructor(public name: string) {
+    FakeChannel.all.add(this);
+  }
+  postMessage(data: unknown): void {
+    for (const c of FakeChannel.all) {
+      if (c === this || c.frozen) continue;
+      queueMicrotask(() => c.onmessage?.({ data }));
+    }
+  }
+  close(): void {
+    FakeChannel.all.delete(this);
+  }
+}
+
+type Mod = typeof import("./node-lock");
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+let locks: FakeLocks;
+let tabA: Mod;
+let tabB: Mod;
+const mkEvents = () => ({
+  onWaiting: vi.fn<(waiting: boolean) => void>(),
+  onRelease: vi.fn<() => void | Promise<void>>(),
+});
+let evA: ReturnType<typeof mkEvents>;
+let evB: ReturnType<typeof mkEvents>;
+
+describe("node lock", () => {
+  beforeEach(async () => {
+    locks = new FakeLocks();
+    FakeChannel.all.clear();
+    vi.stubGlobal("navigator", { locks });
+    vi.stubGlobal("BroadcastChannel", FakeChannel);
+    vi.resetModules();
+    tabA = await import("./node-lock");
+    vi.resetModules();
+    tabB = await import("./node-lock");
+    evA = mkEvents();
+    evB = mkEvents();
+  });
+
+  afterEach(() => {
+    tabA._resetNodeLockForTests();
+    tabB._resetNodeLockForTests();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("the first tab takes the seat at once", async () => {
+    await tabA.acquireNodeLock(evA);
+    expect(tabA.holdsNodeLock()).toBe(true);
+    expect(evA.onWaiting).toHaveBeenCalledWith(false);
+    expect(evA.onWaiting).not.toHaveBeenCalledWith(true);
+  });
+
+  it("a second tab waits, is told so, and gets the seat when the first goes", async () => {
+    await tabA.acquireNodeLock(evA);
+    let granted = false;
+    const wait = tabB.acquireNodeLock(evB).then(() => {
+      granted = true;
+    });
+    await flush();
+    expect(evB.onWaiting).toHaveBeenCalledWith(true);
+    expect(tabB.holdsNodeLock()).toBe(false);
+    expect(granted).toBe(false);
+
+    // The holder closes: the Lock Manager releases for it.
+    tabA.releaseNodeLock();
+    await wait;
+    expect(tabB.holdsNodeLock()).toBe(true);
+    expect(evB.onWaiting).toHaveBeenLastCalledWith(false);
+  });
+
+  it("a holder resolves again at once, a waiter joins its own wait", async () => {
+    await tabA.acquireNodeLock(evA);
+    await tabA.acquireNodeLock(evA);
+    const first = tabB.acquireNodeLock(evB);
+    const second = tabB.acquireNodeLock(evB);
+    expect(second).toBe(first);
+  });
+
+  it("Use here asks the holder to step down and takes its place", async () => {
+    await tabA.acquireNodeLock(evA);
+    const wait = tabB.acquireNodeLock(evB);
+    await flush();
+
+    tabB.claimNodeLock();
+    await flush();
+    expect(evA.onRelease).toHaveBeenCalledTimes(1);
+    expect(tabA.holdsNodeLock()).toBe(false);
+    await wait;
+    expect(tabB.holdsNodeLock()).toBe(true);
+  });
+
+  it("the tab that stepped down queues behind the asker", async () => {
+    await tabA.acquireNodeLock(evA);
+    // The holder's teardown asks for the seat back, the way connect() does.
+    evA.onRelease.mockImplementation(() => {
+      void tabA.acquireNodeLock(evA);
+    });
+    const wait = tabB.acquireNodeLock(evB);
+    await flush();
+    tabB.claimNodeLock();
+    await wait;
+    await flush();
+    expect(tabB.holdsNodeLock()).toBe(true);
+    expect(tabA.holdsNodeLock()).toBe(false);
+    expect(evA.onWaiting).toHaveBeenLastCalledWith(true);
+
+    // ...and comes back when the asker closes.
+    tabB.releaseNodeLock();
+    await flush();
+    expect(tabA.holdsNodeLock()).toBe(true);
+  });
+
+  it("a frozen holder is stolen from after the grace period", async () => {
+    vi.useFakeTimers();
+    await tabA.acquireNodeLock(evA);
+    const frozen = [...FakeChannel.all][0];
+    frozen.frozen = true;
+    const wait = tabB.acquireNodeLock(evB);
+    await vi.advanceTimersByTimeAsync(0);
+
+    tabB.claimNodeLock();
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(tabB.holdsNodeLock()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1_500);
+    await wait;
+    expect(tabB.holdsNodeLock()).toBe(true);
+    // The holder learns through its own request rejecting.
+    expect(evA.onRelease).toHaveBeenCalledTimes(1);
+    expect(tabA.holdsNodeLock()).toBe(false);
+
+    // Its old queued request was dropped: releasing hands the seat to nobody
+    // rather than straight back to itself.
+    tabB.releaseNodeLock();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tabB.holdsNodeLock()).toBe(false);
+    expect(locks.holder).toBeNull();
+  });
+
+  it("behaves as before without a Lock Manager", async () => {
+    vi.stubGlobal("navigator", {});
+    vi.resetModules();
+    const mod: Mod = await import("./node-lock");
+    await mod.acquireNodeLock(evA);
+    expect(mod.holdsNodeLock()).toBe(true);
+    mod._resetNodeLockForTests();
+  });
+});

--- a/frontend/src/lib/transport/node-lock.ts
+++ b/frontend/src/lib/transport/node-lock.ts
@@ -1,0 +1,206 @@
+/**
+ * One libp2p node per browser profile.
+ *
+ * The peerId comes from a per-profile seed (device-key.ts), so two tabs of
+ * the same profile are two nodes with one peerId. The relay and every peer
+ * keep one stream per peerId, so the two starve each other of pongs and
+ * reconnect every ~125 s, taking every voice and file link down with them
+ * (the 2026-09-04 and 2026-09-06 diag packs). The Web Locks API is scoped
+ * to origin + profile, exactly the scope of the seed, so one named lock is
+ * the seat: the holder runs the node, every other tab waits and is told so.
+ *
+ * A tab that closes or crashes releases on its own and the next in line
+ * comes up without anyone doing anything. A waiting tab can also ask for
+ * the seat ("Use here"): the holder tears its node down and releases. If
+ * the holder cannot answer (frozen by the browser) the waiter takes the
+ * seat outright after a grace period; the holder's request promise then
+ * rejects, which is how it learns it lost the seat.
+ *
+ * Best effort, like the DM queue lock: a browser without the Lock Manager
+ * behaves exactly as before.
+ */
+
+const LOCK_NAME = "awful:node";
+const CHANNEL_NAME = "awful:node";
+/** How long a takeover waits for the holder to step down before stealing. */
+const STEAL_AFTER_MS = 5_000;
+
+export interface NodeLockEvents {
+  /** true while another tab has the seat and this one is queued for it. */
+  onWaiting: (waiting: boolean) => void;
+  /**
+   * This tab must give the seat up: tear the node down. Called when a
+   * waiter asked for it, or when one stole it. The lock is released once
+   * the returned promise settles.
+   */
+  onRelease: () => void | Promise<void>;
+}
+
+let held = false;
+let acquiring: Promise<void> | null = null;
+let resolveAcquired: (() => void) | null = null;
+/** Resolves the lock callback's promise, which is what releases the lock. */
+let releaseHold: (() => void) | null = null;
+/** Aborts our queued request, for when a steal made it redundant. */
+let queuedAbort: AbortController | null = null;
+let dropQueued = false;
+let channel: BroadcastChannel | null = null;
+let events: NodeLockEvents | null = null;
+
+function supported(): boolean {
+  return typeof navigator !== "undefined" && !!navigator.locks;
+}
+
+function isAbort(err: unknown): boolean {
+  return (err as { name?: string } | null)?.name === "AbortError";
+}
+
+/** The lock callback: hold the seat until releaseNodeLock(). */
+function grant(): Promise<void> {
+  held = true;
+  acquiring = null;
+  resolveAcquired?.();
+  resolveAcquired = null;
+  events?.onWaiting(false);
+  return new Promise<void>((r) => {
+    releaseHold = r;
+  });
+}
+
+/** Whether this tab currently holds the seat. */
+export function holdsNodeLock(): boolean {
+  return held;
+}
+
+/**
+ * Wait for the seat. Resolves once this tab holds it - immediately when it is
+ * free, and after the holder is gone when it is not. Safe to call again: a
+ * holder resolves at once, a waiter joins its own wait.
+ */
+export function acquireNodeLock(ev: NodeLockEvents): Promise<void> {
+  events = ev;
+  if (held) return Promise.resolve();
+  if (acquiring) return acquiring;
+  if (!supported()) {
+    held = true;
+    return Promise.resolve();
+  }
+  listen();
+
+  acquiring = new Promise<void>((resolve) => {
+    resolveAcquired = resolve;
+  });
+  let queued = false;
+  navigator.locks
+    .request(LOCK_NAME, { ifAvailable: true }, (lock) => {
+      if (lock) return grant();
+      // Someone else has it. Say so, then wait our turn behind them.
+      queued = true;
+      ev.onWaiting(true);
+      return undefined;
+    })
+    .then(() => {
+      if (!queued) return;
+      queued = false;
+      queuedAbort = new AbortController();
+      return navigator.locks.request(
+        LOCK_NAME,
+        { signal: queuedAbort.signal },
+        () => grant()
+      );
+    })
+    .catch((err: unknown) => {
+      if (isAbort(err)) {
+        // Our own queued request, dropped after a steal got us the seat.
+        if (dropQueued) {
+          dropQueued = false;
+          return;
+        }
+        // Stolen from under us: the seat is already gone, tear down.
+        if (held) {
+          held = false;
+          releaseHold = null;
+          void ev.onRelease();
+        }
+        return;
+      }
+      // Lock Manager refused (opaque origin, storage blocked): behave as if
+      // there were none, which is what every tab did before.
+      held = true;
+      acquiring = null;
+      resolveAcquired?.();
+      resolveAcquired = null;
+      ev.onWaiting(false);
+    });
+  return acquiring;
+}
+
+/** Give the seat up. No-op when this tab does not hold it. */
+export function releaseNodeLock(): void {
+  held = false;
+  releaseHold?.();
+  releaseHold = null;
+}
+
+/**
+ * Ask for the seat from a waiting tab. The holder steps down through
+ * onRelease and the Lock Manager hands the seat to the next waiter.
+ */
+export function claimNodeLock(): void {
+  if (held || !supported()) return;
+  channel?.postMessage({ type: "release" });
+  // A frozen holder never reads the channel. Its lock is real, though, so
+  // after a grace period take it by force; the holder's own request rejects
+  // with AbortError, and it tears down when it thaws.
+  setTimeout(() => {
+    if (held) return;
+    void navigator.locks
+      .request(LOCK_NAME, { steal: true }, (lock) => {
+        if (!lock) return undefined;
+        // The request we queued is behind this one now and would hand the
+        // seat straight back to us on the next release. Drop it.
+        if (queuedAbort) {
+          dropQueued = true;
+          queuedAbort.abort();
+          queuedAbort = null;
+        }
+        return grant();
+      })
+      .catch((err: unknown) => {
+        if (isAbort(err) && held) {
+          held = false;
+          releaseHold = null;
+          void events?.onRelease();
+        }
+      });
+  }, STEAL_AFTER_MS);
+}
+
+// ponytail: FIFO hands the seat to the oldest waiter, not necessarily the
+// tab that clicked; with two waiters the click may light up the other one.
+function listen(): void {
+  if (channel || typeof BroadcastChannel === "undefined") return;
+  channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.onmessage = (e: MessageEvent) => {
+    if (e.data?.type !== "release" || !held || !events) return;
+    // Not held from this instant: a connect() the teardown kicks off queues
+    // behind the asker instead of short-circuiting on `held`.
+    held = false;
+    void Promise.resolve(events.onRelease()).finally(() => {
+      releaseHold?.();
+      releaseHold = null;
+    });
+  };
+}
+
+/** Test hook: forget every module-level piece of state. */
+export function _resetNodeLockForTests(): void {
+  releaseNodeLock();
+  acquiring = null;
+  resolveAcquired = null;
+  queuedAbort = null;
+  dropQueued = false;
+  events = null;
+  channel?.close();
+  channel = null;
+}

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -83,6 +83,7 @@ import { DtlnProcessor } from "../audio/dtln-processor";
 import { WORKLET_URL } from "../audio/worklet-url";
 import { requireSession } from "../identity/identity";
 import { deviceKeySeed } from "./device-key";
+import { acquireNodeLock, releaseNodeLock } from "./node-lock";
 import { looksLikeDid, looksLikePeerId } from "../identity/identity-utils";
 import {
   canonicalContentV3,
@@ -344,6 +345,8 @@ export interface ParticipantState {
 
 interface TransportState {
   relayConnected: boolean;
+  /** Another tab of this browser profile runs the node; this one is queued for it. See node-lock.ts. */
+  nodeHeldElsewhere: boolean;
   connected: boolean;
   connecting: boolean;
   /**
@@ -458,6 +461,7 @@ interface TransportState {
 
 export const transportState = $state<TransportState>({
   relayConnected: false,
+  nodeHeldElsewhere: false,
   connected: false,
   connecting: false,
   joiningCall: false,
@@ -3604,6 +3608,28 @@ function _scheduleConnectRetry(): void {
   _connectRetryDelay = Math.min(_connectRetryDelay * 2, CONNECT_RETRY_MAX_MS);
 }
 
+const _nodeLockEvents = {
+  onWaiting: (waiting: boolean) => {
+    transportState.nodeHeldElsewhere = waiting;
+    rec(ev("session.node", { d: { state: waiting ? "waiting" : "held" } }));
+  },
+  onRelease: () => _stepDown(),
+};
+
+/**
+ * Another tab of this profile asked for the node: tear ours down and queue
+ * behind it, so the seat comes back here when that tab goes. The room on
+ * screen stays as it is; connect() rejoins every saved room on the way back.
+ */
+function _stepDown(): void {
+  rec(ev("session.node", { d: { state: "stepdown" } }));
+  leaveCall();
+  _transport.disconnect();
+  transportState.relayConnected = false;
+  transportState.connected = false;
+  connect().catch(() => {});
+}
+
 export async function connect() {
   // The flag is not proof. A page restored from the back-forward cache, or a
   // tab the browser froze, keeps relayConnected === true over a node that is
@@ -3622,6 +3648,10 @@ export async function connect() {
 
   _connectPromise = (async () => {
     try {
+      // One node per browser profile: a second tab of the same profile would
+      // share this peerId and the two would starve each other (node-lock.ts).
+      // Waits here, for as long as it takes, when another tab has the seat.
+      await acquireNodeLock(_nodeLockEvents);
       // This device's own libp2p key, NOT the identity key: two devices on the
       // same account would otherwise share a peerId and never connect.
       await _transport.connect(deviceKeySeed());
@@ -3880,6 +3910,7 @@ function _disconnectWithoutBroadcasting(): void {
   _fileTransport.resetTransfers();
   leaveCall();
   _transport.disconnect();
+  releaseNodeLock();
   stopTelemetryTaps();
   _peerIdToDid.clear();
   clearCardStates();
@@ -4481,7 +4512,7 @@ export function requestFileDownload(
   if (peerId) {
     _fileTransport.registerSeeder(file, peerId);
   }
-  _fileTransport.ensureDownload(file);
+  _fileTransport.ensureDownload(file, { retry: true });
 }
 
 export async function toggleReaction(

--- a/frontend/src/lib/transport/types.ts
+++ b/frontend/src/lib/transport/types.ts
@@ -313,7 +313,8 @@ export interface FileTransferEvents {
 export interface FileTransferTransport {
   seedFiles(files: File[]): Promise<FileDescriptor[]>;
   registerSeeder(file: FileDescriptor, seederPeerId: string): void;
-  ensureDownload(file: FileDescriptor): void;
+  /** `retry`: the user asked, so per-pair give-up state is forgotten first. */
+  ensureDownload(file: FileDescriptor, opts?: { retry?: boolean }): void;
   handleSignal(fromPeerId: string, envelope: FileSignalEnvelope): void;
   onPeerConnect(peerId: string): void;
   onPeerDisconnect(peerId: string): void;


### PR DESCRIPTION
## transport: one libp2p node per browser profile (fc0c3d7)

Two tabs, or a tab and the installed PWA, of the same browser profile share the libp2p seed and so the peerId. The relay and every peer keep one stream per peerId, so the two nodes starved each other of pongs and reconnected every ~125 s without ever disconnecting, taking every voice and file link down with them. Both the 2026-09-04 and 2026-09-06 diag packs were this: 36 connects against 2 disconnects, a voice redial storm, 428 of Chrome's 500 PeerConnections.

connect() now takes a Web Lock ("awful:node", scoped to origin plus profile like the seed) before building the node (node-lock.ts). A second tab waits, shows "awful.chat is open in another tab", and can take the seat with "Use here": the holder tears its node down over a BroadcastChannel and queues behind it, so the seat comes back when that tab closes. A frozen holder is stolen from after 5 s and learns through its own request rejecting. Browsers without the Lock Manager behave as before. A new telemetry kind, session.node (waiting, held, stepdown), lets the next pack confirm which tab ran the node.

Verified in headless Firefox with a second tab of the same profile: it waits, "Use here" moves the node with the same peerId and the other peer still sees it, closing the tab hands it back.

## files: the redial storm gives up (fc0c3d7, 9ff18b1)

Every reconnect re-announced the whole file inventory, and every announce re-dialled every stuck file with no ceiling: 520 file requests in two minutes. Every initiator dial now goes through one backoff-aware path, capped at six attempts per file-and-peer pair; file.request is recorded once per download, not once per announce; the reconcile tick no longer dials "pending" files nobody asked for; a transfer whose reachable seeders are all capped flips to "failed" so the Download button shows, and that click, a real disconnect, or the peer reconnecting starts the count over.

Also: the torrent event handler recomputed status from webtorrent's done flag, which stays false for a seed, so the first peer connecting rewrote the sender's own file to "downloading" and the reconcile tick dialled peers for a file we already hold. A seeded torrent now stays "seeding".

Verified: a 700 KB file still arrives over WebTorrent between two headless peers.

## files: a file link dialled before TURN landed is redialled once it does (1d553a0)

ICE servers are snapshotted when a file link is built, and the first dials of a session happen before the TURN credentials arrive, so between two NATs those links never connected and the image sat on its skeleton. Unconnected links are now torn down and redialled when the credential list changes, the way voice already did.

## call: the tile menu offers the person (bd1fd75)

Right-clicking someone's tile had Message and the volume slider. Now also Mute / Unmute (the slider at 0 with a name; Unmute brings back the level they had, and dragging the slider to 0 flips the row in place), View profile (the same card the user list opens, leaving fullscreen first), and Add to / Remove from phonebook. isInPhonebook was three identical copies and is now one export next to add and remove.

The peer-volume e2e had been silently broken since the stage started filtering call peers by room; both injected-call scenarios now set callPeerRooms.

---

Typecheck clean in frontend and dashboard; transport, component, file and dashboard suites pass; e2e two-tabs, large-file, tile-person-menu and peer-volume pass.
