### PR TITLE
Dev to main: two pages that need no account, and a file link that stops hanging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -263,3 +263,12 @@ TURN_SECRET=
 # identity. So it does not bound one client, and raising it is usually not
 # what you want; TURN_TOTAL_QUOTA is the real limit.
 #TURN_USER_QUOTA=12
+
+# ── Optional pages ───────────────────────────────────────────────────────────
+
+# /qs - send a file to one person, no account and no room. The code is the
+# only secret; bytes go peer to peer and are never stored on the server.
+#USE_QS=true
+
+# /qc - a call with no room and no account.
+#USE_QC=true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,11 @@ services:
       # 9000. QmRelay is still a placeholder - replace it with the peer id the
       # relay prints on boot.
       VITE_RELAY_MULTIADDR: ${VITE_RELAY_MULTIADDR:-/ip4/127.0.0.1/tcp/8080/ws/p2p/QmRelay}
+      # Optional pages, off unless set: /qs sends a file to one person with no
+      # account, /qc is a call with no room. The dev server reads the VITE_
+      # spelling; a built image reads APP_USE_QS / APP_USE_QC instead.
+      VITE_USE_QS: ${USE_QS:-}
+      VITE_USE_QC: ${USE_QC:-}
     depends_on:
       - relay
     networks:

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -377,6 +377,10 @@ services:
       # Empty = this origin's own /sfu.
       - APP_SFU_URL=${VITE_SFU_URL:-}
       - APP_SFU_URLS=${VITE_SFU_URLS:-}
+      # Optional pages, off unless set: /qs sends a file to one person with
+      # no account, /qc is a call with no room.
+      - APP_USE_QS=${USE_QS:-}
+      - APP_USE_QC=${USE_QC:-}
     restart: unless-stopped
     # Drops every capability except what the stock nginx image needs: the
     # master starts as root and setuid/setgids its workers to the nginx user

--- a/frontend/docker-entrypoint.d/40-awful-config.sh
+++ b/frontend/docker-entrypoint.d/40-awful-config.sh
@@ -27,6 +27,11 @@ api_url=${APP_API_URL:-${VITE_API_URL:-}}
 relay=${APP_RELAY_MULTIADDR:-${VITE_RELAY_MULTIADDR:-}}
 sfu=${APP_SFU_URLS:-${VITE_SFU_URLS:-${APP_SFU_URL:-${VITE_SFU_URL:-}}}}
 
+# Feature flags. Bare USE_QS/USE_QC are accepted too - they name nothing else
+# in this container, and they are the spelling the flags were asked for.
+use_qs=${APP_USE_QS:-${USE_QS:-${VITE_USE_QS:-}}}
+use_qc=${APP_USE_QC:-${USE_QC:-${VITE_USE_QC:-}}}
+
 # JSON forbids a raw control character inside a string, so a value carrying a
 # stray CR - a .env saved with CRLF line endings, a paste through a web UI -
 # would produce a file the app cannot parse. It is dropped rather than
@@ -35,6 +40,15 @@ sfu=${APP_SFU_URLS:-${VITE_SFU_URLS:-${APP_SFU_URL:-${VITE_SFU_URL:-}}}}
 # are escaped for the same reason.
 esc() {
   printf '%s' "$1" | tr -d '\000-\037' | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# A JSON boolean, defaulting to false: an unset or unrecognised flag leaves
+# the route off, so a typo hides the feature rather than exposing one.
+flag() {
+  case $(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -d ' \t') in
+    1 | true | yes | on) printf 'true' ;;
+    *) printf 'false' ;;
+  esac
 }
 
 # Comma separated list -> JSON array, empty entries dropped.
@@ -51,11 +65,14 @@ cat > "$OUT" <<JSON
 {
   "apiUrl": "$(esc "$api_url")",
   "relayMultiaddr": "$(esc "$relay")",
-  "sfuUrls": [$sfu_json]
+  "sfuUrls": [$sfu_json],
+  "useQs": $(flag "$use_qs"),
+  "useQc": $(flag "$use_qc")
 }
 JSON
 
-echo "[awful] wrote $OUT (api=${api_url:-unset} relay=${relay:-unset} sfu=${sfu:-unset})"
+echo "[awful] wrote $OUT (api=${api_url:-unset} relay=${relay:-unset}" \
+     "sfu=${sfu:-unset} qs=$(flag "$use_qs") qc=$(flag "$use_qc"))"
 
 # Nothing configured means nothing works: no relay to dial, no API. It is
 # worth being noisy about, because the container is otherwise healthy and the

--- a/frontend/e2e/driver.mjs
+++ b/frontend/e2e/driver.mjs
@@ -152,6 +152,7 @@ export class Peer {
         if (document.querySelector('input[placeholder="Room code, short code or link"]')) return 'ready';
         if (document.querySelector('textarea')) return 'ready';
         if (/Create new identity/i.test(t)) return 'ready';
+        if (/Quick (send|call)/i.test(t)) return 'ready'; // /qs and /qc have no identity at all
         return false;
       })()`),
       { timeout: 30_000 }

--- a/frontend/e2e/run-all.sh
+++ b/frontend/e2e/run-all.sh
@@ -12,7 +12,10 @@ SCENARIOS="dm-extras sync-recovers dm-removal title-and-sound dtln-gain clock-sk
 room-removal reconnect-churn audio-prefs peer-volume background-sync rapid-switch
 drag-drop room-clock backfill-below-window call-status call-roster-ttl
 call-late-join call-join-speed call-without-sfu relay-upgrade history-pull mobile-shell
-device-sync"
+device-sync quick-send quick-send-alongside-app quick-call
+quick-call-alongside-app"
+# The quick-* scenarios need their routes turned on: start the dev server with
+# VITE_USE_QS=true VITE_USE_QC=true, or they fail saying so.
 fail=0
 failed=""
 for sc in $SCENARIOS; do

--- a/frontend/e2e/run-all.sh
+++ b/frontend/e2e/run-all.sh
@@ -13,7 +13,7 @@ room-removal reconnect-churn audio-prefs peer-volume background-sync rapid-switc
 drag-drop room-clock backfill-below-window call-status call-roster-ttl
 call-late-join call-join-speed call-without-sfu relay-upgrade history-pull mobile-shell
 device-sync quick-send quick-send-alongside-app quick-call
-quick-call-alongside-app"
+quick-call-alongside-app quick-call-account"
 # The quick-* scenarios need their routes turned on: start the dev server with
 # VITE_USE_QS=true VITE_USE_QC=true, or they fail saying so.
 fail=0

--- a/frontend/e2e/scenarios/quick-call-account.mjs
+++ b/frontend/e2e/scenarios/quick-call-account.mjs
@@ -1,0 +1,143 @@
+/**
+ * /qc with the account this device already has.
+ *
+ * The point is the pair of things that must BOTH be true: the person in the
+ * call is the real identity - same DID, same profile, so the other side sees
+ * who they actually are - while the call itself stays as disposable as a
+ * guest's, in a database that goes with the tab and never touching the saved
+ * rooms.
+ */
+import { bootPeers, closeAll, Peer, sleep } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("quick call can use the account on this device");
+const [alice] = await bootPeers(["Alice"], { ports: [9307] });
+const bob = new Peer(9308, "Bob");
+let qcContext = null;
+
+try {
+  await bob.start();
+  await alice.createRoom("Homeroom");
+  await alice.waitFor("alice's app is connected", () =>
+    alice.eval(`window.__awful.state.connected === true`)
+  );
+  // joinRoom puts our own DID in the roster, which is the only place the app
+  // tab exposes it.
+  const accountDid = await alice.waitFor("alice's account did", () =>
+    alice.eval(`window.__awful.state.roomUsers.find((d) => d.startsWith('did:')) || null`)
+  );
+
+  const created = await alice.bidi.send("browsingContext.create", {
+    type: "tab",
+  });
+  qcContext = created.context;
+  const quick = alice.tab(qcContext);
+  await quick.go("/qc");
+
+  // A device WITH an account is asked who to be; one without is not.
+  const choosing = await quick.waitFor("the choice appears", async () => {
+    const stage = await quick.eval(`window.__qc?.state.stage`);
+    return stage === "choosing" ? stage : null;
+  });
+  check.equal(choosing, "choosing", "an account on the device is offered");
+
+  await quick.clickText("Use my account");
+  await quick.waitFor("the unlock screen", () =>
+    quick.eval(`window.__qc.state.stage === 'unlocking'`)
+  );
+
+  // The unlock may complete on its own from a remembered password; if not,
+  // type it like a person would.
+  const ready = await quick.waitFor("the account is unlocked", async () => {
+    const stage = await quick.eval(`window.__qc.state.stage`);
+    if (stage === "setup") return stage;
+    if (stage === "failed") throw new Error(await quick.eval(`window.__qc.state.error`));
+    if (await quick.fill("password", "e2e-password")) {
+      await quick.clickText("Unlock");
+    }
+    return null;
+  }, { timeout: 60_000 });
+  check.equal(ready, "setup", "unlocking leads to the setup screen");
+
+  check.equal(
+    await quick.eval(`window.__qc.state.identity`),
+    "account",
+    "the call is being joined as the account"
+  );
+  check.equal(
+    await quick.eval(`window.__qc.state.profile.name`),
+    "Alice",
+    "the account's own display name came across"
+  );
+
+  await quick.clickText("Join call");
+  await quick.waitFor("in the call", async () => {
+    const stage = await quick.eval(`window.__qc.state.stage`);
+    if (stage === "failed") throw new Error(await quick.eval(`window.__qc.state.error`));
+    return stage === "in-call";
+  }, { timeout: 60_000 });
+
+  // The real identity, not a throwaway one.
+  check.equal(
+    await quick.eval(`window.__qc.did()`),
+    accountDid,
+    "the call runs under the account's own DID"
+  );
+  // ...in a database that is still disposable.
+  check.ok(
+    /^awful-quick-/.test(await quick.eval(`window.__qc.dbName()`)),
+    "the call is still written to a throwaway database"
+  );
+  // ...and the app tab was not disturbed.
+  check.equal(
+    await alice.eval(`window.__awful.state.nodeHeldElsewhere`),
+    false,
+    "the app tab still holds the node"
+  );
+
+  // Somebody who has never signed in sees the account's real name.
+  const code = await quick.eval(`window.__qc.state.code`);
+  await bob.go(`/qc#${code}`);
+  await bob.waitFor("bob reaches the setup screen", () =>
+    bob.eval(`window.__qc?.state.stage === 'setup'`)
+  );
+  await bob.fill("Your display name", "Bob");
+  await bob.clickText("Join call");
+  await bob.waitFor("bob is in the call", () =>
+    bob.eval(`window.__qc.state.stage === 'in-call'`), { timeout: 60_000 });
+  const sawName = await bob.waitFor("bob sees the account's name", () =>
+    bob.eval(`[...window.__awful.state.peerNames.values()].includes('Alice')`),
+    { timeout: 90_000 }
+  );
+  check.ok(sawName, "the other side sees the account, not a guest");
+
+  // Closing the tab still takes everything with it, account or not.
+  await alice.bidi.send("browsingContext.close", { context: qcContext });
+  qcContext = null;
+  await sleep(2000);
+  const left = await alice.waitFor("the quick database is gone", async () => {
+    const names = await alice.json(
+      `indexedDB.databases().then((d) => JSON.stringify(d.map((x) => x.name).filter((n) => n && n.startsWith('awful-quick-'))))`
+    );
+    return names.length === 0 ? names : null;
+  }, { timeout: 30_000 });
+  check.equal(left.length, 0, "nothing survived the tab");
+
+  // And the account's real database still holds only the room it had.
+  const rooms = await alice.json(
+    `window.__awful.state.roomCode ? JSON.stringify([window.__awful.state.roomCode]) : "[]"`
+  );
+  check.ok(
+    !rooms.includes(code),
+    "the quick call never joined the account's saved rooms",
+    rooms
+  );
+} finally {
+  check.finish();
+  if (qcContext) {
+    await alice.bidi
+      .send("browsingContext.close", { context: qcContext })
+      .catch(() => {});
+  }
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/quick-call-alongside-app.mjs
+++ b/frontend/e2e/scenarios/quick-call-alongside-app.mjs
@@ -1,0 +1,104 @@
+/**
+ * /qc in a second tab of a profile that is already signed in, and what it
+ * leaves behind when that tab closes.
+ *
+ * Two things are being pinned. The app runs ONE libp2p node per profile,
+ * elected with a Web Lock (node-lock.ts) - a quick call must not take that
+ * seat from the tab holding the user's account. And the whole promise of the
+ * page is that the call is gone afterwards: its database must not outlive it.
+ */
+import { bootPeers, closeAll, Peer, sleep } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("quick call runs beside the app and cleans up");
+const [alice] = await bootPeers(["Alice"], { ports: [9307] });
+const bob = new Peer(9308, "Bob");
+let qcContext = null;
+
+/** Quick databases this browser profile currently has. */
+const QUICK_DBS = `indexedDB.databases().then((d) =>
+  JSON.stringify(d.map((x) => x.name).filter((n) => n && n.startsWith('awful-quick-'))))`;
+
+try {
+  await bob.start();
+  await alice.createRoom("Callab");
+  await alice.waitFor("alice's app is connected", () =>
+    alice.eval(`window.__awful.state.connected === true`)
+  );
+
+  const created = await alice.bidi.send("browsingContext.create", {
+    type: "tab",
+  });
+  qcContext = created.context;
+  const quick = alice.tab(qcContext);
+  await quick.go("/qc");
+
+  await quick.waitFor("the quick tab is ready", async () =>
+    quick.eval(`window.__qc?.state.stage === 'setup'`)
+  );
+  await quick.fill("Your name", "Guest");
+  await quick.clickText("Join call");
+  const code = await quick.waitFor("the quick tab joins its call", async () => {
+    const stage = await quick.eval(`window.__qc.state.stage`);
+    if (stage === "failed") throw new Error(await quick.eval(`window.__qc.state.error`));
+    return stage === "in-call" ? quick.eval(`window.__qc.state.code`) : null;
+  }, { timeout: 60_000 });
+
+  // The app tab kept its seat and its connection.
+  check.equal(
+    await alice.eval(`window.__awful.state.nodeHeldElsewhere`),
+    false,
+    "the app tab still holds the node"
+  );
+  check.ok(
+    await alice.eval(`window.__awful.state.connected === true`),
+    "the app tab is still connected"
+  );
+  // And is still in its OWN room, not the call's.
+  check.ok(
+    (await alice.eval(`window.__awful.state.roomCode`)) !== code,
+    "the app tab was not dragged into the call"
+  );
+
+  // A second person, from a browser that has never signed in.
+  await bob.go(`/qc#${code}`);
+  await bob.waitFor("bob reaches the setup screen", () =>
+    bob.eval(`window.__qc?.state.stage === 'setup'`)
+  );
+  await bob.fill("Your name", "Bob");
+  await bob.clickText("Join call");
+  await bob.waitFor("bob is in the call", () =>
+    bob.eval(`window.__qc.state.stage === 'in-call'`), { timeout: 60_000 });
+  await quick.waitFor("the two are in one call", () =>
+    quick.eval(`[...window.__awful.state.callPeerIds].length >= 1`),
+    { timeout: 90_000 }
+  );
+  check.ok(true, "a signed-in profile can hold a quick call beside its app");
+
+  const during = await alice.json(QUICK_DBS);
+  check.equal(during.length, 1, "the call has a database of its own", during);
+
+  // Close the quick tab: pagehide fires, the database goes.
+  await alice.bidi.send("browsingContext.close", { context: qcContext });
+  qcContext = null;
+  await sleep(2000);
+
+  const after = await alice.waitFor("the quick database is gone", async () => {
+    const names = await alice.json(QUICK_DBS);
+    return names.length === 0 ? names : null;
+  }, { timeout: 30_000 });
+  check.equal(after.length, 0, "nothing survived the tab", after);
+
+  check.ok(
+    await alice.eval(`window.__awful.state.connected === true`),
+    "the app tab survived the whole thing"
+  );
+} finally {
+  check.finish();
+  if (qcContext) {
+    await alice.bidi
+      .send("browsingContext.close", { context: qcContext })
+      .catch(() => {});
+  }
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/quick-call-alongside-app.mjs
+++ b/frontend/e2e/scenarios/quick-call-alongside-app.mjs
@@ -33,10 +33,18 @@ try {
   const quick = alice.tab(qcContext);
   await quick.go("/qc");
 
-  await quick.waitFor("the quick tab is ready", async () =>
-    quick.eval(`window.__qc?.state.stage === 'setup'`)
+  // This profile HAS an account, so /qc asks who to be first. Guest, here:
+  // the account path has its own scenario.
+  await quick.waitFor("the choice appears", () =>
+    quick.eval(`window.__qc?.state.stage === 'choosing'`)
   );
-  await quick.fill("Your name", "Guest");
+  await quick.clickText("Join as a guest");
+  await quick.waitFor("the quick tab is ready", async () =>
+    quick.eval(`window.__qc.state.stage === 'setup'`)
+  );
+  if (!(await quick.fill("Your display name", "Guest"))) {
+    throw new Error("no name field on the quick setup screen");
+  }
   await quick.clickText("Join call");
   const code = await quick.waitFor("the quick tab joins its call", async () => {
     const stage = await quick.eval(`window.__qc.state.stage`);
@@ -65,7 +73,9 @@ try {
   await bob.waitFor("bob reaches the setup screen", () =>
     bob.eval(`window.__qc?.state.stage === 'setup'`)
   );
-  await bob.fill("Your name", "Bob");
+  if (!(await bob.fill("Your display name", "Bob"))) {
+    throw new Error("no name field on bob's setup screen");
+  }
   await bob.clickText("Join call");
   await bob.waitFor("bob is in the call", () =>
     bob.eval(`window.__qc.state.stage === 'in-call'`), { timeout: 60_000 });

--- a/frontend/e2e/scenarios/quick-call.mjs
+++ b/frontend/e2e/scenarios/quick-call.mjs
@@ -27,7 +27,9 @@ async function joinAs(peer, name) {
     const s = await peer.json(qcState);
     return s.stage === "setup";
   });
-  await peer.fill("Your name", name);
+  if (!(await peer.fill("Your display name", name))) {
+    throw new Error(`${name}: no name field on the setup screen`);
+  }
   await peer.clickText("Join call");
   return peer.waitFor(`${name} is in the call`, async () => {
     const s = await peer.json(qcState);
@@ -48,7 +50,7 @@ try {
   const code = await alice.waitFor("alice gets a code", () =>
     alice.eval(`window.__qc?.state.code || null`)
   );
-  check.ok(/^[0-9A-HJKMNP-TV-Z]{13}$/.test(code), "code is a room code", code);
+  check.ok(/^[0-9A-HJKMNP-TV-Z]{10}$/.test(code), "code is a 10-character quick code", code);
   check.equal(
     await alice.eval(`window.location.pathname + '|' + window.location.hash`),
     `/qc|#${code}`,
@@ -93,6 +95,24 @@ try {
     alice.eval(`[...window.__awful.state.peerNames.values()].includes('Bob')`)
   );
   check.ok(named, "the profile reached the other side");
+
+  // A quick call is a room nobody keeps, so it has the room's chat.
+  await alice.waitFor("alice can type", () =>
+    alice.eval(`!!document.querySelector('textarea')`)
+  );
+  await alice.eval(`(() => {
+    const el = document.querySelector('textarea');
+    const set = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+    set.call(el, 'hello from alice');
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    return true;
+  })()`);
+  const heard = await bob.waitFor("bob reads it", () =>
+    bob.eval(`document.body.innerText.includes('hello from alice')`),
+    { timeout: 60_000 }
+  );
+  check.ok(heard, "the chat works in a quick call");
 
   // Nothing about this call may be in the database a real account uses.
   // start() visits /app first, so awful-chat exists on this profile - what

--- a/frontend/e2e/scenarios/quick-call.mjs
+++ b/frontend/e2e/scenarios/quick-call.mjs
@@ -1,0 +1,134 @@
+/**
+ * /qc end to end: two browsers with no identity meet on a code and end up in
+ * one call, with voice flowing.
+ *
+ * Also the two promises the page makes about what it leaves behind: the call
+ * is written to a throwaway database, and the real one is untouched.
+ */
+import { Peer, closeAll } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("quick call connects two strangers");
+const alice = new Peer(9307, "Alice");
+const bob = new Peer(9308, "Bob");
+
+const qcState = `(() => JSON.stringify({
+  stage: window.__qc?.state.stage ?? 'none',
+  code: window.__qc?.state.code ?? '',
+  db: window.__qc?.dbName() ?? '',
+  inCall: !!window.__awful?.state.inCall,
+  callPeers: [...(window.__awful?.state.callPeerIds ?? [])].length,
+  roomUsers: (window.__awful?.state.roomUsers ?? []).length,
+  did: window.__awful?.state.roomCode ? true : false,
+}))()`;
+
+async function joinAs(peer, name) {
+  await peer.waitFor(`${name} reaches the setup screen`, async () => {
+    const s = await peer.json(qcState);
+    return s.stage === "setup";
+  });
+  await peer.fill("Your name", name);
+  await peer.clickText("Join call");
+  return peer.waitFor(`${name} is in the call`, async () => {
+    const s = await peer.json(qcState);
+    if (s.stage === "failed") throw new Error(`${name} failed to join`);
+    return s.stage === "in-call" ? s : null;
+  }, { timeout: 60_000 });
+}
+
+try {
+  await alice.start();
+  await bob.start();
+
+  await alice.go("/qc");
+  if (!(await alice.eval(`/Quick call/i.test(document.body.innerText)`))) {
+    throw new Error("this instance has /qc off - start vite with VITE_USE_QC=true");
+  }
+
+  const code = await alice.waitFor("alice gets a code", () =>
+    alice.eval(`window.__qc?.state.code || null`)
+  );
+  check.ok(/^[0-9A-HJKMNP-TV-Z]{13}$/.test(code), "code is a room code", code);
+  check.equal(
+    await alice.eval(`window.location.pathname + '|' + window.location.hash`),
+    `/qc|#${code}`,
+    "code lives in the fragment"
+  );
+
+  const hostState = await joinAs(alice, "Alice");
+  check.ok(
+    /^awful-quick-[0-9a-f]{16}$/.test(hostState.db),
+    "the call is written to a throwaway database",
+    hostState.db
+  );
+  check.ok(hostState.inCall, "alice is in the call");
+
+  await bob.go(`/qc#${code}`);
+  const guestState = await joinAs(bob, "Bob");
+  check.equal(guestState.code, code, "bob joined the same code");
+  check.ok(
+    guestState.db !== hostState.db,
+    "each page gets its own database",
+    [hostState.db, guestState.db]
+  );
+
+  // The point of the whole thing: they can hear each other.
+  const paired = await alice.waitFor("alice sees bob in the call", async () =>
+    alice.json(`(() => {
+      const s = window.__awful.state;
+      const voice = window.__awful.voice();
+      return JSON.stringify({
+        callPeers: [...s.callPeerIds].length,
+        voicePeers: voice.activePeers?.length ?? voice.peers?.length ?? 0,
+      });
+    })()`).then((s) => (s.callPeers >= 1 ? s : null)), { timeout: 90_000 });
+  check.ok(paired.callPeers >= 1, "the two are in one call", paired);
+
+  await bob.waitFor("bob sees alice too", async () =>
+    bob.eval(`[...window.__awful.state.callPeerIds].length >= 1`)
+  );
+
+  // Names crossed over, so a stranger is not "Anonymous" to the other side.
+  const named = await alice.waitFor("alice sees bob's name", () =>
+    alice.eval(`[...window.__awful.state.peerNames.values()].includes('Bob')`)
+  );
+  check.ok(named, "the profile reached the other side");
+
+  // Nothing about this call may be in the database a real account uses.
+  // start() visits /app first, so awful-chat exists on this profile - what
+  // matters is that /qc put nothing in it.
+  const real = await alice.json(`(() => new Promise((resolve) => {
+    const req = indexedDB.open('awful-chat');
+    req.onerror = () => resolve(JSON.stringify({ rooms: 0, messages: 0 }));
+    req.onsuccess = () => {
+      const db = req.result;
+      const names = [...db.objectStoreNames];
+      if (!names.includes('rooms')) {
+        db.close();
+        resolve(JSON.stringify({ rooms: 0, messages: 0 }));
+        return;
+      }
+      const tx = db.transaction(['rooms', 'messages'], 'readonly');
+      const rooms = tx.objectStore('rooms').count();
+      const messages = tx.objectStore('messages').count();
+      tx.oncomplete = () => {
+        db.close();
+        resolve(JSON.stringify({ rooms: rooms.result, messages: messages.result }));
+      };
+    };
+  }))()`);
+  check.equal(real.rooms, 0, "no room was written to the real database");
+  check.equal(real.messages, 0, "no messages either");
+
+  const dbs = await alice.json(
+    `indexedDB.databases().then((d) => JSON.stringify(d.map((x) => x.name)))`
+  );
+  check.ok(
+    dbs.some((n) => n.startsWith("awful-quick-")),
+    "the call lived in a quick database",
+    dbs
+  );
+} finally {
+  check.finish();
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/quick-send-alongside-app.mjs
+++ b/frontend/e2e/scenarios/quick-send-alongside-app.mjs
@@ -1,0 +1,93 @@
+/**
+ * /qs in a second tab of a profile that already has the app open.
+ *
+ * The app runs ONE libp2p node per browser profile, elected with a Web Lock,
+ * because two nodes sharing one peerId starve each other (node-lock.ts, the
+ * 2026-09-04 and 09-06 diag packs). /qs is a second node in that same profile
+ * - it dodges the seat by connecting with no key seed, so it has a peerId of
+ * its own and takes no lock. This is the check that it stays that way: the
+ * app tab must not be told the node is held elsewhere, and the quick send
+ * must still move a file.
+ */
+import { bootPeers, closeAll, Peer } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("quick send does not steal the app's node");
+const [alice] = await bootPeers(["Alice"], { ports: [9307] });
+const bob = new Peer(9308, "Bob");
+let qsContext = null;
+
+try {
+  await bob.start();
+  await alice.createRoom("Nodelab");
+  await alice.waitFor("alice's app is connected", () =>
+    alice.eval(`window.__awful.state.connected === true`)
+  );
+
+  // A second tab of the SAME profile: same Lock Manager, same device key.
+  const created = await alice.bidi.send("browsingContext.create", {
+    type: "tab",
+  });
+  qsContext = created.context;
+  const quick = alice.tab(qsContext);
+  await quick.go("/qs");
+
+  const code = await quick.waitFor("the quick tab connects", () =>
+    quick.eval(
+      `window.__qs?.state.status === 'ready' ? window.__qs.state.code : null`
+    )
+  );
+
+  // The whole point: the app tab kept its seat.
+  const held = await alice.eval(`window.__awful.state.nodeHeldElsewhere`);
+  check.equal(held, false, "the app tab still holds the node");
+  check.ok(
+    await alice.eval(`window.__awful.state.connected === true`),
+    "the app tab is still connected"
+  );
+  check.ok(
+    (await quick.eval(`window.__qs.state.code`)) === code,
+    "the quick tab is not queued behind it"
+  );
+
+  await bob.go(`/qs#${code}`);
+  await bob.waitFor("bob joins", () =>
+    bob.eval(`window.__qs?.state.status === 'ready'`)
+  );
+  await quick.waitFor("the two are introduced", () =>
+    quick.eval(`window.__qs.state.peers >= 1`)
+  );
+
+  const hash = await quick.eval(`(async () => {
+    const bytes = new Uint8Array(700 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 7) & 0xff;
+    await window.__qs.offerFiles([new File([bytes], 'alongside.bin')]);
+    return window.__qs.state.offered[0].infoHash;
+  })()`);
+
+  await bob.waitFor("bob is offered the file", () =>
+    bob.eval(`window.__qs.state.incoming.length > 0`)
+  );
+  await bob.eval(`window.__qs.acceptFile(${JSON.stringify(hash)})`);
+  const done = await bob.waitFor("bob completes the transfer", async () =>
+    bob.json(`(() => {
+      const t = window.__qs.state.transfers.get(${JSON.stringify(hash)});
+      if (!t || (t.status !== 'complete' && t.status !== 'seeding' && t.status !== 'failed')) return null;
+      return JSON.stringify({ status: t.status, progress: t.progress, error: t.error ?? null });
+    })()`), { timeout: 90_000 });
+  check.ok(done.status !== "failed" && done.progress >= 1, "the file arrived", done);
+
+  // And the app is still itself afterwards.
+  check.ok(
+    await alice.eval(`window.__awful.state.connected === true`),
+    "the app tab survived the whole thing"
+  );
+} finally {
+  check.finish();
+  if (qsContext) {
+    await alice.bidi
+      .send("browsingContext.close", { context: qsContext })
+      .catch(() => {});
+  }
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/quick-send.mjs
+++ b/frontend/e2e/scenarios/quick-send.mjs
@@ -37,7 +37,7 @@ try {
     const s = await alice.json(qsState);
     return s.status === "ready" && s.code ? s : null;
   });
-  check.ok(/^[0-9A-HJKMNP-TV-Z]{13}$/.test(host.code), "code is a room code", host.code);
+  check.ok(/^[0-9A-HJKMNP-TV-Z]{10}$/.test(host.code), "code is a 10-character quick code", host.code);
 
   // The code rides in the fragment, never the path - the whole point of the
   // /r/#<code> form the app already uses for invites.

--- a/frontend/e2e/scenarios/quick-send.mjs
+++ b/frontend/e2e/scenarios/quick-send.mjs
@@ -1,0 +1,114 @@
+/**
+ * /qs end to end: two browsers that have never made an identity meet on a
+ * code, and a file crosses between them over WebRTC.
+ *
+ * Deliberately does NOT use bootPeers - signing up is the thing this page is
+ * supposed to do without.
+ */
+import { Peer, closeAll } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("quick send moves a file with no identity");
+const alice = new Peer(9307, "Alice");
+const bob = new Peer(9308, "Bob");
+
+const qsState = `(() => JSON.stringify({
+  status: window.__qs?.state.status ?? 'none',
+  code: window.__qs?.state.code ?? '',
+  peers: window.__qs?.state.peers ?? 0,
+  offered: (window.__qs?.state.offered ?? []).map((f) => f.infoHash),
+  incoming: (window.__qs?.state.incoming ?? []).map((f) => ({ h: f.infoHash, n: f.filename, s: f.size })),
+  transfers: [...(window.__qs?.state.transfers ?? new Map()).values()].map((t) => ({
+    h: t.infoHash, status: t.status, progress: t.progress, error: t.error ?? null,
+  })),
+}))()`;
+
+try {
+  await alice.start();
+  await bob.start();
+
+  await alice.go("/qs");
+  // The route is off by default, and a timeout here reads as a broken app
+  // rather than an unset flag.
+  if (!(await alice.eval(`/Quick send/i.test(document.body.innerText)`))) {
+    throw new Error("this instance has /qs off - start vite with VITE_USE_QS=true");
+  }
+  const host = await alice.waitFor("alice gets a code", async () => {
+    const s = await alice.json(qsState);
+    return s.status === "ready" && s.code ? s : null;
+  });
+  check.ok(/^[0-9A-HJKMNP-TV-Z]{13}$/.test(host.code), "code is a room code", host.code);
+
+  // The code rides in the fragment, never the path - the whole point of the
+  // /r/#<code> form the app already uses for invites.
+  const inBar = await alice.eval(`window.location.pathname + '|' + window.location.hash`);
+  check.equal(inBar, `/qs|#${host.code}`, "code lives in the fragment");
+
+  await bob.go(`/qs#${host.code}`);
+  await bob.waitFor("bob joins the code", async () => {
+    const s = await bob.json(qsState);
+    return s.status === "ready" && s.code === host.code;
+  });
+
+  await alice.waitFor("the two are introduced", async () => {
+    const s = await alice.json(qsState);
+    return s.peers >= 1;
+  });
+
+  // Over the 512 KB inline limit, so this is a real WebTorrent transfer.
+  const offered = await alice.json(`(async () => {
+    const bytes = new Uint8Array(700 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31) & 0xff;
+    await window.__qs.offerFiles([new File([bytes], 'holiday.bin', { type: 'application/octet-stream' })]);
+    return JSON.stringify(window.__qs.state.offered.map((f) => f.infoHash));
+  })()`);
+  check.equal(offered.length, 1, "alice is seeding one file");
+
+  const seen = await bob.waitFor("bob is offered the file", async () => {
+    const s = await bob.json(qsState);
+    return s.incoming.length ? s.incoming[0] : null;
+  }, { timeout: 60_000 });
+  check.equal(seen.n, "holiday.bin", "the offer names the file");
+  check.equal(seen.s, 700 * 1024, "the offer carries its size");
+
+  // Nothing downloads until a person asks - the descriptor is the sender's
+  // own claim until the bytes are hashed. An announce registers the seeder
+  // ("pending"), which is bookkeeping: no torrent, no bytes.
+  const before = await bob.json(qsState);
+  const idle = before.transfers.find((t) => t.h === seen.h);
+  check.ok(
+    !idle || (idle.status === "pending" && !idle.progress),
+    "nothing was pulled unasked",
+    before.transfers
+  );
+
+  await bob.eval(`window.__qs.acceptFile(${JSON.stringify(seen.h)})`);
+  const done = await bob.waitFor("bob completes the transfer", async () => {
+    const s = await bob.json(qsState);
+    const t = s.transfers.find((t) => t.h === seen.h);
+    if (!t || (t.status !== "complete" && t.status !== "seeding" && t.status !== "failed")) {
+      return null;
+    }
+    return t;
+  }, { timeout: 90_000 });
+  check.ok(done.status !== "failed" && done.progress >= 1, "the file arrived", done);
+
+  const saveable = await bob.eval(
+    `!!document.querySelector('a[download="holiday.bin"]')`
+  );
+  check.ok(saveable, "a Save link is on the page");
+
+  // The promise on the page: nothing survives it.
+  const stored = await bob.json(`(async () => {
+    const names = (await indexedDB.databases?.() ?? []).map((d) => d.name);
+    return JSON.stringify({ names, keys: Object.keys(localStorage) });
+  })()`);
+  check.ok(
+    !stored.names.some((n) => /quick|qs/i.test(n ?? "")),
+    "no database of its own was created",
+    stored.names
+  );
+} finally {
+  check.finish();
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/room-open-feedback.mjs
+++ b/frontend/e2e/scenarios/room-open-feedback.mjs
@@ -1,0 +1,55 @@
+/**
+ * Clicking a room from /app changes the screen on the click: the sidebar
+ * highlights, the chat pane mounts and its "Connecting..." overlay covers
+ * it until the room is open. Before, nothing moved until history was
+ * decrypted, the roster read and the profile broadcast.
+ *
+ * Deterministic without timing games: IndexedDB answers in a later task,
+ * so a few microtasks after the click the join is still inside its first
+ * await, and Svelte has already flushed the view.
+ */
+import { Peer, sleep } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("opening a room reacts on the click");
+const p = new Peer(9307, "A");
+
+try {
+  await p.start();
+  await p.signUp("Clicker");
+  const room = await p.createRoom("FeedbackRoom");
+  for (let i = 0; i < 5; i++) await p.say(`message ${i}`);
+  await sleep(500);
+
+  await p.go("/app");
+  await p.waitFor("room listed", () =>
+    p.eval(`[...document.querySelectorAll('button')].some((b) => /FeedbackRoom/.test(b.innerText)) || null`));
+  check.ok((await p.eval(`window.__awful.state.roomCode`)) === null, "starts outside any room");
+
+  const snap = await p.json(`(async () => {
+    const btn = [...document.querySelectorAll('button')].find((b) => /FeedbackRoom/.test(b.innerText));
+    btn.click();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    const s = window.__awful.state;
+    return JSON.stringify({
+      connecting: s.connecting,
+      overlay: /Connecting\\.\\.\\./.test(document.body.innerText),
+      pane: !!document.querySelector('textarea'),
+      opened: s.roomCode === ${JSON.stringify(room)},
+    });
+  })()`);
+  check.ok(snap.pane, "chat pane mounts on the click", snap);
+  check.ok(snap.connecting && snap.overlay, "overlay shows while the join runs", snap);
+
+  await p.waitFor("room open", async () =>
+    (await p.eval(`window.__awful.state.roomCode`)) === room && !(await p.eval(`window.__awful.state.connecting`)));
+  const after = await p.json(`JSON.stringify({
+    overlay: /Connecting\\.\\.\\./.test(document.body.innerText),
+    messages: window.__awful.state.messages.length,
+  })`);
+  check.ok(!after.overlay && after.messages === 5, "overlay lifts with the history in place", after);
+} finally {
+  await p.close();
+}
+
+check.finish();

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,8 +8,24 @@
   import { notifyState } from "$lib/notify.svelte";
   import { ensurePushSubscription } from "$lib/push.svelte";
   import { parseRoomCode } from "$lib/palette/query";
+  import { useQc, useQs } from "$lib/runtime-config";
+  import { isQuickStorage } from "$lib/quick/quick-storage";
+  import QuickSend from "$lib/components/QuickSend.svelte";
+  import QuickCall from "$lib/components/QuickCall.svelte";
 
-  let currentRoute = $state<"landing" | "app">("landing");
+  let currentRoute = $state<"landing" | "app" | "qs" | "qc">("landing");
+
+  /**
+   * The routes an instance can turn off. A disabled one falls through to the
+   * landing page rather than 404ing: the flag is an operator's choice, not a
+   * broken link, and the page it would have shown does not exist here.
+   */
+  function optionalRoute(pathname: string): "qs" | "qc" | null {
+    const path = pathname.replace(/\/$/, "");
+    if (path === "/qs") return useQs() ? "qs" : null;
+    if (path === "/qc") return useQc() ? "qc" : null;
+    return null;
+  }
 
   /** A percent-encoded URL piece, or the piece itself when it is malformed. */
   function decode(part: string): string {
@@ -65,6 +81,10 @@
   // this device without a reload.
   $effect(() => {
     if (!identityStore.isUnlocked) return;
+    // Never for a quick page: its identity dies with the tab, and a push
+    // subscription would leave a device mailbox on the relay for an identity
+    // that no longer exists anywhere.
+    if (isQuickStorage()) return;
     void notifyState.permission;
     void ensurePushSubscription();
   });
@@ -75,9 +95,12 @@
     upgradeLegacyPath();
     const pathname = window.location.pathname;
     const roomCode = urlRoomCode();
+    const optional = optionalRoute(pathname);
 
     if (roomCode) {
       currentRoute = "app";
+    } else if (optional) {
+      currentRoute = optional;
     } else if (pathname === "/app" || pathname === "/share-target") {
       // /share-target is normally a POST the service worker answers; a GET
       // reaches nginx only when no worker controls the page yet, and the
@@ -93,7 +116,14 @@
 
     const pathname = window.location.pathname;
 
-    if (urlRoomCode() || pathname === "/app" || pathname === "/share-target") {
+    const optional = optionalRoute(pathname);
+    if (optional) {
+      currentRoute = optional;
+    } else if (
+      urlRoomCode() ||
+      pathname === "/app" ||
+      pathname === "/share-target"
+    ) {
       currentRoute = "app";
     } else {
       currentRoute = "landing";
@@ -119,6 +149,10 @@
   <div class="min-h-screen bg-background flex items-center justify-center">
     <div class="w-2 h-2 rounded-full bg-muted-foreground animate-pulse"></div>
   </div>
+{:else if currentRoute === "qs"}
+  <QuickSend />
+{:else if currentRoute === "qc"}
+  <QuickCall />
 {:else if currentRoute === "landing"}
   <Landing />
 {:else}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,7 +9,6 @@
   import { ensurePushSubscription } from "$lib/push.svelte";
   import { parseRoomCode } from "$lib/palette/query";
   import { useQc, useQs } from "$lib/runtime-config";
-  import { isQuickStorage } from "$lib/quick/quick-storage";
   import QuickSend from "$lib/components/QuickSend.svelte";
   import QuickCall from "$lib/components/QuickCall.svelte";
 
@@ -81,10 +80,12 @@
   // this device without a reload.
   $effect(() => {
     if (!identityStore.isUnlocked) return;
-    // Never for a quick page: its identity dies with the tab, and a push
-    // subscription would leave a device mailbox on the relay for an identity
-    // that no longer exists anywhere.
-    if (isQuickStorage()) return;
+    // Never on a quick page. A guest's identity dies with the tab and would
+    // leave a device mailbox on the relay for an identity that no longer
+    // exists; and an account unlocked to take a quick call did not ask to
+    // re-register push from here. The ROUTE decides, not the storage scope,
+    // which on /qc only moves once the person has chosen who to be.
+    if (currentRoute === "qs" || currentRoute === "qc") return;
     void notifyState.permission;
     void ensurePushSubscription();
   });

--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -360,17 +360,45 @@
     history.replaceState({}, "", "/app");
   }
 
+  /** Bumped per join so a failed one only backs out if nothing newer ran. */
+  let joinSeq = 0;
+
   async function handleJoin(
     roomCode: string,
     _displayName: string,
     roomName?: string
   ) {
     joinError = null;
+    const known =
+      roomName || roomsStore.rooms.find((r) => r.roomCode === roomCode)?.name;
+    const label = known || roomCode;
+    // Switch the view on the click, not after the join: from /app nothing on
+    // screen changed until history was decrypted, the roster read and the
+    // profile broadcast, and the chat view's own "Connecting..." overlay
+    // could not show because the chat view was not mounted yet. Now the
+    // sidebar highlights, the pane mounts, and the overlay covers it until
+    // the room is open. A join that fails backs the view out again.
+    const seq = ++joinSeq;
+    const prev = {
+      roomCode: activeRoomCode,
+      roomName: activeRoomName,
+      dmPeerId: activeDmPeerId,
+    };
+    activeRoomCode = roomCode;
+    activeRoomName = label;
+    activeDmPeerId = null;
+    sidebarTab = "rooms";
+    const backOut = () => {
+      if (seq !== joinSeq) return;
+      activeRoomCode = prev.roomCode;
+      activeRoomName = prev.roomName;
+      activeDmPeerId = prev.dmPeerId;
+    };
     try {
-      if (!(await joinRoom(roomCode))) return;
-      const known =
-        roomName || roomsStore.rooms.find((r) => r.roomCode === roomCode)?.name;
-      const label = known || roomCode;
+      if (!(await joinRoom(roomCode))) {
+        backOut();
+        return;
+      }
       activeRoomCode = roomCode;
       activeRoomName = label;
       activeDmPeerId = null;
@@ -386,6 +414,7 @@
       await saveRoom(roomCode, label);
       history.pushState({ roomCode }, "", `/r/#${roomCode}`);
     } catch (err) {
+      backOut();
       joinError = err instanceof Error ? err.message : String(err);
     }
   }
@@ -494,10 +523,11 @@
     // on screen: the fast paths skipped the claim, so a second quick click
     // during an in-flight switch either no-opped or wrote view state that
     // the losing join later contradicted. Last click wins, by construction.
+    // The drawer closes on the tap, not once the room is open.
+    sidebarOpen = false;
     await handleJoin(code, "", room?.name);
     activeDmPeerId = null;
     sidebarTab = "rooms";
-    sidebarOpen = false;
   }
 
   /**

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -109,7 +109,7 @@
   import { getRegistry, getPlugin } from "$lib/plugins/registry";
   import { isPluginEnabled } from "$lib/plugins/prefs.svelte";
   import type { HostApi } from "$lib/plugins/api";
-  import { seededRandom } from "$lib/utils";
+  import { formatSize, seededRandom } from "$lib/utils";
   import { getQuotableText } from "$lib/quote-helper";
   import { createInvite, formatShortCode } from "$lib/invite";
   import {
@@ -945,14 +945,6 @@
   function getStagedPreviewURL(file: File): string | null {
     if (!isPreviewable(file)) return null;
     return stagedPreviewUrls.get(fileKey(file)) ?? null;
-  }
-
-  function formatSize(size: number): string {
-    if (size < 1024) return `${size} B`;
-    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
-    if (size < 1024 * 1024 * 1024)
-      return `${(size / (1024 * 1024)).toFixed(1)} MB`;
-    return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`;
   }
 
   function hasFilesInDataTransfer(dt: DataTransfer | null): boolean {

--- a/frontend/src/lib/components/MsgRender.svelte
+++ b/frontend/src/lib/components/MsgRender.svelte
@@ -38,6 +38,7 @@
   import { mailboxPrefs } from "$lib/transport/mailbox.svelte";
   import { putSavedGif, deleteSavedGif, isGifSaved, getAttachmentsByInfoHash } from "$lib/storage";
   import { linkify } from "$lib/mentions";
+  import { formatSize } from "$lib/utils";
   import { mediaBoxStyle } from "$lib/image-size";
   import { INLINE_FILE_MAX_BYTES, attachmentHydration } from "$lib/transport/files.svelte";
 
@@ -562,14 +563,6 @@
       }
     })();
   });
-
-  function formatSize(size: number): string {
-    if (size < 1024) return `${size} B`;
-    if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
-    if (size < 1024 * 1024 * 1024)
-      return `${(size / (1024 * 1024)).toFixed(1)} MB`;
-    return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  }
 
   function isGifUrl(text: string): boolean {
     // The whole message must be the URL - a gif link inside a sentence stays

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -1,0 +1,206 @@
+<script lang="ts">
+  /**
+   * /qc - the whole page. A setup screen, then the app's own call view.
+   *
+   * The call UI is deliberately NOT reimplemented: VoiceVideoCallView reads
+   * the same global stores here as it does inside a room, so a quick call
+   * gets camera, screen share, mute, deafen, spotlight, picture-in-picture,
+   * per-tile menus and plugin call tiles for nothing.
+   */
+  import { onDestroy, onMount } from "svelte";
+  import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+  import { Check, Copy, Link2, PhoneOff } from "@lucide/svelte";
+  import { Button } from "$lib/components/ui/button/index.js";
+  import { Input } from "$lib/components/ui/input/index.js";
+  import AvatarPickerDialog from "$lib/components/AvatarPickerDialog.svelte";
+  import VoiceVideoCallView from "$lib/components/VoiceVideoCallView.svelte";
+  import { profileStore } from "$lib/profile.svelte";
+  import { formatRoomCode } from "$lib/room-code";
+  import {
+    endQuickCall,
+    prepareQuickCall,
+    quickCall,
+    rememberQuickProfile,
+    setQuickCallCode,
+    startQuickCall,
+    teardownQuickCall,
+  } from "$lib/quick/quick-call.svelte";
+
+  let name = $state(quickCall.profile.name);
+  let avatarUrl = $state(quickCall.profile.avatarUrl);
+  let remember = $state(quickCall.remembered);
+  let pickerOpen = $state(false);
+  let copied = $state(false);
+  // The avatar picker's GIF search is a svelte-query consumer, and this page
+  // is not inside AppView's provider. Without one it throws while mounting,
+  // which in Svelte 5 leaves the PREVIOUS route on screen - the page simply
+  // did not appear.
+  const queryClient = new QueryClient();
+
+  const link = $derived(
+    quickCall.code ? `${window.location.origin}/qc#${quickCall.code}` : ""
+  );
+  /** True when this page minted the code rather than following a link. */
+  let isHost = $state(false);
+
+  onMount(() => {
+    const fromLink = window.location.hash.slice(1);
+    isHost = !fromLink;
+    setQuickCallCode(fromLink || undefined);
+    // The identity has to be live before the avatar picker can write
+    // anything - see prepareQuickCall.
+    void prepareQuickCall();
+    // The code IS the secret, so it lives in the fragment and never in the
+    // path - same reasoning as room invites, see App.svelte.
+    if (isHost) {
+      history.replaceState(history.state, "", `/qc#${quickCall.code}`);
+    }
+    // pagehide, not beforeunload: it is the one that fires on mobile when the
+    // tab is discarded, and dropping the database is the whole promise here.
+    const bye = () => teardownQuickCall();
+    window.addEventListener("pagehide", bye);
+    return () => window.removeEventListener("pagehide", bye);
+  });
+
+  onDestroy(teardownQuickCall);
+
+  async function join() {
+    // The picker writes straight to the profile store, so what it set wins
+    // over the value this page started with.
+    const picked = profileStore.avatarUrl ?? avatarUrl;
+    rememberQuickProfile(remember ? { name, avatarUrl: picked } : null);
+    await startQuickCall({ name, avatarUrl: picked });
+  }
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(link);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      // Clipboard denied: the address bar holds the same link.
+    }
+  }
+</script>
+
+<QueryClientProvider client={queryClient}>
+  {#if quickCall.stage === "in-call"}
+    <div class="flex h-screen flex-col bg-background text-foreground">
+      <header
+        class="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2"
+      >
+        <div class="flex min-w-0 items-center gap-2">
+          <Link2 class="size-4 shrink-0 text-muted-foreground" />
+          <code class="truncate font-mono text-sm">
+            {formatRoomCode(quickCall.code)}
+          </code>
+        </div>
+        <div class="flex shrink-0 items-center gap-2">
+          <Button variant="outline" size="sm" onclick={copyLink}>
+            {#if copied}
+              <Check class="size-4" /> Copied
+            {:else}
+              <Copy class="size-4" /> Copy link
+            {/if}
+          </Button>
+          <Button variant="destructive" size="sm" onclick={endQuickCall}>
+            <PhoneOff class="size-4" /> Leave
+          </Button>
+        </div>
+      </header>
+      <div class="flex min-h-0 flex-1 flex-col">
+        <VoiceVideoCallView beside={false} />
+      </div>
+    </div>
+  {:else}
+    <div class="flex min-h-screen justify-center bg-background text-foreground p-4">
+      <div class="w-full max-w-md space-y-6 py-10">
+        <header class="space-y-1">
+          <h1 class="text-2xl font-semibold">Quick call</h1>
+          <p class="text-sm text-muted-foreground">
+            {#if isHost}
+              Start a call and send the link to whoever should join. No account,
+              and nothing about it is kept once you close the tab.
+            {:else}
+              You have been invited to a call. Pick a name and join - no account
+              needed.
+            {/if}
+          </p>
+        </header>
+
+        <div class="space-y-3 rounded-lg border border-border p-4">
+          <button
+            type="button"
+            class="flex items-center gap-3 text-left"
+            onclick={() => (pickerOpen = true)}
+          >
+            {#if profileStore.avatarUrl ?? avatarUrl}
+              <img
+                src={profileStore.avatarUrl ?? avatarUrl}
+                alt=""
+                class="size-12 rounded-full object-cover"
+              />
+            {:else}
+              <span
+                class="flex size-12 items-center justify-center rounded-full bg-muted text-lg"
+              >
+                {name.trim().charAt(0).toUpperCase() || "?"}
+              </span>
+            {/if}
+            <span class="text-sm text-muted-foreground underline-offset-2 hover:underline">
+              {profileStore.avatarUrl ?? avatarUrl ? "Change picture" : "Add a picture"}
+            </span>
+          </button>
+
+          <label class="block space-y-1.5">
+            <span class="text-sm font-medium">Your name</span>
+            <Input bind:value={name} maxlength={64} placeholder="Your name" />
+          </label>
+
+          <label class="flex items-center gap-2 text-sm text-muted-foreground">
+            <input type="checkbox" bind:checked={remember} class="size-4" />
+            Remember this for next time
+          </label>
+        </div>
+
+        {#if quickCall.stage === "failed"}
+          <p class="text-sm text-destructive">
+            {quickCall.error ?? "Could not join the call."}
+          </p>
+        {/if}
+
+        <Button
+          class="w-full"
+          disabled={quickCall.stage === "joining" ||
+            quickCall.stage === "preparing"}
+          onclick={join}
+        >
+          {quickCall.stage === "joining" ? "Joining..." : "Join call"}
+        </Button>
+
+        {#if quickCall.code}
+          <div class="space-y-2 rounded-lg border border-border p-4">
+            <div class="flex items-center justify-between gap-3">
+              <code class="font-mono tracking-wide">
+                {formatRoomCode(quickCall.code)}
+              </code>
+              <Button variant="outline" size="sm" onclick={copyLink}>
+                {#if copied}
+                  <Check class="size-4" /> Copied
+                {:else}
+                  <Copy class="size-4" /> Copy link
+                {/if}
+              </Button>
+            </div>
+            <p class="text-xs text-muted-foreground">
+              Anyone holding this link can join the call, so send it to the
+              people you mean to talk to.
+            </p>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
+  <AvatarPickerDialog open={pickerOpen} onClose={() => (pickerOpen = false)} />
+</QueryClientProvider>

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -1,25 +1,33 @@
 <script lang="ts">
   /**
-   * /qc - the whole page. A setup screen, then the app's own call view.
+   * /qc - the whole page.
    *
-   * The call UI is deliberately NOT reimplemented: VoiceVideoCallView reads
-   * the same global stores here as it does inside a room, so a quick call
-   * gets camera, screen share, mute, deafen, spotlight, picture-in-picture,
-   * per-tile menus and plugin call tiles for nothing.
+   * Nothing about the call is reimplemented. Once the identity and the
+   * throwaway database are in place this hands over to ChatView, which is the
+   * same component a room uses: it brings the message list, the composer, the
+   * plugin slash commands and VoiceVideoCallView with it. A quick call is a
+   * room nobody keeps, so it should look and work like one.
    */
   import { onDestroy, onMount } from "svelte";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
-  import { Check, Copy, Link2, PhoneOff } from "@lucide/svelte";
+  import { Check, Copy, LogIn, UserRound } from "@lucide/svelte";
   import { Button } from "$lib/components/ui/button/index.js";
   import { Input } from "$lib/components/ui/input/index.js";
+  import * as Card from "$lib/components/ui/card/index.js";
   import AvatarPickerDialog from "$lib/components/AvatarPickerDialog.svelte";
-  import VoiceVideoCallView from "$lib/components/VoiceVideoCallView.svelte";
+  import ChatView from "$lib/components/ChatView.svelte";
+  import UnlockIdentity from "$lib/components/UnlockIdentity.svelte";
+  import { identityStore } from "$lib/identity/identity.svelte";
   import { profileStore } from "$lib/profile.svelte";
-  import { formatRoomCode } from "$lib/room-code";
+  import { formatQuickCode } from "$lib/room-code";
   import {
+    adoptAccount,
+    chooseAccount,
     endQuickCall,
-    prepareQuickCall,
+    hasAccount,
+    prepareAsGuest,
     quickCall,
+    quickCallLink,
     rememberQuickProfile,
     setQuickCallCode,
     startQuickCall,
@@ -27,34 +35,38 @@
   } from "$lib/quick/quick-call.svelte";
 
   let name = $state(quickCall.profile.name);
-  let avatarUrl = $state(quickCall.profile.avatarUrl);
   let remember = $state(quickCall.remembered);
   let pickerOpen = $state(false);
   let copied = $state(false);
-  // The avatar picker's GIF search is a svelte-query consumer, and this page
-  // is not inside AppView's provider. Without one it throws while mounting,
-  // which in Svelte 5 leaves the PREVIOUS route on screen - the page simply
-  // did not appear.
-  const queryClient = new QueryClient();
-
-  const link = $derived(
-    quickCall.code ? `${window.location.origin}/qc#${quickCall.code}` : ""
-  );
   /** True when this page minted the code rather than following a link. */
   let isHost = $state(false);
+
+  // The avatar picker writes straight through to the profile store, so that
+  // is the live value once an identity exists; before it does, the remembered
+  // one is all there is.
+  const avatar = $derived(
+    profileStore.avatarUrl ?? quickCall.profile.avatarUrl
+  );
+  const initial = $derived(name.trim().charAt(0).toUpperCase() || "?");
+  const link = $derived(quickCall.code ? quickCallLink(quickCall.code) : "");
+
+  // ChatView's GIF search is a svelte-query consumer and this page is not
+  // inside AppView's provider. Without one it throws while mounting, which in
+  // Svelte 5 leaves the PREVIOUS route on screen - the page simply does not
+  // appear.
+  const queryClient = new QueryClient();
 
   onMount(() => {
     const fromLink = window.location.hash.slice(1);
     isHost = !fromLink;
     setQuickCallCode(fromLink || undefined);
-    // The identity has to be live before the avatar picker can write
-    // anything - see prepareQuickCall.
-    void prepareQuickCall();
     // The code IS the secret, so it lives in the fragment and never in the
     // path - same reasoning as room invites, see App.svelte.
     if (isHost) {
       history.replaceState(history.state, "", `/qc#${quickCall.code}`);
     }
+    // With no account on this device there is nothing to choose between.
+    if (!hasAccount()) void prepareAsGuest();
     // pagehide, not beforeunload: it is the one that fires on mobile when the
     // tab is discarded, and dropping the database is the whole promise here.
     const bye = () => teardownQuickCall();
@@ -64,12 +76,30 @@
 
   onDestroy(teardownQuickCall);
 
+  // UnlockIdentity runs the whole unlock itself, remembered password and all,
+  // so the only thing left here is to notice that it landed.
+  $effect(() => {
+    if (quickCall.stage !== "unlocking") return;
+    if (!identityStore.isUnlocked) return;
+    void adoptAccount();
+  });
+
+  // Take the name the account (or the remembered profile) turned out to have,
+  // unless the person has already typed over it.
+  let nameTouched = $state(false);
+  $effect(() => {
+    if (quickCall.stage !== "setup" || nameTouched) return;
+    name = quickCall.profile.name;
+  });
+
   async function join() {
-    // The picker writes straight to the profile store, so what it set wins
-    // over the value this page started with.
-    const picked = profileStore.avatarUrl ?? avatarUrl;
-    rememberQuickProfile(remember ? { name, avatarUrl: picked } : null);
-    await startQuickCall({ name, avatarUrl: picked });
+    // Only a guest's name is worth remembering: an account already has one.
+    rememberQuickProfile(
+      remember && quickCall.identity === "guest"
+        ? { name, avatarUrl: avatar }
+        : null
+    );
+    await startQuickCall({ name, avatarUrl: avatar });
   }
 
   async function copyLink() {
@@ -85,120 +115,154 @@
 
 <QueryClientProvider client={queryClient}>
   {#if quickCall.stage === "in-call"}
-    <div class="flex h-screen flex-col bg-background text-foreground">
-      <header
-        class="flex shrink-0 items-center justify-between gap-3 border-b border-border px-4 py-2"
-      >
-        <div class="flex min-w-0 items-center gap-2">
-          <Link2 class="size-4 shrink-0 text-muted-foreground" />
-          <code class="truncate font-mono text-sm">
-            {formatRoomCode(quickCall.code)}
-          </code>
-        </div>
-        <div class="flex shrink-0 items-center gap-2">
-          <Button variant="outline" size="sm" onclick={copyLink}>
-            {#if copied}
-              <Check class="size-4" /> Copied
-            {:else}
-              <Copy class="size-4" /> Copy link
-            {/if}
-          </Button>
-          <Button variant="destructive" size="sm" onclick={endQuickCall}>
-            <PhoneOff class="size-4" /> Leave
-          </Button>
-        </div>
-      </header>
-      <div class="flex min-h-0 flex-1 flex-col">
-        <VoiceVideoCallView beside={false} />
+    <div class="min-h-dvh bg-background text-foreground font-mono flex">
+      <div class="flex min-h-dvh min-w-0 flex-1 flex-col">
+        <ChatView
+          roomCode={quickCall.code}
+          roomName="Quick call"
+          selfId={identityStore.did ?? ""}
+          onLeave={endQuickCall}
+        />
       </div>
     </div>
+  {:else if quickCall.stage === "unlocking"}
+    <UnlockIdentity />
   {:else}
-    <div class="flex min-h-screen justify-center bg-background text-foreground p-4">
-      <div class="w-full max-w-md space-y-6 py-10">
-        <header class="space-y-1">
-          <h1 class="text-2xl font-semibold">Quick call</h1>
-          <p class="text-sm text-muted-foreground">
-            {#if isHost}
-              Start a call and send the link to whoever should join. No account,
-              and nothing about it is kept once you close the tab.
-            {:else}
-              You have been invited to a call. Pick a name and join - no account
-              needed.
-            {/if}
-          </p>
-        </header>
-
-        <div class="space-y-3 rounded-lg border border-border p-4">
-          <button
-            type="button"
-            class="flex items-center gap-3 text-left"
-            onclick={() => (pickerOpen = true)}
-          >
-            {#if profileStore.avatarUrl ?? avatarUrl}
-              <img
-                src={profileStore.avatarUrl ?? avatarUrl}
-                alt=""
-                class="size-12 rounded-full object-cover"
-              />
-            {:else}
-              <span
-                class="flex size-12 items-center justify-center rounded-full bg-muted text-lg"
-              >
-                {name.trim().charAt(0).toUpperCase() || "?"}
-              </span>
-            {/if}
-            <span class="text-sm text-muted-foreground underline-offset-2 hover:underline">
-              {profileStore.avatarUrl ?? avatarUrl ? "Change picture" : "Add a picture"}
-            </span>
-          </button>
-
-          <label class="block space-y-1.5">
-            <span class="text-sm font-medium">Your name</span>
-            <Input bind:value={name} maxlength={64} placeholder="Your name" />
-          </label>
-
-          <label class="flex items-center gap-2 text-sm text-muted-foreground">
-            <input type="checkbox" bind:checked={remember} class="size-4" />
-            Remember this for next time
-          </label>
-        </div>
-
-        {#if quickCall.stage === "failed"}
-          <p class="text-sm text-destructive">
-            {quickCall.error ?? "Could not join the call."}
-          </p>
-        {/if}
-
-        <Button
-          class="w-full"
-          disabled={quickCall.stage === "joining" ||
-            quickCall.stage === "preparing"}
-          onclick={join}
-        >
-          {quickCall.stage === "joining" ? "Joining..." : "Join call"}
-        </Button>
-
-        {#if quickCall.code}
-          <div class="space-y-2 rounded-lg border border-border p-4">
-            <div class="flex items-center justify-between gap-3">
-              <code class="font-mono tracking-wide">
-                {formatRoomCode(quickCall.code)}
-              </code>
-              <Button variant="outline" size="sm" onclick={copyLink}>
-                {#if copied}
-                  <Check class="size-4" /> Copied
-                {:else}
-                  <Copy class="size-4" /> Copy link
-                {/if}
-              </Button>
-            </div>
-            <p class="text-xs text-muted-foreground">
-              Anyone holding this link can join the call, so send it to the
-              people you mean to talk to.
-            </p>
+    <div
+      class="min-h-dvh overflow-y-auto bg-background text-foreground flex items-center justify-center p-4 font-mono"
+    >
+      <Card.Root
+        class="w-full max-w-sm bg-card border-border text-card-foreground"
+      >
+        <Card.Header class="pb-4">
+          <div class="flex items-center gap-2 mb-1">
+            <div class="w-2 h-2 rounded-full bg-primary"></div>
+            <Card.Title class="text-lg font-mono font-semibold">
+              Quick call
+            </Card.Title>
           </div>
+          <Card.Description class="text-muted-foreground text-xs font-mono">
+            {#if quickCall.stage === "choosing"}
+              No account needed · nothing is kept when you close the tab
+            {:else if isHost}
+              Send the link · nothing is kept when you close the tab
+            {:else}
+              You have been invited · nothing is kept when you close the tab
+            {/if}
+          </Card.Description>
+        </Card.Header>
+
+        {#if quickCall.stage === "choosing"}
+          <Card.Content class="flex flex-col gap-2">
+            <Button onclick={() => void prepareAsGuest()} class="w-full font-mono">
+              <UserRound class="size-4" /> Join as a guest
+            </Button>
+            <Button
+              variant="outline"
+              onclick={chooseAccount}
+              class="w-full font-mono"
+            >
+              <LogIn class="size-4" /> Use my account
+            </Button>
+            <p class="text-xs text-muted-foreground font-mono leading-relaxed">
+              Either way the call is disposable: it never joins your saved
+              rooms, and its chat goes when the tab does.
+            </p>
+          </Card.Content>
+        {:else}
+          <Card.Content class="flex flex-col items-center gap-4">
+            <button
+              type="button"
+              onclick={() => (pickerOpen = true)}
+              aria-label="Pick profile picture"
+              class="relative group flex size-24 items-center justify-center rounded-full overflow-hidden bg-primary/20 ring-2 ring-border hover:ring-primary/60 transition-all cursor-pointer focus:outline-none focus:ring-primary"
+            >
+              {#if avatar}
+                <img src={avatar} alt="" class="size-full object-cover" />
+              {:else}
+                <span
+                  class="text-3xl font-semibold text-primary font-mono select-none"
+                  >{initial}</span
+                >
+              {/if}
+              <div
+                class="absolute inset-0 rounded-full flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity"
+              >
+                <span class="text-white text-xs font-mono">Change</span>
+              </div>
+            </button>
+
+            <Input
+              bind:value={name}
+              oninput={() => (nameTouched = true)}
+              maxlength={64}
+              placeholder="Your display name"
+              class="bg-background border-input text-foreground placeholder:text-muted-foreground font-mono text-center focus-visible:ring-ring"
+            />
+
+            {#if quickCall.identity === "account"}
+              <p class="text-xs text-muted-foreground font-mono text-center">
+                Calling as your account · the call itself is still disposable
+              </p>
+            {:else}
+              <label
+                class="flex items-start gap-2.5 cursor-pointer group self-start"
+              >
+                <input
+                  type="checkbox"
+                  bind:checked={remember}
+                  class="mt-0.5 w-4 h-4 rounded border-input bg-background accent-primary cursor-pointer"
+                />
+                <span
+                  class="text-xs text-muted-foreground group-hover:text-foreground transition-colors font-mono leading-relaxed"
+                >
+                  Remember this name and picture for next time
+                </span>
+              </label>
+            {/if}
+
+            {#if quickCall.stage === "failed"}
+              <p class="text-xs text-destructive font-mono text-center">
+                {quickCall.error ?? "Could not join the call."}
+              </p>
+            {/if}
+          </Card.Content>
+
+          <Card.Footer class="flex-col gap-3">
+            <Button
+              onclick={join}
+              disabled={quickCall.stage === "joining"}
+              class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-mono"
+            >
+              {quickCall.stage === "joining" ? "Joining..." : "Join call"}
+            </Button>
+
+            <div class="w-full space-y-1.5">
+              <div class="flex items-center justify-between gap-2">
+                <code class="text-sm font-mono tracking-wide text-foreground">
+                  {formatQuickCode(quickCall.code)}
+                </code>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onclick={copyLink}
+                  class="font-mono text-xs"
+                >
+                  {#if copied}
+                    <Check class="size-3.5" /> Copied
+                  {:else}
+                    <Copy class="size-3.5" /> Copy link
+                  {/if}
+                </Button>
+              </div>
+              <p class="text-xs text-muted-foreground font-mono leading-relaxed">
+                Anyone with this link can join, so send it to the people you
+                mean to talk to.
+              </p>
+            </div>
+          </Card.Footer>
         {/if}
-      </div>
+      </Card.Root>
     </div>
   {/if}
 

--- a/frontend/src/lib/components/QuickSend.svelte
+++ b/frontend/src/lib/components/QuickSend.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  /**
+   * /qs - the whole page. No sidebar, no chat, no identity: what the code
+   * names is a two-person room that exists for as long as this tab does.
+   */
+  import { onDestroy, onMount } from "svelte";
+  import { Check, Copy, Download, Link2, Upload } from "@lucide/svelte";
+  import { Button } from "$lib/components/ui/button/index.js";
+  import { formatRoomCode } from "$lib/room-code";
+  import { formatSize } from "$lib/utils";
+  import {
+    acceptFile,
+    offerFiles,
+    quickSend,
+    startQuickSend,
+    stopQuickSend,
+  } from "$lib/quick/quick-send.svelte";
+
+  let copied = $state(false);
+  let dragging = $state(false);
+  let input = $state<HTMLInputElement | null>(null);
+
+  const link = $derived(
+    quickSend.code ? `${window.location.origin}/qs#${quickSend.code}` : ""
+  );
+  /** A transfer still moving is the only thing a tab close would destroy. */
+  const busy = $derived(
+    [...quickSend.transfers.values()].some((t) => t.status === "downloading")
+  );
+
+  onMount(() => {
+    void start();
+    // A pasted link arrives as a hash change on an already-open page.
+    const onHash = () => void start();
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  });
+
+  onDestroy(stopQuickSend);
+
+  async function start() {
+    const fromLink = window.location.hash.slice(1);
+    await startQuickSend(fromLink || undefined);
+    // The code IS the secret, so it lives in the fragment and never in the
+    // path - same reasoning as room invites, see App.svelte. Writing it back
+    // makes the address bar the link to share, and survives a reload.
+    if (!fromLink && quickSend.code) {
+      history.replaceState(history.state, "", `/qs#${quickSend.code}`);
+    }
+  }
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(link);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      // Clipboard denied: the address bar already holds the same link.
+    }
+  }
+
+  async function take(list: FileList | null) {
+    if (!list?.length) return;
+    await offerFiles([...list]);
+    if (input) input.value = ""; // so the same file can be picked twice
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragging = false;
+    void take(e.dataTransfer?.files ?? null);
+  }
+</script>
+
+<svelte:window
+  onbeforeunload={(e) => {
+    if (!busy) return;
+    e.preventDefault();
+    return "";
+  }}
+/>
+
+<div class="min-h-screen bg-background text-foreground flex justify-center p-4">
+  <div class="w-full max-w-xl space-y-6 py-10">
+    <header class="space-y-1">
+      <h1 class="text-2xl font-semibold">Quick send</h1>
+      <p class="text-sm text-muted-foreground">
+        Send a file to one person. No account, nothing stored: the file goes
+        straight to them over an encrypted peer-to-peer link, and closing this
+        tab ends it.
+      </p>
+    </header>
+
+    {#if quickSend.status === "connecting"}
+      <p class="text-sm text-muted-foreground">Connecting...</p>
+    {:else if quickSend.status === "failed"}
+      <div class="rounded-lg border border-destructive/40 p-4 space-y-3">
+        <p class="text-sm">{quickSend.error ?? "Could not connect."}</p>
+        <Button variant="outline" size="sm" onclick={() => void start()}>
+          Try again
+        </Button>
+      </div>
+    {:else if quickSend.status === "ready"}
+      <section class="rounded-lg border border-border p-4 space-y-3">
+        <div class="flex items-center justify-between gap-3">
+          <code class="text-lg font-mono tracking-wide">
+            {formatRoomCode(quickSend.code)}
+          </code>
+          <Button variant="outline" size="sm" onclick={copyLink}>
+            {#if copied}
+              <Check class="size-4" /> Copied
+            {:else}
+              <Copy class="size-4" /> Copy link
+            {/if}
+          </Button>
+        </div>
+        <p class="text-xs text-muted-foreground flex items-center gap-1.5">
+          <Link2 class="size-3.5 shrink-0" />
+          {#if quickSend.peers === 0}
+            Waiting for the other side. Send them the link.
+          {:else if quickSend.peers === 1}
+            One person is here.
+          {:else}
+            {quickSend.peers} people are here - anyone with the link can join.
+          {/if}
+        </p>
+      </section>
+
+      <section
+        class="rounded-lg border border-dashed p-6 text-center transition-colors {dragging
+          ? 'border-primary bg-primary/5'
+          : 'border-border'}"
+        ondragover={(e) => {
+          e.preventDefault();
+          dragging = true;
+        }}
+        ondragleave={() => (dragging = false)}
+        ondrop={onDrop}
+        aria-label="Add files to send"
+      >
+        <Upload class="size-6 mx-auto mb-2 text-muted-foreground" />
+        <p class="text-sm text-muted-foreground mb-3">
+          Drop files here, or
+        </p>
+        <input
+          bind:this={input}
+          type="file"
+          multiple
+          class="hidden"
+          onchange={(e) => void take(e.currentTarget.files)}
+        />
+        <Button variant="outline" size="sm" onclick={() => input?.click()}>
+          Choose files
+        </Button>
+      </section>
+
+      {#if quickSend.offered.length}
+        <section class="space-y-2">
+          <h2 class="text-sm font-medium">Sending</h2>
+          {#each quickSend.offered as file (file.infoHash)}
+            {@const transfer = quickSend.transfers.get(file.infoHash)}
+            <div
+              class="rounded-lg border border-border p-3 flex items-center justify-between gap-3"
+            >
+              <div class="min-w-0">
+                <p class="text-sm truncate">{file.filename}</p>
+                <p class="text-xs text-muted-foreground">
+                  {formatSize(file.size)} • {transfer?.peers
+                    ? `${transfer.peers} downloading`
+                    : "ready"}
+                </p>
+              </div>
+            </div>
+          {/each}
+        </section>
+      {/if}
+
+      {#if quickSend.incoming.length}
+        <section class="space-y-2">
+          <h2 class="text-sm font-medium">Offered to you</h2>
+          {#each quickSend.incoming as file (file.infoHash)}
+            {@const transfer = quickSend.transfers.get(file.infoHash)}
+            <div class="rounded-lg border border-border p-3 space-y-2">
+              <div class="flex items-center justify-between gap-3">
+                <div class="min-w-0">
+                  <p class="text-sm truncate">{file.filename}</p>
+                  <p class="text-xs text-muted-foreground">
+                    {formatSize(file.size)}
+                  </p>
+                </div>
+                {#if transfer?.blobURL}
+                  <!-- The bytes are already here; this is the save. -->
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    href={transfer.blobURL}
+                    download={file.filename}
+                  >
+                    <Download class="size-4" /> Save
+                  </Button>
+                {:else if transfer?.status === "failed"}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onclick={() => acceptFile(file.infoHash, true)}
+                  >
+                    Retry
+                  </Button>
+                {:else if transfer?.status === "downloading"}
+                  <span class="text-xs text-muted-foreground tabular-nums">
+                    {Math.round((transfer.progress ?? 0) * 100)}%
+                  </span>
+                {:else}
+                  <Button size="sm" onclick={() => acceptFile(file.infoHash)}>
+                    Accept
+                  </Button>
+                {/if}
+              </div>
+              {#if transfer?.status === "downloading"}
+                <div class="h-1 rounded bg-muted overflow-hidden">
+                  <div
+                    class="h-full bg-primary transition-[width]"
+                    style="width: {Math.round((transfer.progress ?? 0) * 100)}%"
+                  ></div>
+                </div>
+              {:else if transfer?.status === "failed"}
+                <p class="text-xs text-destructive">
+                  {transfer.error ?? "Transfer failed."}
+                </p>
+              {/if}
+            </div>
+          {/each}
+        </section>
+      {/if}
+    {/if}
+
+    <p class="text-xs text-muted-foreground">
+      The relay introduces the two of you and TURN may carry the connection
+      when neither side is directly reachable - the file itself never touches a
+      server. Anyone holding the link can join, so send it to one person.
+    </p>
+  </div>
+</div>

--- a/frontend/src/lib/components/QuickSend.svelte
+++ b/frontend/src/lib/components/QuickSend.svelte
@@ -4,14 +4,16 @@
    * names is a two-person room that exists for as long as this tab does.
    */
   import { onDestroy, onMount } from "svelte";
-  import { Check, Copy, Download, Link2, Upload } from "@lucide/svelte";
+  import { Check, Copy, Download, Upload, Users } from "@lucide/svelte";
   import { Button } from "$lib/components/ui/button/index.js";
-  import { formatRoomCode } from "$lib/room-code";
+  import * as Card from "$lib/components/ui/card/index.js";
+  import { formatQuickCode } from "$lib/room-code";
   import { formatSize } from "$lib/utils";
   import {
     acceptFile,
     offerFiles,
     quickSend,
+    quickSendLink,
     startQuickSend,
     stopQuickSend,
   } from "$lib/quick/quick-send.svelte";
@@ -20,9 +22,7 @@
   let dragging = $state(false);
   let input = $state<HTMLInputElement | null>(null);
 
-  const link = $derived(
-    quickSend.code ? `${window.location.origin}/qs#${quickSend.code}` : ""
-  );
+  const link = $derived(quickSend.code ? quickSendLink(quickSend.code) : "");
   /** A transfer still moving is the only thing a tab close would destroy. */
   const busy = $derived(
     [...quickSend.transfers.values()].some((t) => t.status === "downloading")
@@ -80,164 +80,214 @@
   }}
 />
 
-<div class="min-h-screen bg-background text-foreground flex justify-center p-4">
-  <div class="w-full max-w-xl space-y-6 py-10">
-    <header class="space-y-1">
-      <h1 class="text-2xl font-semibold">Quick send</h1>
-      <p class="text-sm text-muted-foreground">
-        Send a file to one person. No account, nothing stored: the file goes
-        straight to them over an encrypted peer-to-peer link, and closing this
-        tab ends it.
-      </p>
-    </header>
+<div
+  class="min-h-dvh overflow-y-auto bg-background text-foreground flex items-center justify-center p-4 font-mono"
+>
+  <Card.Root class="w-full max-w-md bg-card border-border text-card-foreground">
+    <Card.Header class="pb-4">
+      <div class="flex items-center gap-2 mb-1">
+        <div
+          class="w-2 h-2 rounded-full {quickSend.peers > 0
+            ? 'bg-primary'
+            : 'bg-muted-foreground'}"
+        ></div>
+        <Card.Title class="text-lg font-mono font-semibold">
+          Quick send
+        </Card.Title>
+      </div>
+      <Card.Description class="text-muted-foreground text-xs font-mono">
+        Send a file to one person · no account · the bytes go straight to them
+      </Card.Description>
+    </Card.Header>
 
     {#if quickSend.status === "connecting"}
-      <p class="text-sm text-muted-foreground">Connecting...</p>
+      <Card.Content>
+        <p class="text-xs text-muted-foreground font-mono">Connecting...</p>
+      </Card.Content>
     {:else if quickSend.status === "failed"}
-      <div class="rounded-lg border border-destructive/40 p-4 space-y-3">
-        <p class="text-sm">{quickSend.error ?? "Could not connect."}</p>
-        <Button variant="outline" size="sm" onclick={() => void start()}>
+      <Card.Content class="space-y-3">
+        <p class="text-xs text-destructive font-mono">
+          {quickSend.error ?? "Could not connect."}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          class="font-mono"
+          onclick={() => void start()}
+        >
           Try again
         </Button>
-      </div>
+      </Card.Content>
     {:else if quickSend.status === "ready"}
-      <section class="rounded-lg border border-border p-4 space-y-3">
-        <div class="flex items-center justify-between gap-3">
-          <code class="text-lg font-mono tracking-wide">
-            {formatRoomCode(quickSend.code)}
-          </code>
-          <Button variant="outline" size="sm" onclick={copyLink}>
-            {#if copied}
-              <Check class="size-4" /> Copied
+      <Card.Content class="space-y-4">
+        <div class="space-y-1.5">
+          <div class="flex items-center justify-between gap-2">
+            <code class="text-base font-mono tracking-wide text-foreground">
+              {formatQuickCode(quickSend.code)}
+            </code>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={copyLink}
+              class="font-mono text-xs"
+            >
+              {#if copied}
+                <Check class="size-3.5" /> Copied
+              {:else}
+                <Copy class="size-3.5" /> Copy link
+              {/if}
+            </Button>
+          </div>
+          <p
+            class="text-xs text-muted-foreground font-mono flex items-center gap-1.5"
+          >
+            <Users class="size-3.5 shrink-0" />
+            {#if quickSend.peers === 0}
+              Waiting for the other side · send them the link
+            {:else if quickSend.peers === 1}
+              One person is here
             {:else}
-              <Copy class="size-4" /> Copy link
+              {quickSend.peers} people are here · anyone with the link can join
             {/if}
+          </p>
+        </div>
+
+        <div
+          class="rounded-lg border border-dashed p-6 text-center transition-colors {dragging
+            ? 'border-primary bg-primary/5'
+            : 'border-border'}"
+          ondragover={(e) => {
+            e.preventDefault();
+            dragging = true;
+          }}
+          ondragleave={() => (dragging = false)}
+          ondrop={onDrop}
+          role="region"
+          aria-label="Add files to send"
+        >
+          <Upload class="size-6 mx-auto mb-2 text-muted-foreground" />
+          <p class="text-xs text-muted-foreground font-mono mb-3">
+            Drop files here, or
+          </p>
+          <input
+            bind:this={input}
+            type="file"
+            multiple
+            class="hidden"
+            onchange={(e) => void take(e.currentTarget.files)}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            class="font-mono"
+            onclick={() => input?.click()}
+          >
+            Choose files
           </Button>
         </div>
-        <p class="text-xs text-muted-foreground flex items-center gap-1.5">
-          <Link2 class="size-3.5 shrink-0" />
-          {#if quickSend.peers === 0}
-            Waiting for the other side. Send them the link.
-          {:else if quickSend.peers === 1}
-            One person is here.
-          {:else}
-            {quickSend.peers} people are here - anyone with the link can join.
-          {/if}
-        </p>
-      </section>
 
-      <section
-        class="rounded-lg border border-dashed p-6 text-center transition-colors {dragging
-          ? 'border-primary bg-primary/5'
-          : 'border-border'}"
-        ondragover={(e) => {
-          e.preventDefault();
-          dragging = true;
-        }}
-        ondragleave={() => (dragging = false)}
-        ondrop={onDrop}
-        aria-label="Add files to send"
-      >
-        <Upload class="size-6 mx-auto mb-2 text-muted-foreground" />
-        <p class="text-sm text-muted-foreground mb-3">
-          Drop files here, or
-        </p>
-        <input
-          bind:this={input}
-          type="file"
-          multiple
-          class="hidden"
-          onchange={(e) => void take(e.currentTarget.files)}
-        />
-        <Button variant="outline" size="sm" onclick={() => input?.click()}>
-          Choose files
-        </Button>
-      </section>
-
-      {#if quickSend.offered.length}
-        <section class="space-y-2">
-          <h2 class="text-sm font-medium">Sending</h2>
-          {#each quickSend.offered as file (file.infoHash)}
-            {@const transfer = quickSend.transfers.get(file.infoHash)}
-            <div
-              class="rounded-lg border border-border p-3 flex items-center justify-between gap-3"
-            >
-              <div class="min-w-0">
-                <p class="text-sm truncate">{file.filename}</p>
-                <p class="text-xs text-muted-foreground">
-                  {formatSize(file.size)} • {transfer?.peers
-                    ? `${transfer.peers} downloading`
-                    : "ready"}
-                </p>
-              </div>
-            </div>
-          {/each}
-        </section>
-      {/if}
-
-      {#if quickSend.incoming.length}
-        <section class="space-y-2">
-          <h2 class="text-sm font-medium">Offered to you</h2>
-          {#each quickSend.incoming as file (file.infoHash)}
-            {@const transfer = quickSend.transfers.get(file.infoHash)}
-            <div class="rounded-lg border border-border p-3 space-y-2">
-              <div class="flex items-center justify-between gap-3">
+        {#if quickSend.offered.length}
+          <div class="space-y-2">
+            <h2 class="text-xs font-mono font-medium text-muted-foreground">
+              Sending
+            </h2>
+            {#each quickSend.offered as file (file.infoHash)}
+              {@const transfer = quickSend.transfers.get(file.infoHash)}
+              <div
+                class="rounded-lg border border-border p-3 flex items-center justify-between gap-3"
+              >
                 <div class="min-w-0">
-                  <p class="text-sm truncate">{file.filename}</p>
-                  <p class="text-xs text-muted-foreground">
-                    {formatSize(file.size)}
+                  <p class="text-sm font-mono truncate">{file.filename}</p>
+                  <p class="text-xs text-muted-foreground font-mono">
+                    {formatSize(file.size)} · {transfer?.peers
+                      ? `${transfer.peers} downloading`
+                      : "ready"}
                   </p>
                 </div>
-                {#if transfer?.blobURL}
-                  <!-- The bytes are already here; this is the save. -->
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    href={transfer.blobURL}
-                    download={file.filename}
-                  >
-                    <Download class="size-4" /> Save
-                  </Button>
+              </div>
+            {/each}
+          </div>
+        {/if}
+
+        {#if quickSend.incoming.length}
+          <div class="space-y-2">
+            <h2 class="text-xs font-mono font-medium text-muted-foreground">
+              Offered to you
+            </h2>
+            {#each quickSend.incoming as file (file.infoHash)}
+              {@const transfer = quickSend.transfers.get(file.infoHash)}
+              <div class="rounded-lg border border-border p-3 space-y-2">
+                <div class="flex items-center justify-between gap-3">
+                  <div class="min-w-0">
+                    <p class="text-sm font-mono truncate">{file.filename}</p>
+                    <p class="text-xs text-muted-foreground font-mono">
+                      {formatSize(file.size)}
+                    </p>
+                  </div>
+                  {#if transfer?.blobURL}
+                    <!-- The bytes are already here; this is the save. -->
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="font-mono"
+                      href={transfer.blobURL}
+                      download={file.filename}
+                    >
+                      <Download class="size-4" /> Save
+                    </Button>
+                  {:else if transfer?.status === "failed"}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="font-mono"
+                      onclick={() => acceptFile(file.infoHash, true)}
+                    >
+                      Retry
+                    </Button>
+                  {:else if transfer?.status === "downloading"}
+                    <span
+                      class="text-xs text-muted-foreground font-mono tabular-nums"
+                    >
+                      {Math.round((transfer.progress ?? 0) * 100)}%
+                    </span>
+                  {:else}
+                    <Button
+                      size="sm"
+                      class="font-mono"
+                      onclick={() => acceptFile(file.infoHash)}
+                    >
+                      Accept
+                    </Button>
+                  {/if}
+                </div>
+                {#if transfer?.status === "downloading"}
+                  <div class="h-1 rounded bg-muted overflow-hidden">
+                    <div
+                      class="h-full bg-primary transition-[width]"
+                      style="width: {Math.round(
+                        (transfer.progress ?? 0) * 100
+                      )}%"
+                    ></div>
+                  </div>
                 {:else if transfer?.status === "failed"}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onclick={() => acceptFile(file.infoHash, true)}
-                  >
-                    Retry
-                  </Button>
-                {:else if transfer?.status === "downloading"}
-                  <span class="text-xs text-muted-foreground tabular-nums">
-                    {Math.round((transfer.progress ?? 0) * 100)}%
-                  </span>
-                {:else}
-                  <Button size="sm" onclick={() => acceptFile(file.infoHash)}>
-                    Accept
-                  </Button>
+                  <p class="text-xs text-destructive font-mono">
+                    {transfer.error ?? "Transfer failed."}
+                  </p>
                 {/if}
               </div>
-              {#if transfer?.status === "downloading"}
-                <div class="h-1 rounded bg-muted overflow-hidden">
-                  <div
-                    class="h-full bg-primary transition-[width]"
-                    style="width: {Math.round((transfer.progress ?? 0) * 100)}%"
-                  ></div>
-                </div>
-              {:else if transfer?.status === "failed"}
-                <p class="text-xs text-destructive">
-                  {transfer.error ?? "Transfer failed."}
-                </p>
-              {/if}
-            </div>
-          {/each}
-        </section>
-      {/if}
+            {/each}
+          </div>
+        {/if}
+      </Card.Content>
     {/if}
 
-    <p class="text-xs text-muted-foreground">
-      The relay introduces the two of you and TURN may carry the connection
-      when neither side is directly reachable - the file itself never touches a
-      server. Anyone holding the link can join, so send it to one person.
-    </p>
-  </div>
+    <Card.Footer>
+      <p class="text-xs text-muted-foreground font-mono leading-relaxed">
+        The relay introduces the two of you and TURN may carry the connection
+        when neither side is directly reachable · the file itself never
+        touches a server. Anyone with the link can join, so send it to one
+        person.
+      </p>
+    </Card.Footer>
+  </Card.Root>
 </div>

--- a/frontend/src/lib/identity/identity.svelte.ts
+++ b/frontend/src/lib/identity/identity.svelte.ts
@@ -17,6 +17,7 @@
 
 import type { KeypairRecord, WebAuthnCapabilities } from "./identity";
 import {
+  createEphemeralIdentity,
   createIdentity,
   getIdentity,
   lockIdentity,
@@ -138,6 +139,24 @@ export async function create(password: string): Promise<string> {
   } finally {
     identityStore.loading = false;
   }
+}
+
+/**
+ * Unlock the session under a keypair that exists only in memory.
+ *
+ * Deliberately NOT setUnlocked: that asks the browser to persist storage,
+ * and a page whose whole point is leaving nothing behind should not be
+ * pinning a throwaway database against eviction. `keypair` stays null too -
+ * there is no record to load, and nothing should offer to lock or back up
+ * an identity that cannot be recovered.
+ */
+export async function createEphemeral(): Promise<void> {
+  const keypair = await createEphemeralIdentity();
+  identityStore.isUnlocked = true;
+  identityStore.did = keypair.did;
+  identityStore.publicKey = keypair.publicKey;
+  identityStore.error = null;
+  identityStore.initializing = false;
 }
 
 /**

--- a/frontend/src/lib/identity/identity.ts
+++ b/frontend/src/lib/identity/identity.ts
@@ -300,6 +300,28 @@ export async function createIdentity(
 }
 
 /**
+ * A keypair for one page, held only in memory.
+ *
+ * Nothing is written: no mnemonic record, no keypair record, no wipe of what
+ * was there before. The session and the at-rest key are activated exactly as
+ * a real unlock does, so everything downstream (signing, sealed rows, the
+ * DID peers see) behaves normally - it simply ceases to exist when the page
+ * does. For /qc, where there is no account and there is not meant to be one.
+ *
+ * Deliberately paired with a quick storage scope (quick-storage.ts): these
+ * rows are sealed with a key that dies with the page, so writing them into
+ * the real database would leave undecryptable junk in it.
+ */
+export async function createEphemeralIdentity(): Promise<KeypairRecord> {
+  const { privateKey, publicKey } = deriveKeypairFromMnemonic(
+    generateMnemonic()
+  );
+  const did = publicKeyToDid(publicKey);
+  await _activateSession(privateKey, publicKey, did);
+  return { id: "keypair", did, publicKey };
+}
+
+/**
  * Restore an existing identity from a BIP39 mnemonic (account recovery).
  * Re-derives the keypair, re-encrypts the mnemonic with the given password,
  * and overwrites any existing identity in IndexedDB.

--- a/frontend/src/lib/quick/quick-call.svelte.ts
+++ b/frontend/src/lib/quick/quick-call.svelte.ts
@@ -11,24 +11,31 @@
  *   - the identity: a keypair held only in memory (createEphemeralIdentity)
  *   - the database: a throwaway scope, deleted on the way out (quick-storage)
  *
- * What survives on purpose is the name and picture you call under, in
- * localStorage, because being asked who you are before every call is the
- * thing people hate about this kind of page.
+ * Who you are in the call is a choice: a throwaway identity under a name this
+ * page remembers in localStorage (being asked who you are before every call
+ * is the thing people hate about this kind of page), or the account this
+ * device already has - same DID, same profile, still a disposable database.
  *
  * The libp2p node is ephemeral too (session-key.ts) so a quick call can run
  * beside a tab already signed into the account, without taking its node seat.
  */
 
-import { createEphemeral } from "$lib/identity/identity.svelte";
-import { saveAvatar, saveName } from "$lib/profile.svelte";
-import { newRoomCode, normalizeRoomCode } from "$lib/room-code";
+import { createEphemeral, identityStore } from "$lib/identity/identity.svelte";
+import { loadProfile, saveAvatar, saveName } from "$lib/profile.svelte";
+import {
+  clearAtRestFlagForCurrentOwner,
+  closeDatabase,
+  getOwnProfile,
+  putOwnProfile,
+} from "$lib/storage";
+import { newQuickCode, normalizeQuickCode } from "$lib/room-code";
 import {
   joinRoom,
   leaveRoom,
   useEphemeralSession,
 } from "$lib/transport/transport.svelte";
 import { joinCall, leaveCall } from "$lib/transport/call.svelte";
-import { dbName, dropQuickStorage, isQuickStorage } from "./quick-storage";
+import { dbName, dropQuickStorage, useQuickStorage } from "./quick-storage";
 
 const PROFILE_KEY = "awful_qc_profile";
 /**
@@ -42,7 +49,11 @@ export interface QuickProfile {
 }
 
 export type QuickCallStage =
-  | "preparing"
+  /** Deciding who to be: only reached when this device HAS an account. */
+  | "choosing"
+  /** The account's own unlock screen is up. */
+  | "unlocking"
+  /** Name and picture, then Join. */
   | "setup"
   | "joining"
   | "in-call"
@@ -50,6 +61,8 @@ export type QuickCallStage =
 
 interface QuickCallState {
   stage: QuickCallStage;
+  /** Which identity is in the call: a throwaway one, or the real account. */
+  identity: "guest" | "account";
   code: string;
   error: string | null;
   /** What the setup screen starts filled in with. */
@@ -105,7 +118,8 @@ export function rememberQuickProfile(profile: QuickProfile | null): void {
 const remembered = readRememberedProfile();
 
 export const quickCall = $state<QuickCallState>({
-  stage: "preparing",
+  stage: "choosing",
+  identity: "guest",
   code: "",
   error: null,
   profile: remembered ?? { name: anonymousName() },
@@ -113,37 +127,48 @@ export const quickCall = $state<QuickCallState>({
 });
 
 /**
- * Mint a code, or take one from a link. The same 65-bit Crockford code rooms
- * use: it IS the membership secret, and a call is no less worth guessing than
- * a room - room-code.ts explains why it is not shorter.
+ * Mint a code, or take one from a link. A quick code, not a room code: ten
+ * characters for a call that lives hours, see room-code.ts for the numbers.
+ * A link carrying something else falls back to a fresh code rather than
+ * joining whatever the string happened to name.
  */
 export function setQuickCallCode(fromLink?: string): string {
-  quickCall.code = fromLink ? normalizeRoomCode(fromLink) : newRoomCode();
+  quickCall.code =
+    (fromLink ? normalizeQuickCode(fromLink) : "") || newQuickCode();
   return quickCall.code;
 }
 
 /**
- * Mint the identity and seed the profile, BEFORE the setup screen is usable.
+ * Switch this page onto its throwaway database.
  *
- * The identity has to exist first because every profile row is sealed with
- * its key - the avatar picker writes straight through to storage, and with no
- * session it would fail on the first click. Nothing here touches the network.
+ * Everything before this ran against the REAL one, because that is where the
+ * account's keypair and profile live and "use my account" has to be able to
+ * read them. The handle is closed first: the module caches an open
+ * connection, and leaving it open would keep writing to the wrong database.
+ *
+ * From here on the page is disposable. The libp2p node goes ephemeral in the
+ * same breath - whichever identity is in the call, the node must not take the
+ * seat belonging to a tab running the account (node-lock.ts).
  */
-/** Set once the ephemeral identity is live. Nothing may join before it is. */
+function switchToThrowawayStorage(): void {
+  closeDatabase();
+  useQuickStorage();
+  useEphemeralSession();
+}
+
+/** Set once an identity is live and the storage scope has moved. */
 let prepared = false;
 
-export async function prepareQuickCall(): Promise<void> {
-  if (quickCall.stage !== "preparing") return;
-  if (!isQuickStorage()) {
-    // main.ts switches the scope before the app mounts. Without it this page
-    // would write a room and a stranger's profile into the user's real
-    // database - refuse rather than quietly do that.
-    quickCall.stage = "failed";
-    quickCall.error = "Quick call storage was not set up - reload the page.";
-    return;
-  }
+/**
+ * Call as a stranger: a keypair that exists only in memory, under whatever
+ * name was remembered from last time.
+ */
+export async function prepareAsGuest(): Promise<void> {
+  if (prepared) return;
+  quickCall.identity = "guest";
+  quickCall.error = null;
   try {
-    useEphemeralSession();
+    switchToThrowawayStorage();
     await createEphemeral();
     await saveName(quickCall.profile.name);
     if (quickCall.profile.avatarUrl) {
@@ -157,18 +182,55 @@ export async function prepareQuickCall(): Promise<void> {
   }
 }
 
+/** Show the account's own unlock screen. */
+export function chooseAccount(): void {
+  quickCall.identity = "account";
+  quickCall.error = null;
+  quickCall.stage = "unlocking";
+}
+
+/**
+ * Carry the unlocked account into the call: same DID, same profile, same
+ * name colour and tag the room would show - but still a disposable database
+ * and a disposable node, so the call itself is no more permanent than a
+ * guest's. Called once identityStore reports the unlock landed.
+ *
+ * The whole profile ROW is copied rather than the display store: an uploaded
+ * avatar lives in the store as a blob: URL, which means nothing to anyone
+ * else, and copying the row keeps the bytes (and the colour, tag and bio)
+ * that _sendProfile actually puts on the wire.
+ */
+export async function adoptAccount(): Promise<void> {
+  if (prepared) return;
+  quickCall.error = null;
+  try {
+    const mine = await getOwnProfile(identityStore.did ?? undefined);
+    switchToThrowawayStorage();
+    if (mine) await putOwnProfile({ ...mine, isMe: true });
+    await loadProfile();
+    quickCall.profile = {
+      name: mine?.nickname?.trim() || quickCall.profile.name,
+      avatarUrl: mine?.pfpURL ?? quickCall.profile.avatarUrl,
+    };
+    prepared = true;
+    quickCall.stage = "setup";
+  } catch (err) {
+    quickCall.stage = "failed";
+    quickCall.error = err instanceof Error ? err.message : String(err);
+  }
+}
+
 /** Everything between "Join" and being in the call. */
 export async function startQuickCall(profile: QuickProfile): Promise<void> {
-  if (quickCall.stage !== "setup" && quickCall.stage !== "failed") return;
-  // "failed" is a retryable state - but not when what failed was the setup
-  // itself. Without this, a page whose storage scope never got switched let
-  // the second click join, which is the one outcome that writes a call into
-  // the user's real database.
+  // Checked FIRST, and loudly. "failed" is a retryable state - but not when
+  // what failed was the setup itself, and a join before any identity exists
+  // is the one path that would write a call into the user's real database.
   if (!prepared) {
     quickCall.stage = "failed";
     quickCall.error ??= "Quick call is not set up - reload the page.";
     return;
   }
+  if (quickCall.stage !== "setup" && quickCall.stage !== "failed") return;
   quickCall.stage = "joining";
   quickCall.error = null;
   quickCall.profile = profile;
@@ -195,10 +257,27 @@ export function endQuickCall(): void {
   quickCall.stage = "setup";
 }
 
+/** Whether this device has an account that could be brought into the call. */
+export function hasAccount(): boolean {
+  return identityStore.keypair !== null;
+}
+
 /** The page is going away: hang up and take the database with it. */
 export function teardownQuickCall(): void {
   leaveCall();
+  // An ephemeral identity's "database swept" marker is localStorage that
+  // would outlive everything else about the call. The account path leaves the
+  // real account's own marker alone - it earned it on the real database.
+  if (quickCall.identity === "guest") clearAtRestFlagForCurrentOwner();
   void dropQuickStorage();
+}
+
+/** Test seam: the module keeps one page's worth of state. */
+export function _resetQuickCallForTest(): void {
+  prepared = false;
+  quickCall.stage = "choosing";
+  quickCall.identity = "guest";
+  quickCall.error = null;
 }
 
 if (import.meta.env.DEV && typeof window !== "undefined") {
@@ -208,6 +287,7 @@ if (import.meta.env.DEV && typeof window !== "undefined") {
     state: quickCall,
     dbName,
     startQuickCall,
+    did: () => identityStore.did,
   };
 }
 

--- a/frontend/src/lib/quick/quick-call.svelte.ts
+++ b/frontend/src/lib/quick/quick-call.svelte.ts
@@ -1,0 +1,217 @@
+/**
+ * /qc - a call with no account and no room.
+ *
+ * The opposite trade to /qs. A call is not a file transfer: it is presence
+ * heartbeats, a voice roster, an SFU placement, plugin call tiles - all of it
+ * already written, all of it reading the app's own stores. Rebuilding that
+ * against a bare transport would be a second implementation of the hardest
+ * part of this codebase, so /qc runs the REAL stack and makes the two things
+ * that must not persist ephemeral instead:
+ *
+ *   - the identity: a keypair held only in memory (createEphemeralIdentity)
+ *   - the database: a throwaway scope, deleted on the way out (quick-storage)
+ *
+ * What survives on purpose is the name and picture you call under, in
+ * localStorage, because being asked who you are before every call is the
+ * thing people hate about this kind of page.
+ *
+ * The libp2p node is ephemeral too (session-key.ts) so a quick call can run
+ * beside a tab already signed into the account, without taking its node seat.
+ */
+
+import { createEphemeral } from "$lib/identity/identity.svelte";
+import { saveAvatar, saveName } from "$lib/profile.svelte";
+import { newRoomCode, normalizeRoomCode } from "$lib/room-code";
+import {
+  joinRoom,
+  leaveRoom,
+  useEphemeralSession,
+} from "$lib/transport/transport.svelte";
+import { joinCall, leaveCall } from "$lib/transport/call.svelte";
+import { dbName, dropQuickStorage, isQuickStorage } from "./quick-storage";
+
+const PROFILE_KEY = "awful_qc_profile";
+/**
+ * Everything a stranger sees of you. The picture is a data or https URL, the
+ * same string the avatar picker produces - it caps an upload at 512 KB, so
+ * this stays well inside a localStorage quota.
+ */
+export interface QuickProfile {
+  name: string;
+  avatarUrl?: string;
+}
+
+export type QuickCallStage =
+  | "preparing"
+  | "setup"
+  | "joining"
+  | "in-call"
+  | "failed";
+
+interface QuickCallState {
+  stage: QuickCallStage;
+  code: string;
+  error: string | null;
+  /** What the setup screen starts filled in with. */
+  profile: QuickProfile;
+  /** Whether that profile came back from a previous call. */
+  remembered: boolean;
+}
+
+/** A name to call under when there is nothing remembered and nothing typed. */
+function anonymousName(): string {
+  return `Guest ${crypto.getRandomValues(new Uint32Array(1))[0] % 9000 + 1000}`;
+}
+
+export function readRememberedProfile(): QuickProfile | null {
+  try {
+    const raw = localStorage.getItem(PROFILE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<QuickProfile>;
+    if (typeof parsed?.name !== "string" || !parsed.name.trim()) return null;
+    return {
+      name: parsed.name.slice(0, 64),
+      avatarUrl:
+        typeof parsed.avatarUrl === "string" ? parsed.avatarUrl : undefined,
+    };
+  } catch {
+    return null; // unparseable or blocked: call as a guest
+  }
+}
+
+/**
+ * Keep this profile for the next call, or forget it.
+ *
+ * A picture that will not fit is dropped rather than losing the name with it:
+ * a quota error here would otherwise mean the whole "remember me" silently
+ * did nothing.
+ */
+export function rememberQuickProfile(profile: QuickProfile | null): void {
+  try {
+    if (!profile) {
+      localStorage.removeItem(PROFILE_KEY);
+      return;
+    }
+    try {
+      localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+    } catch {
+      localStorage.setItem(PROFILE_KEY, JSON.stringify({ name: profile.name }));
+    }
+  } catch {
+    // Storage blocked entirely: the call still works, it just asks next time.
+  }
+}
+
+const remembered = readRememberedProfile();
+
+export const quickCall = $state<QuickCallState>({
+  stage: "preparing",
+  code: "",
+  error: null,
+  profile: remembered ?? { name: anonymousName() },
+  remembered: remembered !== null,
+});
+
+/**
+ * Mint a code, or take one from a link. The same 65-bit Crockford code rooms
+ * use: it IS the membership secret, and a call is no less worth guessing than
+ * a room - room-code.ts explains why it is not shorter.
+ */
+export function setQuickCallCode(fromLink?: string): string {
+  quickCall.code = fromLink ? normalizeRoomCode(fromLink) : newRoomCode();
+  return quickCall.code;
+}
+
+/**
+ * Mint the identity and seed the profile, BEFORE the setup screen is usable.
+ *
+ * The identity has to exist first because every profile row is sealed with
+ * its key - the avatar picker writes straight through to storage, and with no
+ * session it would fail on the first click. Nothing here touches the network.
+ */
+/** Set once the ephemeral identity is live. Nothing may join before it is. */
+let prepared = false;
+
+export async function prepareQuickCall(): Promise<void> {
+  if (quickCall.stage !== "preparing") return;
+  if (!isQuickStorage()) {
+    // main.ts switches the scope before the app mounts. Without it this page
+    // would write a room and a stranger's profile into the user's real
+    // database - refuse rather than quietly do that.
+    quickCall.stage = "failed";
+    quickCall.error = "Quick call storage was not set up - reload the page.";
+    return;
+  }
+  try {
+    useEphemeralSession();
+    await createEphemeral();
+    await saveName(quickCall.profile.name);
+    if (quickCall.profile.avatarUrl) {
+      await saveAvatar(quickCall.profile.avatarUrl);
+    }
+    prepared = true;
+    quickCall.stage = "setup";
+  } catch (err) {
+    quickCall.stage = "failed";
+    quickCall.error = err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** Everything between "Join" and being in the call. */
+export async function startQuickCall(profile: QuickProfile): Promise<void> {
+  if (quickCall.stage !== "setup" && quickCall.stage !== "failed") return;
+  // "failed" is a retryable state - but not when what failed was the setup
+  // itself. Without this, a page whose storage scope never got switched let
+  // the second click join, which is the one outcome that writes a call into
+  // the user's real database.
+  if (!prepared) {
+    quickCall.stage = "failed";
+    quickCall.error ??= "Quick call is not set up - reload the page.";
+    return;
+  }
+  quickCall.stage = "joining";
+  quickCall.error = null;
+  quickCall.profile = profile;
+
+  try {
+    // The profile goes in before joinRoom, which broadcasts it to everyone
+    // already in the call.
+    await saveName(profile.name.trim() || anonymousName());
+    if (profile.avatarUrl) await saveAvatar(profile.avatarUrl);
+    const joined = await joinRoom(quickCall.code);
+    if (!joined) throw new Error("Could not join the call.");
+    await joinCall();
+    quickCall.stage = "in-call";
+  } catch (err) {
+    quickCall.stage = "failed";
+    quickCall.error = err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** Hang up and go back to the setup screen, still on the same code. */
+export function endQuickCall(): void {
+  leaveCall();
+  leaveRoom();
+  quickCall.stage = "setup";
+}
+
+/** The page is going away: hang up and take the database with it. */
+export function teardownQuickCall(): void {
+  leaveCall();
+  void dropQuickStorage();
+}
+
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  // Dev-only handle, same reasoning as transport.svelte.ts's __awful: a call
+  // between two people is only observable with two real browsers.
+  (window as unknown as Record<string, unknown>).__qc = {
+    state: quickCall,
+    dbName,
+    startQuickCall,
+  };
+}
+
+/** The link to hand someone. The code stays in the fragment - see App.svelte. */
+export function quickCallLink(code: string): string {
+  return `${window.location.origin}/qc#${code}`;
+}

--- a/frontend/src/lib/quick/quick-call.test.ts
+++ b/frontend/src/lib/quick/quick-call.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The remembered profile is the one thing /qc keeps on purpose, so it is the
+ * one thing worth pinning: it must survive a quota failure with the name
+ * intact, and must never come back as a half-record that puts an empty name
+ * in front of strangers.
+ */
+
+const store = new Map<string, string>();
+let quota = Infinity;
+
+const fakeLocalStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    if (v.length > quota) throw new Error("QuotaExceededError");
+    store.set(k, v);
+  },
+  removeItem: (k: string) => void store.delete(k),
+};
+
+let quickStorageOn = true;
+
+vi.mock("$lib/identity/identity.svelte", () => ({
+  createEphemeral: vi.fn(async () => {}),
+}));
+vi.mock("$lib/profile.svelte", () => ({
+  saveName: vi.fn(async () => {}),
+  saveAvatar: vi.fn(async () => {}),
+}));
+vi.mock("$lib/transport/transport.svelte", () => ({
+  joinRoom: vi.fn(async () => true),
+  leaveRoom: vi.fn(),
+  useEphemeralSession: vi.fn(),
+}));
+vi.mock("$lib/transport/call.svelte", () => ({
+  joinCall: vi.fn(async () => {}),
+  leaveCall: vi.fn(),
+}));
+vi.mock("./quick-storage", () => ({
+  isQuickStorage: () => quickStorageOn,
+  dropQuickStorage: async () => {},
+}));
+
+async function load() {
+  vi.resetModules();
+  vi.stubGlobal("localStorage", fakeLocalStorage);
+  return import("./quick-call.svelte");
+}
+
+describe("quick call profile", () => {
+  beforeEach(() => {
+    store.clear();
+    quota = Infinity;
+    quickStorageOn = true;
+    vi.unstubAllGlobals();
+  });
+
+  it("calls as a guest when nothing was remembered", async () => {
+    const m = await load();
+    expect(m.quickCall.remembered).toBe(false);
+    expect(m.quickCall.profile.name).toMatch(/^Guest \d{4}$/);
+  });
+
+  it("comes back with the name and picture from last time", async () => {
+    vi.stubGlobal("localStorage", fakeLocalStorage);
+    const m1 = await load();
+    m1.rememberQuickProfile({ name: "Ada", avatarUrl: "data:image/png;base64,x" });
+
+    const m2 = await load();
+    expect(m2.quickCall.remembered).toBe(true);
+    expect(m2.quickCall.profile).toEqual({
+      name: "Ada",
+      avatarUrl: "data:image/png;base64,x",
+    });
+  });
+
+  it("keeps the name when the picture will not fit", async () => {
+    const m = await load();
+    quota = 40;
+    m.rememberQuickProfile({ name: "Ada", avatarUrl: "x".repeat(500) });
+    expect(m.readRememberedProfile()).toEqual({ name: "Ada" });
+  });
+
+  it("forgets on request", async () => {
+    const m = await load();
+    m.rememberQuickProfile({ name: "Ada" });
+    m.rememberQuickProfile(null);
+    expect(m.readRememberedProfile()).toBeNull();
+  });
+
+  it("ignores a record with no usable name", async () => {
+    const m = await load();
+    for (const raw of ['{"name":""}', '{"name":"  "}', "{}", "not json"]) {
+      store.set("awful_qc_profile", raw);
+      expect(m.readRememberedProfile(), raw).toBeNull();
+    }
+  });
+
+  it("refuses to join when the throwaway scope was not set up", async () => {
+    quickStorageOn = false;
+    const m = await load();
+    await m.prepareQuickCall();
+    expect(m.quickCall.stage).toBe("failed");
+
+    const transport = await import("$lib/transport/transport.svelte");
+    await m.startQuickCall({ name: "Ada" });
+    // Nothing may reach the real database, so nothing joins either.
+    expect(transport.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it("puts the profile in before joining, so the room sees it", async () => {
+    const m = await load();
+    const { saveName } = await import("$lib/profile.svelte");
+    const { joinRoom } = await import("$lib/transport/transport.svelte");
+    const { joinCall } = await import("$lib/transport/call.svelte");
+    const order: string[] = [];
+    vi.mocked(saveName).mockImplementation(async () => void order.push("name"));
+    vi.mocked(joinRoom).mockImplementation(async () => {
+      order.push("room");
+      return true;
+    });
+    vi.mocked(joinCall).mockImplementation(async () => void order.push("call"));
+
+    await m.prepareQuickCall();
+    m.setQuickCallCode("ABCDEFGHJKMNP");
+    await m.startQuickCall({ name: "Ada" });
+
+    expect(m.quickCall.stage).toBe("in-call");
+    expect(order).toEqual(["name", "name", "room", "call"]);
+    expect(joinRoom).toHaveBeenCalledWith("ABCDEFGHJKMNP");
+  });
+
+  it("does not sit in 'joining' when the join fails", async () => {
+    const m = await load();
+    const { joinRoom } = await import("$lib/transport/transport.svelte");
+    vi.mocked(joinRoom).mockRejectedValueOnce(new Error("relay is down"));
+    await m.prepareQuickCall();
+    await m.startQuickCall({ name: "Ada" });
+    expect(m.quickCall.stage).toBe("failed");
+    expect(m.quickCall.error).toBe("relay is down");
+  });
+});

--- a/frontend/src/lib/quick/quick-call.test.ts
+++ b/frontend/src/lib/quick/quick-call.test.ts
@@ -19,14 +19,23 @@ const fakeLocalStorage = {
   removeItem: (k: string) => void store.delete(k),
 };
 
-let quickStorageOn = true;
+const identityStore = { keypair: null as unknown, did: "did:key:zSelf" };
+let ownProfile: Record<string, unknown> | undefined;
 
 vi.mock("$lib/identity/identity.svelte", () => ({
   createEphemeral: vi.fn(async () => {}),
+  identityStore,
 }));
 vi.mock("$lib/profile.svelte", () => ({
   saveName: vi.fn(async () => {}),
   saveAvatar: vi.fn(async () => {}),
+  loadProfile: vi.fn(async () => {}),
+}));
+vi.mock("$lib/storage", () => ({
+  closeDatabase: vi.fn(),
+  clearAtRestFlagForCurrentOwner: vi.fn(),
+  getOwnProfile: vi.fn(async () => ownProfile),
+  putOwnProfile: vi.fn(async () => {}),
 }));
 vi.mock("$lib/transport/transport.svelte", () => ({
   joinRoom: vi.fn(async () => true),
@@ -38,8 +47,9 @@ vi.mock("$lib/transport/call.svelte", () => ({
   leaveCall: vi.fn(),
 }));
 vi.mock("./quick-storage", () => ({
-  isQuickStorage: () => quickStorageOn,
-  dropQuickStorage: async () => {},
+  useQuickStorage: vi.fn(() => "awful-quick-test"),
+  dropQuickStorage: vi.fn(async () => {}),
+  dbName: () => "awful-quick-test",
 }));
 
 async function load() {
@@ -50,9 +60,11 @@ async function load() {
 
 describe("quick call profile", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     store.clear();
     quota = Infinity;
-    quickStorageOn = true;
+    identityStore.keypair = null;
+    ownProfile = undefined;
     vi.unstubAllGlobals();
   });
 
@@ -97,45 +109,98 @@ describe("quick call profile", () => {
     }
   });
 
-  it("refuses to join when the throwaway scope was not set up", async () => {
-    quickStorageOn = false;
+  it("refuses to join before an identity exists", async () => {
     const m = await load();
-    await m.prepareQuickCall();
-    expect(m.quickCall.stage).toBe("failed");
-
-    const transport = await import("$lib/transport/transport.svelte");
+    const { joinRoom } = await import("$lib/transport/transport.svelte");
+    // Straight to Join without choosing who to be: nothing may reach the
+    // network, and nothing may be written anywhere.
     await m.startQuickCall({ name: "Ada" });
-    // Nothing may reach the real database, so nothing joins either.
-    expect(transport.joinRoom).not.toHaveBeenCalled();
+    expect(m.quickCall.stage).toBe("failed");
+    expect(joinRoom).not.toHaveBeenCalled();
   });
 
-  it("puts the profile in before joining, so the room sees it", async () => {
+  it("moves off the real database before a guest writes anything", async () => {
     const m = await load();
+    const { closeDatabase } = await import("$lib/storage");
+    const { useQuickStorage } = await import("./quick-storage");
+    const { createEphemeral } = await import("$lib/identity/identity.svelte");
     const { saveName } = await import("$lib/profile.svelte");
-    const { joinRoom } = await import("$lib/transport/transport.svelte");
-    const { joinCall } = await import("$lib/transport/call.svelte");
     const order: string[] = [];
-    vi.mocked(saveName).mockImplementation(async () => void order.push("name"));
-    vi.mocked(joinRoom).mockImplementation(async () => {
-      order.push("room");
-      return true;
+    vi.mocked(closeDatabase).mockImplementation(() => void order.push("close"));
+    vi.mocked(useQuickStorage).mockImplementation(() => {
+      order.push("switch");
+      return "awful-quick-test";
     });
-    vi.mocked(joinCall).mockImplementation(async () => void order.push("call"));
+    vi.mocked(createEphemeral).mockImplementation(
+      async () => void order.push("identity")
+    );
+    vi.mocked(saveName).mockImplementation(async () => void order.push("name"));
 
-    await m.prepareQuickCall();
-    m.setQuickCallCode("ABCDEFGHJKMNP");
-    await m.startQuickCall({ name: "Ada" });
+    await m.prepareAsGuest();
 
-    expect(m.quickCall.stage).toBe("in-call");
-    expect(order).toEqual(["name", "name", "room", "call"]);
-    expect(joinRoom).toHaveBeenCalledWith("ABCDEFGHJKMNP");
+    expect(order).toEqual(["close", "switch", "identity", "name"]);
+    expect(m.quickCall.stage).toBe("setup");
+    expect(m.quickCall.identity).toBe("guest");
+  });
+
+  it("carries the account's whole profile row into the call", async () => {
+    identityStore.keypair = { did: "did:key:zSelf" };
+    ownProfile = {
+      did: "did:key:zSelf",
+      isMe: true,
+      nickname: "Ada",
+      pfpData: new ArrayBuffer(8),
+      color: "#ff0000",
+    };
+    const m = await load();
+    const { putOwnProfile, closeDatabase } = await import("$lib/storage");
+    const { useQuickStorage } = await import("./quick-storage");
+    const { createEphemeral } = await import("$lib/identity/identity.svelte");
+
+    expect(m.hasAccount()).toBe(true);
+    m.chooseAccount();
+    expect(m.quickCall.stage).toBe("unlocking");
+    await m.adoptAccount();
+
+    // The ROW, not the display store: an uploaded avatar is bytes, and a
+    // blob: URL would mean nothing to the other side.
+    expect(putOwnProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ nickname: "Ada", color: "#ff0000" })
+    );
+    // Read the real database first, then move off it.
+    expect(closeDatabase).toHaveBeenCalled();
+    expect(useQuickStorage).toHaveBeenCalled();
+    // The account's session is already live: no second, ephemeral identity.
+    expect(createEphemeral).not.toHaveBeenCalled();
+    expect(m.quickCall.stage).toBe("setup");
+    expect(m.quickCall.profile.name).toBe("Ada");
+  });
+
+  it("keeps an account's own at-rest marker on teardown", async () => {
+    identityStore.keypair = { did: "did:key:zSelf" };
+    ownProfile = { did: "did:key:zSelf", isMe: true, nickname: "Ada" };
+    const m = await load();
+    const { clearAtRestFlagForCurrentOwner } = await import("$lib/storage");
+    m.chooseAccount();
+    await m.adoptAccount();
+    m.teardownQuickCall();
+    // It belongs to the real database, which this page only read.
+    expect(clearAtRestFlagForCurrentOwner).not.toHaveBeenCalled();
+  });
+
+  it("takes a guest's at-rest marker with it", async () => {
+    const m = await load();
+    const { clearAtRestFlagForCurrentOwner } = await import("$lib/storage");
+    await m.prepareAsGuest();
+    m.teardownQuickCall();
+    expect(clearAtRestFlagForCurrentOwner).toHaveBeenCalled();
   });
 
   it("does not sit in 'joining' when the join fails", async () => {
     const m = await load();
     const { joinRoom } = await import("$lib/transport/transport.svelte");
     vi.mocked(joinRoom).mockRejectedValueOnce(new Error("relay is down"));
-    await m.prepareQuickCall();
+    await m.prepareAsGuest();
     await m.startQuickCall({ name: "Ada" });
     expect(m.quickCall.stage).toBe("failed");
     expect(m.quickCall.error).toBe("relay is down");

--- a/frontend/src/lib/quick/quick-send.svelte.ts
+++ b/frontend/src/lib/quick/quick-send.svelte.ts
@@ -25,7 +25,7 @@ import { LibP2PTransport } from "$lib/transport/libp2p/transport";
 import { WebTorrentFileTransport } from "$lib/transport/file/webtorrent";
 import { refreshTurnCredentials } from "$lib/transport/ice-server-list";
 import { isConfigured } from "$lib/runtime-config";
-import { newRoomCode, normalizeRoomCode } from "$lib/room-code";
+import { newQuickCode, normalizeQuickCode } from "$lib/room-code";
 import { quickSessionSeed } from "./session-key";
 import { decode, encode } from "$lib/utils";
 import {
@@ -135,7 +135,12 @@ function noteIncoming(file: FileDescriptor): void {
  * revisit does not build a second node.
  */
 export async function startQuickSend(joinCode?: string): Promise<void> {
-  const code = joinCode ? normalizeRoomCode(joinCode) : newRoomCode();
+  const code = joinCode ? normalizeQuickCode(joinCode) : newQuickCode();
+  if (!code) {
+    quickSend.status = "failed";
+    quickSend.error = "That does not look like a quick send code.";
+    return;
+  }
   if (transport && quickSend.code === code) return;
   if (transport) stopQuickSend();
 

--- a/frontend/src/lib/quick/quick-send.svelte.ts
+++ b/frontend/src/lib/quick/quick-send.svelte.ts
@@ -1,0 +1,272 @@
+/**
+ * /qs - send a file to one person, with no account and no room.
+ *
+ * Deliberately built on the two storage-free layers and nothing else:
+ * LibP2PTransport for introduction and signalling, WebTorrentFileTransport
+ * for the bytes. It does NOT import transport.svelte.ts, which would drag in
+ * the message store, the attachment store and at-rest crypto - all of which
+ * exist to remember things this page must not remember. Nothing here touches
+ * IndexedDB or localStorage, so "gone when the tab closes" is a property of
+ * the code rather than a cleanup routine that has to run.
+ *
+ * The same two consequences as sync.svelte.ts, for the same reason: this is a
+ * SECOND libp2p node in the profile, so it connects with no key seed (a fresh
+ * random peerId, never the device key) and takes no node lock. Two nodes with
+ * two peerIds coexist; two nodes with ONE peerId are the reconnect loop from
+ * the 2026-09-04 and 09-06 diag packs.
+ *
+ * What is honestly true about "no relay": the relay introduces the two peers
+ * and may carry the first hop, and TURN may carry WebRTC when both sides are
+ * behind symmetric NAT. The FILE never touches a server - it goes over the
+ * WebRTC link WebTorrent builds, peer to peer.
+ */
+
+import { LibP2PTransport } from "$lib/transport/libp2p/transport";
+import { WebTorrentFileTransport } from "$lib/transport/file/webtorrent";
+import { refreshTurnCredentials } from "$lib/transport/ice-server-list";
+import { isConfigured } from "$lib/runtime-config";
+import { newRoomCode, normalizeRoomCode } from "$lib/room-code";
+import { quickSessionSeed } from "./session-key";
+import { decode, encode } from "$lib/utils";
+import {
+  isFileSignalWireMessage,
+  type FileSignalWireMessage,
+} from "$lib/types/message";
+import type {
+  FileDescriptor,
+  FileTransferSnapshot,
+} from "$lib/transport/types";
+
+export type QuickSendStatus = "idle" | "connecting" | "ready" | "failed";
+
+interface QuickSendState {
+  status: QuickSendStatus;
+  /** The room code, which IS the secret. Empty until start() runs. */
+  code: string;
+  /** True when this device generated the code rather than following a link. */
+  isHost: boolean;
+  error: string | null;
+  /** How many other people the relay places in this code right now. */
+  peers: number;
+  /** Files this device is seeding, newest last. */
+  offered: FileDescriptor[];
+  /** Files the other side has offered, newest last. */
+  incoming: FileDescriptor[];
+  /** infoHash -> live progress, for both directions. */
+  transfers: Map<string, FileTransferSnapshot>;
+}
+
+export const quickSend = $state<QuickSendState>({
+  status: "idle",
+  code: "",
+  isHost: false,
+  error: null,
+  peers: 0,
+  offered: [],
+  incoming: [],
+  transfers: new Map(),
+});
+
+let transport: LibP2PTransport | null = null;
+let files: WebTorrentFileTransport | null = null;
+/**
+ * The bytes behind everything this device offers, by infoHash.
+ *
+ * WebTorrent holds a seeded file itself, but a peer that arrives later asks
+ * for it through the local lookup - which in the app reads the attachment
+ * store. Here the File objects are simply kept, which is why closing the tab
+ * ends the transfer: there is no copy anywhere else.
+ *
+ * ponytail: an in-memory Map, so an offered file is bounded by the tab's
+ * memory and a received one by what a Blob can hold (~2 GB, less on mobile).
+ * Streaming into showSaveFilePicker() lifts the receive side on Chromium; do
+ * it when somebody actually hits the ceiling.
+ */
+const localFiles = new Map<string, File>();
+
+/** Peers we have wired into the file transport, so teardown is exact. */
+const wired = new Set<string>();
+
+function isRoomPeer(peerId: string): boolean {
+  return !!transport && transport.isRoomPeer(quickSend.code, peerId);
+}
+
+/**
+ * A peer only exists to this page once the RELAY places it in the code.
+ *
+ * The file transport announces our whole inventory to every peer it is told
+ * about, so wiring a peer that merely dialled us would hand a stranger the
+ * list of what this device is offering. Same attestation the app uses to
+ * decide who may be told a room exists.
+ */
+function wirePeer(peerId: string): void {
+  if (!files || wired.has(peerId) || !isRoomPeer(peerId)) return;
+  wired.add(peerId);
+  files.onPeerConnect(peerId);
+  refreshPeerCount();
+}
+
+function unwirePeer(peerId: string): void {
+  if (!wired.delete(peerId)) return;
+  files?.onPeerDisconnect(peerId);
+  refreshPeerCount();
+}
+
+function refreshPeerCount(): void {
+  quickSend.peers = transport?.peersInRoom(quickSend.code).length ?? 0;
+}
+
+function putTransfer(snapshot: FileTransferSnapshot): void {
+  // A new Map, not a mutation: $state does not deep-proxy a Map, so .set on
+  // the existing one updates the data and re-renders nothing.
+  const next = new Map(quickSend.transfers);
+  next.set(snapshot.infoHash, snapshot);
+  quickSend.transfers = next;
+}
+
+function noteIncoming(file: FileDescriptor): void {
+  if (localFiles.has(file.infoHash)) return; // our own, echoed back
+  if (quickSend.incoming.some((f) => f.infoHash === file.infoHash)) return;
+  quickSend.incoming = [...quickSend.incoming, file];
+}
+
+/**
+ * Join a code, or mint one. Idempotent for the same code so a re-render or a
+ * revisit does not build a second node.
+ */
+export async function startQuickSend(joinCode?: string): Promise<void> {
+  const code = joinCode ? normalizeRoomCode(joinCode) : newRoomCode();
+  if (transport && quickSend.code === code) return;
+  if (transport) stopQuickSend();
+
+  quickSend.code = code;
+  quickSend.isHost = !joinCode;
+  quickSend.status = "connecting";
+  quickSend.error = null;
+
+  if (!isConfigured()) {
+    quickSend.status = "failed";
+    quickSend.error = "This instance has no relay configured.";
+    return;
+  }
+
+  // TURN before the first dial, exactly as the app's own connect does: the
+  // list starts STUN-only and a pair behind symmetric NAT never links
+  // without it.
+  refreshTurnCredentials().catch(() => {});
+
+  const t = new LibP2PTransport({ diagBus: "qs" });
+  const f = new WebTorrentFileTransport(() => t.selfId());
+  transport = t;
+  files = f;
+
+  f.setLocalFileLookup(async (infoHash) => localFiles.get(infoHash) ?? null);
+
+  f.on("signal", (peerId, envelope) => {
+    void t.send(
+      peerId,
+      encode({
+        type: "__file_signal",
+        payload: envelope,
+      } satisfies FileSignalWireMessage)
+    );
+  });
+  f.on("transfer", (snapshot) => putTransfer(snapshot));
+
+  t.on("connect", wirePeer);
+  t.on("disconnect", unwirePeer);
+  // The relay's membership reply is what makes a peer real here, and it can
+  // land either side of the connection - a peer already connected fires no
+  // second connect event.
+  t.on("roomPeers", (room, peerIds) => {
+    if (room !== quickSend.code) return;
+    for (const peerId of peerIds) wirePeer(peerId);
+    refreshPeerCount();
+  });
+  t.on("message", (peerId, data) => {
+    if (!isRoomPeer(peerId)) return;
+    let decoded: unknown;
+    try {
+      decoded = decode(data);
+    } catch {
+      return; // not ours; this page speaks one message type
+    }
+    if (!isFileSignalWireMessage(decoded)) return;
+    if (decoded.payload.kind === "file-seeder") {
+      noteIncoming(decoded.payload.file);
+    }
+    f.handleSignal(peerId, decoded.payload);
+  });
+
+  try {
+    // A per-page key, never the device key - and the SAME one on every
+    // reconnect, so a relay bounce does not turn us into a stranger.
+    await t.connect(quickSessionSeed());
+    t.joinRoom(code);
+    quickSend.status = "ready";
+    refreshPeerCount();
+  } catch (err) {
+    quickSend.status = "failed";
+    quickSend.error = err instanceof Error ? err.message : String(err);
+  }
+}
+
+/** Seed files and announce them to whoever is already here. */
+export async function offerFiles(picked: File[]): Promise<void> {
+  if (!files || !picked.length) return;
+  const descriptors = await files.seedFiles(picked);
+  descriptors.forEach((desc, i) => {
+    const file = picked[i];
+    if (file) localFiles.set(desc.infoHash, file);
+  });
+  const known = new Set(quickSend.offered.map((f) => f.infoHash));
+  quickSend.offered = [
+    ...quickSend.offered,
+    ...descriptors.filter((d) => !known.has(d.infoHash)),
+  ];
+}
+
+/**
+ * Pull a file the other side offered.
+ *
+ * A click, never automatic: the descriptor is the sender's own claim, and
+ * bytes nobody asked for is the one thing a page like this must not do.
+ */
+export function acceptFile(infoHash: string, retry = false): void {
+  const file = quickSend.incoming.find((f) => f.infoHash === infoHash);
+  if (file) files?.ensureDownload(file, { retry });
+}
+
+export function stopQuickSend(): void {
+  for (const snapshot of quickSend.transfers.values()) {
+    if (snapshot.blobURL) URL.revokeObjectURL(snapshot.blobURL);
+  }
+  files?.destroy();
+  void transport?.disconnect();
+  transport = null;
+  files = null;
+  localFiles.clear();
+  wired.clear();
+  quickSend.status = "idle";
+  quickSend.code = "";
+  quickSend.peers = 0;
+  quickSend.offered = [];
+  quickSend.incoming = [];
+  quickSend.transfers = new Map();
+  quickSend.error = null;
+}
+
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  // Dev-only handle, same reasoning as transport.svelte.ts's __awful: a
+  // two-peer transfer is only observable with two real browsers.
+  (window as unknown as Record<string, unknown>).__qs = {
+    state: quickSend,
+    offerFiles,
+    acceptFile,
+  };
+}
+
+/** The link to hand a friend. The code stays in the fragment - see App.svelte. */
+export function quickSendLink(code: string): string {
+  return `${window.location.origin}/qs#${code}`;
+}

--- a/frontend/src/lib/quick/quick-send.test.ts
+++ b/frontend/src/lib/quick/quick-send.test.ts
@@ -142,21 +142,30 @@ describe("quick send", () => {
 
   it("joins the code it is given, normalized", async () => {
     const qs = await load();
-    await qs.startQuickSend("abcd-efgh-jkmn-p");
-    expect(transport.joined).toEqual(["ABCDEFGHJKMNP"]);
+    await qs.startQuickSend("7qk3-m9ab-2c");
+    expect(transport.joined).toEqual(["7QK3M9AB2C"]);
     expect(qs.quickSend.status).toBe("ready");
+  });
+
+  it("refuses a link that is not a quick code", async () => {
+    const qs = await load();
+    // A room code is 13 characters and means something else entirely; a page
+    // that "helpfully" joined it would put a stranger in a real room.
+    await qs.startQuickSend("6BMB3GST2JRJZ");
+    expect(qs.quickSend.status).toBe("failed");
+    expect(transport.joined).toEqual([]);
   });
 
   it("mints a code when there is none to join", async () => {
     const qs = await load();
     await qs.startQuickSend();
-    expect(qs.quickSend.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{13}$/);
+    expect(qs.quickSend.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{10}$/);
     expect(qs.quickSend.isHost).toBe(true);
   });
 
   it("ignores a peer the relay has not placed in the code", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
 
     transport.emit("connect", "stranger");
     transport.emit("message", "stranger", frame(OFFER));
@@ -169,10 +178,10 @@ describe("quick send", () => {
 
   it("wires a room peer and surfaces what it offers", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
 
     transport.roomPeers.add("friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
     transport.emit("message", "friend", frame(OFFER));
 
     expect(files.connected).toEqual(["friend"]);
@@ -185,12 +194,12 @@ describe("quick send", () => {
 
   it("wires a room peer only once, however often the relay lists it", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
 
     transport.roomPeers.add("friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
     transport.emit("connect", "friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
 
     expect(files.connected).toEqual(["friend"]);
     expect(qs.quickSend.peers).toBe(1);
@@ -198,12 +207,12 @@ describe("quick send", () => {
 
   it("does not offer us back our own file", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
     await qs.offerFiles([new File(["x"], "mine.txt", { type: "text/plain" })]);
     expect(qs.quickSend.offered.map((f) => f.filename)).toEqual(["mine.txt"]);
 
     transport.roomPeers.add("friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
     transport.emit(
       "message",
       "friend",
@@ -221,9 +230,9 @@ describe("quick send", () => {
 
   it("downloads only on request, and only what was offered", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
     transport.roomPeers.add("friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
     transport.emit("message", "friend", frame(OFFER));
 
     expect(files.downloads).toEqual([]);
@@ -235,9 +244,9 @@ describe("quick send", () => {
 
   it("survives a frame that is not ours", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
     transport.roomPeers.add("friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
 
     expect(() => {
       transport.emit("message", "friend", new TextEncoder().encode("{oops"));
@@ -248,9 +257,9 @@ describe("quick send", () => {
 
   it("leaves nothing behind when the page goes away", async () => {
     const qs = await load();
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
     transport.roomPeers.add("friend");
-    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
     await qs.offerFiles([new File(["x"], "mine.txt")]);
 
     qs.stopQuickSend();
@@ -269,7 +278,7 @@ describe("quick send", () => {
     files = new FakeFiles();
     const qs = await import("./quick-send.svelte");
 
-    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.startQuickSend("7QK3M9AB2C");
     expect(qs.quickSend.status).toBe("failed");
     expect(transport.joined).toEqual([]);
     vi.doUnmock("$lib/runtime-config");

--- a/frontend/src/lib/quick/quick-send.test.ts
+++ b/frontend/src/lib/quick/quick-send.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The gate is the thing worth testing here: a peer only counts once the RELAY
+ * has placed it in the code. Wiring a peer that merely dialled us hands a
+ * stranger the list of what this tab is offering, and believing its file
+ * offer puts a file nobody sent in front of the user.
+ */
+
+class FakeTransport {
+  handlers = new Map<string, Function[]>();
+  roomPeers = new Set<string>();
+  joined: string[] = [];
+  sent: { peerId: string; data: Uint8Array }[] = [];
+  disconnected = false;
+
+  on(event: string, handler: Function) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(handler);
+    this.handlers.set(event, list);
+  }
+  emit(event: string, ...args: unknown[]) {
+    for (const h of this.handlers.get(event) ?? []) h(...args);
+  }
+  async connect() {}
+  joinRoom(code: string) {
+    this.joined.push(code);
+  }
+  isRoomPeer(_room: string, peerId: string) {
+    return this.roomPeers.has(peerId);
+  }
+  peersInRoom() {
+    return [...this.roomPeers];
+  }
+  selfId() {
+    return "self";
+  }
+  async send(peerId: string, data: Uint8Array) {
+    this.sent.push({ peerId, data });
+    return true;
+  }
+  async disconnect() {
+    this.disconnected = true;
+  }
+}
+
+class FakeFiles {
+  handlers = new Map<string, Function[]>();
+  connected: string[] = [];
+  signalled: string[] = [];
+  downloads: string[] = [];
+  destroyed = false;
+  lookup: ((infoHash: string) => Promise<File | null>) | null = null;
+
+  on(event: string, handler: Function) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(handler);
+    this.handlers.set(event, list);
+  }
+  emit(event: string, ...args: unknown[]) {
+    for (const h of this.handlers.get(event) ?? []) h(...args);
+  }
+  setLocalFileLookup(fn: (infoHash: string) => Promise<File | null>) {
+    this.lookup = fn;
+  }
+  async seedFiles(files: File[]) {
+    return files.map((f, i) => ({
+      infoHash: `hash${i}`,
+      filename: f.name,
+      mimeType: f.type,
+      size: f.size,
+    }));
+  }
+  handleSignal(peerId: string) {
+    this.signalled.push(peerId);
+  }
+  ensureDownload(file: { infoHash: string }) {
+    this.downloads.push(file.infoHash);
+  }
+  onPeerConnect(peerId: string) {
+    this.connected.push(peerId);
+  }
+  onPeerDisconnect(peerId: string) {
+    this.connected = this.connected.filter((p) => p !== peerId);
+  }
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+let transport: FakeTransport;
+let files: FakeFiles;
+
+vi.mock("$lib/transport/libp2p/transport", () => ({
+  LibP2PTransport: class {
+    constructor() {
+      return transport as unknown as object;
+    }
+  },
+}));
+vi.mock("$lib/transport/file/webtorrent", () => ({
+  WebTorrentFileTransport: class {
+    constructor() {
+      return files as unknown as object;
+    }
+  },
+}));
+vi.mock("$lib/transport/ice-server-list", () => ({
+  refreshTurnCredentials: () => Promise.resolve(),
+}));
+vi.mock("$lib/runtime-config", () => ({ isConfigured: () => true }));
+
+const OFFER = {
+  type: "__file_signal",
+  payload: {
+    kind: "file-seeder",
+    file: {
+      infoHash: "abc",
+      filename: "holiday.mp4",
+      mimeType: "video/mp4",
+      size: 42,
+    },
+  },
+};
+
+function frame(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(obj));
+}
+
+async function load() {
+  vi.resetModules();
+  transport = new FakeTransport();
+  files = new FakeFiles();
+  return import("./quick-send.svelte");
+}
+
+describe("quick send", () => {
+  beforeEach(() => {
+    transport = new FakeTransport();
+    files = new FakeFiles();
+  });
+
+  it("joins the code it is given, normalized", async () => {
+    const qs = await load();
+    await qs.startQuickSend("abcd-efgh-jkmn-p");
+    expect(transport.joined).toEqual(["ABCDEFGHJKMNP"]);
+    expect(qs.quickSend.status).toBe("ready");
+  });
+
+  it("mints a code when there is none to join", async () => {
+    const qs = await load();
+    await qs.startQuickSend();
+    expect(qs.quickSend.code).toMatch(/^[0-9A-HJKMNP-TV-Z]{13}$/);
+    expect(qs.quickSend.isHost).toBe(true);
+  });
+
+  it("ignores a peer the relay has not placed in the code", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+
+    transport.emit("connect", "stranger");
+    transport.emit("message", "stranger", frame(OFFER));
+
+    // No inventory announce, and nothing offered to the user.
+    expect(files.connected).toEqual([]);
+    expect(files.signalled).toEqual([]);
+    expect(qs.quickSend.incoming).toEqual([]);
+  });
+
+  it("wires a room peer and surfaces what it offers", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("message", "friend", frame(OFFER));
+
+    expect(files.connected).toEqual(["friend"]);
+    expect(qs.quickSend.peers).toBe(1);
+    expect(qs.quickSend.incoming.map((f) => f.filename)).toEqual([
+      "holiday.mp4",
+    ]);
+    expect(files.signalled).toEqual(["friend"]);
+  });
+
+  it("wires a room peer only once, however often the relay lists it", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("connect", "friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+
+    expect(files.connected).toEqual(["friend"]);
+    expect(qs.quickSend.peers).toBe(1);
+  });
+
+  it("does not offer us back our own file", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+    await qs.offerFiles([new File(["x"], "mine.txt", { type: "text/plain" })]);
+    expect(qs.quickSend.offered.map((f) => f.filename)).toEqual(["mine.txt"]);
+
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit(
+      "message",
+      "friend",
+      frame({
+        type: "__file_signal",
+        payload: {
+          kind: "file-seeder",
+          file: { ...OFFER.payload.file, infoHash: "hash0" },
+        },
+      })
+    );
+
+    expect(qs.quickSend.incoming).toEqual([]);
+  });
+
+  it("downloads only on request, and only what was offered", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    transport.emit("message", "friend", frame(OFFER));
+
+    expect(files.downloads).toEqual([]);
+    qs.acceptFile("never-offered");
+    expect(files.downloads).toEqual([]);
+    qs.acceptFile("abc");
+    expect(files.downloads).toEqual(["abc"]);
+  });
+
+  it("survives a frame that is not ours", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+
+    expect(() => {
+      transport.emit("message", "friend", new TextEncoder().encode("{oops"));
+      transport.emit("message", "friend", frame({ type: "__chat", body: "hi" }));
+    }).not.toThrow();
+    expect(qs.quickSend.incoming).toEqual([]);
+  });
+
+  it("leaves nothing behind when the page goes away", async () => {
+    const qs = await load();
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "ABCDEFGHJKMNP", ["friend"]);
+    await qs.offerFiles([new File(["x"], "mine.txt")]);
+
+    qs.stopQuickSend();
+
+    expect(files.destroyed).toBe(true);
+    expect(transport.disconnected).toBe(true);
+    expect(qs.quickSend.code).toBe("");
+    expect(qs.quickSend.offered).toEqual([]);
+    expect(qs.quickSend.status).toBe("idle");
+  });
+
+  it("reports an instance with no relay instead of dialling nothing", async () => {
+    vi.resetModules();
+    vi.doMock("$lib/runtime-config", () => ({ isConfigured: () => false }));
+    transport = new FakeTransport();
+    files = new FakeFiles();
+    const qs = await import("./quick-send.svelte");
+
+    await qs.startQuickSend("ABCDEFGHJKMNP");
+    expect(qs.quickSend.status).toBe("failed");
+    expect(transport.joined).toEqual([]);
+    vi.doUnmock("$lib/runtime-config");
+  });
+});

--- a/frontend/src/lib/quick/quick-storage.test.ts
+++ b/frontend/src/lib/quick/quick-storage.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The sweep is the part worth pinning: it deletes databases by name pattern.
+ * Getting "is anyone using this one" wrong means either a quick page losing
+ * its call mid-sentence, or a leftover database surviving the promise that
+ * nothing does.
+ */
+
+/** A Lock Manager with the two behaviours this module leans on. */
+class FakeLocks {
+  held = new Set<string>();
+  release = new Map<string, () => void>();
+
+  request(name: string, a: unknown, b?: unknown): Promise<unknown> {
+    const opts = (typeof a === "function" ? {} : a) as {
+      ifAvailable?: boolean;
+    };
+    const cb = (typeof a === "function" ? a : b) as (
+      lock: unknown
+    ) => unknown | Promise<unknown>;
+    if (opts.ifAvailable) {
+      // Held by someone else means the callback gets null, not a queue.
+      return Promise.resolve(cb(this.held.has(name) ? null : { name }));
+    }
+    this.held.add(name);
+    return Promise.resolve(cb({ name })).then((p) => {
+      // A held lock's callback returns a promise that stays pending; record
+      // how to settle it so a test can simulate the page going away.
+      if (p instanceof Promise) return p;
+      this.held.delete(name);
+      return p;
+    });
+  }
+}
+
+let locks: FakeLocks;
+let deleted: string[];
+let existing: string[];
+
+function installGlobals() {
+  locks = new FakeLocks();
+  deleted = [];
+  existing = [];
+  vi.stubGlobal("navigator", { locks });
+  vi.stubGlobal("indexedDB", {
+    databases: async () => existing.map((name) => ({ name })),
+    deleteDatabase: (name: string) => {
+      deleted.push(name);
+      existing = existing.filter((n) => n !== name);
+      const req: Record<string, unknown> = {};
+      queueMicrotask(() => (req.onsuccess as () => void)?.());
+      return req;
+    },
+  });
+}
+
+async function load() {
+  vi.resetModules();
+  installGlobals();
+  return import("./quick-storage");
+}
+
+describe("quick storage", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it("uses the real database until it is told otherwise", async () => {
+    const m = await load();
+    expect(m.dbName()).toBe("awful-chat");
+    expect(m.isQuickStorage()).toBe(false);
+  });
+
+  it("switches to a throwaway name, once", async () => {
+    const m = await load();
+    const name = m.useQuickStorage();
+    expect(name).toMatch(/^awful-quick-[0-9a-f]{16}$/);
+    expect(m.dbName()).toBe(name);
+    expect(m.isQuickStorage()).toBe(true);
+    expect(m.useQuickStorage()).toBe(name); // idempotent
+  });
+
+  it("deletes its own database on the way out", async () => {
+    const m = await load();
+    const name = m.useQuickStorage();
+    await m.dropQuickStorage();
+    expect(deleted).toEqual([name]);
+    // And stops claiming a scope it no longer has, so nothing writes into a
+    // database that is being deleted.
+    expect(m.isQuickStorage()).toBe(false);
+    expect(m.dbName()).toBe("awful-chat");
+  });
+
+  it("sweeps a database whose page is gone", async () => {
+    const m = await load();
+    existing = ["awful-chat", "awful-quick-dead0000dead0000", "awful-auth"];
+    await m.sweepOrphanQuickStorage();
+    expect(deleted).toEqual(["awful-quick-dead0000dead0000"]);
+  });
+
+  it("leaves a database another quick page is still holding", async () => {
+    const m = await load();
+    locks.held.add("awful-quick-alive000alive000");
+    existing = ["awful-quick-alive000alive000", "awful-quick-dead0000dead0000"];
+    await m.sweepOrphanQuickStorage();
+    expect(deleted).toEqual(["awful-quick-dead0000dead0000"]);
+  });
+
+  it("never sweeps its own", async () => {
+    const m = await load();
+    const mine = m.useQuickStorage();
+    existing = [mine];
+    await m.sweepOrphanQuickStorage();
+    expect(deleted).toEqual([]);
+  });
+
+  it("does nothing where databases() does not exist", async () => {
+    const m = await load();
+    vi.stubGlobal("indexedDB", { deleteDatabase: () => ({}) });
+    existing = ["awful-quick-dead0000dead0000"];
+    await expect(m.sweepOrphanQuickStorage()).resolves.toBeUndefined();
+    expect(deleted).toEqual([]);
+  });
+});

--- a/frontend/src/lib/quick/quick-storage.ts
+++ b/frontend/src/lib/quick/quick-storage.ts
@@ -1,0 +1,118 @@
+/**
+ * A storage scope that dies with the page.
+ *
+ * /qc runs the whole app stack - transport, rooms, plugins - because that is
+ * what makes a call a call, and all of it writes to IndexedDB. None of it may
+ * land in the database the user's real identity lives in: a quick call is not
+ * a room, and it must not leave one behind.
+ *
+ * So the database gets a different name for the life of the page, and is
+ * deleted on the way out. Per PAGE, not per tab: the ephemeral keypair lives
+ * only in memory, so a reload is a different identity, and rows sealed with
+ * the old key would be unreadable anyway.
+ *
+ * Anything meant to survive (the name and picture you call under) is written
+ * to localStorage by quick-call.svelte.ts instead - see rememberQuickProfile.
+ *
+ * Must be called BEFORE anything opens the database. main.ts does it, ahead
+ * of the app mounting, because identity init opens it on the first frame.
+ */
+
+const MAIN_DB = "awful-chat";
+const QUICK_PREFIX = "awful-quick-";
+
+let quick: string | null = null;
+/** Resolving this releases the lock that marks our database as live. */
+let releaseLock: (() => void) | null = null;
+
+export function isQuickStorage(): boolean {
+  return quick !== null;
+}
+
+/** The database this page uses. Every opener goes through here. */
+export function dbName(): string {
+  return quick ?? MAIN_DB;
+}
+
+/**
+ * Switch this page to a throwaway database, and hold a lock named after it
+ * for as long as the page lives. The lock is what tells the next page which
+ * leftovers are orphans - a tab that crashed released it, a tab still open
+ * did not.
+ */
+export function useQuickStorage(): string {
+  if (quick) return quick;
+  const id = Array.from(crypto.getRandomValues(new Uint8Array(8)), (b) =>
+    b.toString(16).padStart(2, "0")
+  ).join("");
+  quick = QUICK_PREFIX + id;
+  try {
+    void navigator.locks?.request(
+      quick,
+      () => new Promise<void>((resolve) => (releaseLock = resolve))
+    );
+  } catch {
+    // No Lock Manager: the delete below still runs, only the orphan sweep
+    // has nothing to go on.
+  }
+  return quick;
+}
+
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    let req: IDBOpenDBRequest;
+    try {
+      req = indexedDB.deleteDatabase(name);
+    } catch {
+      resolve();
+      return;
+    }
+    // Resolve on blocked too: a delete held up by another connection is not
+    // something a page being unloaded can wait for, and the sweep on the
+    // next page picks it up.
+    req.onsuccess = req.onerror = req.onblocked = () => resolve();
+  });
+}
+
+/**
+ * Drop this page's database. Called on pagehide, where there is no time to
+ * wait for anything - the promise is best effort and the sweep is the net.
+ */
+export async function dropQuickStorage(): Promise<void> {
+  if (!quick) return;
+  const name = quick;
+  quick = null;
+  releaseLock?.();
+  releaseLock = null;
+  await deleteDatabase(name);
+}
+
+/**
+ * Delete quick databases nobody is holding: a tab that crashed, or one whose
+ * pagehide delete was cut short. Skips any whose lock is still held, so two
+ * quick pages open at once do not eat each other.
+ *
+ * ponytail: silently does nothing without indexedDB.databases() (no Safari
+ * before 14, no Firefox before 126). The pagehide delete covers the ordinary
+ * case; this only cleans up after a crash.
+ */
+export async function sweepOrphanQuickStorage(): Promise<void> {
+  if (!navigator.locks || !indexedDB.databases) return;
+  let names: string[];
+  try {
+    names = (await indexedDB.databases())
+      .map((d) => d.name ?? "")
+      .filter((n) => n.startsWith(QUICK_PREFIX) && n !== quick);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    await navigator.locks
+      .request(name, { ifAvailable: true }, async (lock) => {
+        // null means someone still holds it, so the page that owns this
+        // database is alive and it is not an orphan.
+        if (lock) await deleteDatabase(name);
+      })
+      .catch(() => {});
+  }
+}

--- a/frontend/src/lib/quick/session-key.ts
+++ b/frontend/src/lib/quick/session-key.ts
@@ -1,0 +1,18 @@
+/**
+ * The libp2p key a quick page connects under.
+ *
+ * Random, in memory, and NEVER device-key.ts's per-profile seed. Two nodes in
+ * one browser profile is fine; two nodes sharing one peerId is the reconnect
+ * loop from the 2026-09-04 and 09-06 diag packs, because the relay and every
+ * peer keep one stream per peerId and the two starve each other.
+ *
+ * Minted once per page and reused, not generated per connect(): a relay
+ * bounce rebuilds the node, and a peerId that changed with it would look to
+ * everyone else like the person left and a stranger arrived - mid-call.
+ */
+
+let seed: Uint8Array | null = null;
+
+export function quickSessionSeed(): Uint8Array {
+  return (seed ??= crypto.getRandomValues(new Uint8Array(32)));
+}

--- a/frontend/src/lib/room-code.test.ts
+++ b/frontend/src/lib/room-code.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { formatRoomCode, newRoomCode, normalizeRoomCode } from "./room-code";
+import {
+  formatQuickCode,
+  formatRoomCode,
+  isQuickCode,
+  newQuickCode,
+  newRoomCode,
+  normalizeQuickCode,
+  normalizeRoomCode,
+} from "./room-code";
 
 describe("room codes", () => {
   it("is 13 Crockford base32 characters (65 bits)", () => {
@@ -26,5 +34,40 @@ describe("room codes", () => {
     expect(normalizeRoomCode("3f9a1c2b4d5e6f70")).toBe("3f9a1c2b4d5e6f70");
     expect(normalizeRoomCode("a1b2c3")).toBe("a1b2c3");
     expect(formatRoomCode("3f9a1c2b4d5e6f70")).toBe("3f9a1c2b4d5e6f70");
+  });
+});
+
+describe("quick codes", () => {
+  it("is ten characters of the room alphabet", () => {
+    for (let i = 0; i < 50; i++) {
+      const code = newQuickCode();
+      expect(code).toMatch(/^[0-9A-HJKMNP-TV-Z]{10}$/);
+      expect(normalizeQuickCode(code)).toBe(code);
+    }
+  });
+
+  it("folds what a person types, look-alikes and all", () => {
+    expect(normalizeQuickCode(" 7qk3-m9ab-2c ")).toBe("7QK3M9AB2C");
+    expect(normalizeQuickCode("7qk3 m9ab 2c")).toBe("7QK3M9AB2C");
+    // O/I/L never appear in a generated code, so a reader who wrote one down
+    // meant the digit.
+    expect(normalizeQuickCode("oqk3m9ab2c")).toBe("0QK3M9AB2C");
+    expect(normalizeQuickCode("iqk3m9ab2l")).toBe("1QK3M9AB21");
+  });
+
+  it("refuses anything that is not one", () => {
+    // A room code above all: 13 characters means a real room, and a quick
+    // page that joined one would put a stranger in it.
+    expect(normalizeQuickCode("6BMB3GST2JRJZ")).toBe("");
+    expect(normalizeQuickCode("7QK3M9AB")).toBe("");
+    expect(normalizeQuickCode("7QK3M9AB2C!")).toBe("");
+    expect(normalizeQuickCode("")).toBe("");
+    expect(isQuickCode("6BMB3GST2JRJZ")).toBe(false);
+    expect(isQuickCode("7qk3-m9ab-2c")).toBe(true);
+  });
+
+  it("displays as three groups", () => {
+    expect(formatQuickCode("7QK3M9AB2C")).toBe("7QK-3M9A-B2C");
+    expect(formatQuickCode("not-a-code")).toBe("not-a-code");
   });
 });

--- a/frontend/src/lib/room-code.ts
+++ b/frontend/src/lib/room-code.ts
@@ -51,6 +51,61 @@ export function normalizeRoomCode(input: string): string {
   return ROOM_CODE_RE.test(folded) ? folded : trimmed;
 }
 
+/**
+ * Quick codes: /qs and /qc.
+ *
+ * 10 characters, 50 bits, shown as XXX-XXXX-XXX - the shape of a Google Meet
+ * code, and for the same reason. A room is permanent and its code is worth
+ * grinding for; a quick call or a file hand-off is alive for hours at the
+ * outside, and after that the code names nothing at all.
+ *
+ * The arithmetic, at a wildly generous 10,000 guesses per second sustained
+ * against the relay's rendezvous (there is no offline oracle - a guess has to
+ * be registered with the relay to test it), over a four-hour session:
+ *
+ *	one session:            1.4e8 tries / 2^50 = 0.00000013
+ *	1,000 live sessions:    1.4e8 * 1000 / 2^50 = 0.00013
+ *
+ * So one chance in eight thousand that a sustained four-hour attack lands on
+ * ANY live session across a busy instance. Eight characters (40 bits) is
+ * where that stops holding - it puts the same figure at 13%, which is why
+ * this is not shorter still.
+ *
+ * Deliberately a different LENGTH from a room code rather than a different
+ * alphabet, so one look tells them apart and neither parser can be fed the
+ * other's input by accident.
+ */
+const QUICK_CODE_LEN = 10;
+const QUICK_CODE_RE = new RegExp(`^[${ALPHABET}]{${QUICK_CODE_LEN}}$`);
+
+export function newQuickCode(): string {
+  return Array.from(
+    crypto.getRandomValues(new Uint8Array(QUICK_CODE_LEN)),
+    (b) => ALPHABET[b & 31]
+  ).join("");
+}
+
+/** Fold what a person typed or pasted into the wire form, or "" if it cannot be one. */
+export function normalizeQuickCode(input: string): string {
+  const folded = input
+    .trim()
+    .replace(/[-\s]/g, "")
+    .toUpperCase()
+    .replace(/O/g, "0")
+    .replace(/[IL]/g, "1");
+  return QUICK_CODE_RE.test(folded) ? folded : "";
+}
+
+export function isQuickCode(input: string): boolean {
+  return normalizeQuickCode(input) !== "";
+}
+
+/** For display: `7QK3M9AB2C` -> `7QK-3M9A-B2C`. */
+export function formatQuickCode(code: string): string {
+  if (!QUICK_CODE_RE.test(code)) return code;
+  return `${code.slice(0, 3)}-${code.slice(3, 7)}-${code.slice(7)}`;
+}
+
 /** For display: `6BMB3GST2JRJZ` -> `6BMB-3GST-2JRJ-Z`; other codes as is. */
 export function formatRoomCode(code: string): string {
   if (!ROOM_CODE_RE.test(code)) return code;

--- a/frontend/src/lib/runtime-config.test.ts
+++ b/frontend/src/lib/runtime-config.test.ts
@@ -36,6 +36,28 @@ describe("loadRuntimeConfig", () => {
     expect(m.sfuUrls()).toEqual(["wss://a.example/sfu", "wss://b.example/sfu"]);
   });
 
+  it("keeps an optional page off unless the flag plainly says yes", async () => {
+    // The entrypoint writes a JSON boolean, but a hand-edited config.json (or
+    // a VITE_ variable, which is always a string) writes "true". Both count;
+    // anything else leaves the route off rather than half-on.
+    for (const [raw, expected] of [
+      [true, true],
+      ["true", true],
+      ["YES", true],
+      ["1", true],
+      [false, false],
+      ["false", false],
+      ["", false],
+      ["maybe", false],
+      [undefined, false],
+    ] as const) {
+      const m = await load(respond(JSON.stringify({ useQs: raw })));
+      await m.loadRuntimeConfig();
+      expect(m.useQs(), `useQs for ${JSON.stringify(raw)}`).toBe(expected);
+      expect(m.useQc()).toBe(false); // absent stays off
+    }
+  });
+
   it("accepts the single-url form", async () => {
     const m = await load(respond(JSON.stringify({ sfuUrl: "wss://one/sfu" })));
     await m.loadRuntimeConfig();

--- a/frontend/src/lib/runtime-config.ts
+++ b/frontend/src/lib/runtime-config.ts
@@ -25,6 +25,25 @@ export interface RuntimeConfig {
   relayMultiaddr: string;
   /** One SFU, or several. Empty means this origin's own /sfu. */
   sfuUrls: string[];
+  /** The /qs quick-send page. Off unless the instance turns it on. */
+  useQs: boolean;
+  /** The /qc quick-call page. Off unless the instance turns it on. */
+  useQc: boolean;
+}
+
+/**
+ * Anything but a plain yes is off. The value arrives as a JSON boolean from
+ * the entrypoint, but an operator hand-editing config.json (or setting a
+ * VITE_ variable, which is always a string) writes "true" - a flag that
+ * silently stayed off because it was quoted is not worth the debugging.
+ */
+function flag(raw: unknown, fallback: boolean): boolean {
+  if (typeof raw === "boolean") return raw;
+  if (typeof raw !== "string") return fallback;
+  const v = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(v)) return true;
+  if (["0", "false", "no", "off", ""].includes(v)) return false;
+  return fallback;
 }
 
 function splitList(raw: unknown): string[] {
@@ -35,7 +54,13 @@ function splitList(raw: unknown): string[] {
     .filter(Boolean);
 }
 
-const EMPTY: RuntimeConfig = { apiUrl: "", relayMultiaddr: "", sfuUrls: [] };
+const EMPTY: RuntimeConfig = {
+  apiUrl: "",
+  relayMultiaddr: "",
+  sfuUrls: [],
+  useQs: false,
+  useQc: false,
+};
 
 /**
  * The repo-root .env, for `pnpm dev` only.
@@ -55,6 +80,8 @@ function fromBuild(): RuntimeConfig {
     apiUrl: env.VITE_API_URL ?? "",
     relayMultiaddr: env.VITE_RELAY_MULTIADDR ?? "",
     sfuUrls: splitList(env.VITE_SFU_URLS || env.VITE_SFU_URL),
+    useQs: flag(env.VITE_USE_QS, false),
+    useQc: flag(env.VITE_USE_QC, false),
   };
 }
 
@@ -70,6 +97,8 @@ function coerce(raw: unknown, fallback: RuntimeConfig): RuntimeConfig {
     apiUrl: str(r.apiUrl, fallback.apiUrl),
     relayMultiaddr: str(r.relayMultiaddr, fallback.relayMultiaddr),
     sfuUrls: sfu.length ? sfu.map((u) => u.trim()) : fallback.sfuUrls,
+    useQs: flag(r.useQs, fallback.useQs),
+    useQc: flag(r.useQc, fallback.useQc),
   };
 }
 
@@ -183,4 +212,12 @@ export function relayMultiaddr(): string {
 
 export function sfuUrls(): string[] {
   return current.sfuUrls;
+}
+
+export function useQs(): boolean {
+  return current.useQs;
+}
+
+export function useQc(): boolean {
+  return current.useQc;
 }

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -2363,6 +2363,20 @@ function removeAtRestFlags(match: (key: string) => boolean): void {
   }
 }
 
+/**
+ * Drop the sweep flag belonging to the identity that is active right now.
+ *
+ * For the quick pages: their database goes with the tab, so the localStorage
+ * marker saying it was swept must go too, or every ephemeral identity leaves
+ * one behind forever. Deliberately scoped to the current owner - the whole-
+ * family clear would take the real account's flag with it and cost the user a
+ * full re-sweep on their next unlock.
+ */
+export function clearAtRestFlagForCurrentOwner(): void {
+  const key = atRestFlagKey();
+  removeAtRestFlags((candidate) => candidate === key);
+}
+
 /** Call after any write that may have landed plaintext (a locked import):
  *  the next unlock's sweep re-scans and seals it. */
 export function markAtRestSweepNeeded(): void {

--- a/frontend/src/lib/storage.ts
+++ b/frontend/src/lib/storage.ts
@@ -1,5 +1,7 @@
 import { deleteDB, openDB, type IDBPDatabase } from "idb";
 
+import { dbName } from "./quick/quick-storage";
+
 import {
   sealRow,
   openRow,
@@ -266,7 +268,7 @@ export async function getDB(): Promise<AppDB> {
 }
 
 async function openDatabase(): Promise<AppDB> {
-  db = (await openDB("awful-chat", 6, {
+  db = (await openDB(dbName(), 6, {
     async upgrade(database, oldVersion, _newVersion, transaction) {
       if (oldVersion < 1) {
         // messages
@@ -2256,7 +2258,7 @@ export async function wipeLocalDatabase(): Promise<void> {
     db = null;
   }
   invalidatePeerProfilesCache();
-  await deleteDB("awful-chat");
+  await deleteDB(dbName());
 }
 
 /** Close the cached connection without deleting anything - a

--- a/frontend/src/lib/transport/file/webtorrent.test.ts
+++ b/frontend/src/lib/transport/file/webtorrent.test.ts
@@ -170,6 +170,57 @@ describe("WebTorrentFileTransport", () => {
     }
   });
 
+  it("gives up on a link that neither connects nor fails", async () => {
+    // The STUN-only-between-two-NATs case: ICE finds no path and the peer
+    // just sits there. Nothing destroys it, so without a deadline the pair
+    // is never redialled, the transfer never fails, and the file shows a
+    // skeleton for the rest of the session.
+    vi.useFakeTimers();
+    try {
+      const t = new WebTorrentFileTransport(() => "me");
+      const reconcile = () =>
+        (t as never as { reconcileWtPeers: () => void }).reconcileWtPeers();
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      t.ensureDownload(file);
+      expect(livePeers.length).toBe(1);
+
+      // Reconciling changes nothing while the dead link is still held.
+      vi.advanceTimersByTime(20_000);
+      reconcile();
+      expect(livePeers.length).toBe(1);
+      expect(t.getTransfer(HASH)?.status).toBe("downloading");
+
+      // Past the deadline the link is dropped and dialling resumes, so the
+      // pair can finally run out of attempts.
+      for (let i = 0; i < 12; i++) {
+        vi.advanceTimersByTime(60_000);
+        reconcile();
+      }
+      expect(livePeers.length).toBe(6);
+      expect(t.getTransfer(HASH)?.status).toBe("failed");
+      expect(t.getTransfer(HASH)?.error).toBe("Could not reach the sender");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves a connected link alone when the deadline passes", async () => {
+    vi.useFakeTimers();
+    try {
+      const t = new WebTorrentFileTransport(() => "me");
+      t.onPeerConnect("alice");
+      t.registerSeeder(file, "alice");
+      t.ensureDownload(file);
+      const peer = livePeers[0] as EventEmitter & { destroyed: boolean };
+      peer.emit("connect");
+      vi.advanceTimersByTime(120_000);
+      expect(peer.destroyed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("a seeded file stays seeding whatever the torrent's done flag says", async () => {
     const t = new WebTorrentFileTransport(() => "me");
     await t.seedFiles([new File([new Uint8Array(10)], "cat.png", { type: "image/png" })]);

--- a/frontend/src/lib/transport/file/webtorrent.ts
+++ b/frontend/src/lib/transport/file/webtorrent.ts
@@ -58,6 +58,33 @@ const WT_MAX_ATTEMPTS = 6;
  * over the cap are not dropped, just deferred - the reconcile tick dials them
  * as transfers finish and slots come free.
  */
+/**
+ * How long a file link may sit unconnected before it is given up on.
+ *
+ * A SimplePeer whose ICE finds no path does not necessarily fail. With a
+ * STUN-only list between two NATs it can stay in `checking` and never emit
+ * `error` or `close` at all - and nothing else here has a clock. The link
+ * then lived for the rest of the session, which was worse than useless:
+ * dial() skips a pair that already has a peer, and allExhausted() refuses to
+ * give up while one exists, so the transfer sat at "downloading" with no
+ * error and no retry button, holding one of MAX_WT_PEERS the whole time.
+ *
+ * That is what a file over the inline limit looked like on an instance whose
+ * relay hands out no TURN (an unset TURN_SECRET answers /turn-credentials
+ * with 204): everything else worked - chat, voice, video, and any file small
+ * enough to ride inline - while anything bigger never loaded and never said
+ * why. Smaller files were fine because they never build one of these links
+ * at all; they travel inside the message, over libp2p, which has the relay
+ * circuit to fall back on. WebTorrent's own link has only TURN.
+ *
+ * Deliberately past the browser's own ICE failure detection (~15-30s), so a
+ * link the browser would have failed by itself is never cut short by this.
+ * On expiry the peer is destroyed, its close handler frees the slot, and the
+ * reconcile tick dials again - which is what lets the attempt count climb to
+ * WT_MAX_ATTEMPTS and the transfer finally say "Could not reach the sender".
+ */
+const WT_CONNECT_TIMEOUT_MS = 30_000;
+
 const MAX_WT_PEERS = 32;
 /**
  * One peer's share of that table.
@@ -733,16 +760,27 @@ export class WebTorrentFileTransport implements FileTransferTransport {
     // pair per file was the most that could ever work.
     (peer as unknown as { id: string }).id = peerId;
 
+    // Cleared by whichever of connect/error/close arrives first; the whole
+    // point is the case where none of them ever does.
+    const connectDeadline = setTimeout(() => {
+      if (this.wtPeers.get(key) !== peer) return;
+      this.wtPeers.delete(key);
+      peer.destroy();
+    }, WT_CONNECT_TIMEOUT_MS);
+
     peer.on("connect", () => {
+      clearTimeout(connectDeadline);
       this.forgetRetryState(key);
       void this.attachToTorrent(infoHash, peer);
     });
 
     peer.on("error", () => {
+      clearTimeout(connectDeadline);
       this.wtPeers.delete(key);
     });
 
     peer.on("close", () => {
+      clearTimeout(connectDeadline);
       this.wtPeers.delete(key);
     });
     return true;

--- a/frontend/src/lib/transport/files.svelte.ts
+++ b/frontend/src/lib/transport/files.svelte.ts
@@ -240,18 +240,6 @@ async function _adoptInline(
   });
 }
 
-export function isFileSignalWireMessage(
-  value: unknown
-): value is FileSignalWireMessage {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { type?: unknown }).type === "__file_signal" &&
-    typeof (value as { payload?: unknown }).payload === "object" &&
-    (value as { payload?: unknown }).payload !== null
-  );
-}
-
 export function maybePeerIdFromSenderId(senderId: string): string | null {
   const connectedPeers = _transport.peers();
   if (connectedPeers.includes(senderId)) return senderId;

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -3734,6 +3734,9 @@ export function beginConversationOpen(): () => boolean {
 
 export async function joinRoom(roomCode: string): Promise<boolean> {
   const stillCurrent = beginConversationOpen();
+  // Before the relay wait too: the chat view's overlay reads this, and a
+  // room opened while the relay was still dialling showed no sign of it.
+  transportState.connecting = true;
   if (!transportState.relayConnected) {
     await connect();
   }
@@ -3745,7 +3748,6 @@ export async function joinRoom(roomCode: string): Promise<boolean> {
   }
 
   transportState.error = null;
-  transportState.connecting = true;
   try {
     // Claim the room before the awaits, not after. Everything that routes an
     // incoming message compares against transportState.roomCode, so during the

--- a/frontend/src/lib/transport/transport.svelte.ts
+++ b/frontend/src/lib/transport/transport.svelte.ts
@@ -48,6 +48,7 @@ import {
 import { normalizeWireName } from "../wire-name";
 import {
   MessageType,
+  isFileSignalWireMessage,
   boundReactionEmoji,
   boundReplyTo,
   wireToMessage,
@@ -84,6 +85,7 @@ import { WORKLET_URL } from "../audio/worklet-url";
 import { requireSession } from "../identity/identity";
 import { deviceKeySeed } from "./device-key";
 import { acquireNodeLock, releaseNodeLock } from "./node-lock";
+import { quickSessionSeed } from "$lib/quick/session-key";
 import { looksLikeDid, looksLikePeerId } from "../identity/identity-utils";
 import {
   canonicalContentV3,
@@ -154,7 +156,6 @@ import {
   stripAndAdoptInlineFiles,
   fileFingerprint,
   initFiles,
-  isFileSignalWireMessage,
   maybePeerIdFromSenderId,
   shouldAutoDownload,
   withFileTransfer,
@@ -3630,6 +3631,18 @@ function _stepDown(): void {
   connect().catch(() => {});
 }
 
+/**
+ * A quick page (/qc) runs this whole stack beside a tab that may already be
+ * running it for the user's real account. It must therefore NOT take the one
+ * node seat, and must not connect under the device key - see session-key.ts.
+ * Set before the first connect(); there is no way back within a page.
+ */
+let _ephemeralSession = false;
+
+export function useEphemeralSession(): void {
+  _ephemeralSession = true;
+}
+
 export async function connect() {
   // The flag is not proof. A page restored from the back-forward cache, or a
   // tab the browser froze, keeps relayConnected === true over a node that is
@@ -3651,10 +3664,14 @@ export async function connect() {
       // One node per browser profile: a second tab of the same profile would
       // share this peerId and the two would starve each other (node-lock.ts).
       // Waits here, for as long as it takes, when another tab has the seat.
-      await acquireNodeLock(_nodeLockEvents);
+      // An ephemeral session has a peerId of its own, so it neither needs the
+      // seat nor may take it from the tab running the user's account.
+      if (!_ephemeralSession) await acquireNodeLock(_nodeLockEvents);
       // This device's own libp2p key, NOT the identity key: two devices on the
       // same account would otherwise share a peerId and never connect.
-      await _transport.connect(deviceKeySeed());
+      await _transport.connect(
+        _ephemeralSession ? quickSessionSeed() : deviceKeySeed()
+      );
       transportState.relayConnected = true;
       transportState.error = null;
       _connectRetryDelay = CONNECT_RETRY_BASE_MS;

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -309,6 +309,23 @@ export interface FileSignalWireMessage {
   payload: FileSignalEnvelope;
 }
 
+/**
+ * Lives with the wire type rather than in files.svelte.ts: /qs routes the same
+ * envelope with none of the app around it, and importing that module for a
+ * six-line shape check would pull the whole attachment store in with it.
+ */
+export function isFileSignalWireMessage(
+  value: unknown
+): value is FileSignalWireMessage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "__file_signal" &&
+    typeof (value as { payload?: unknown }).payload === "object" &&
+    (value as { payload?: unknown }).payload !== null
+  );
+}
+
 // ── Union ─────────────────────────────────────────────────────────────────────
 
 export type AnyWireMessage =

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -161,3 +161,12 @@ export function seededRandom(seed: string): () => number {
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
 }
+
+/** Bytes as a person reads them: `1.4 MB`. Third copy of this was the one. */
+export function formatSize(size: number): string {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  if (size < 1024 * 1024 * 1024)
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,11 +1,8 @@
 import { mount } from "svelte";
 import "./app.css";
 import App from "./App.svelte";
-import { loadRuntimeConfig, useQc } from "$lib/runtime-config";
-import {
-  sweepOrphanQuickStorage,
-  useQuickStorage,
-} from "$lib/quick/quick-storage";
+import { loadRuntimeConfig } from "$lib/runtime-config";
+import { sweepOrphanQuickStorage } from "$lib/quick/quick-storage";
 import { captureInstallPrompt } from "$lib/install-prompt.svelte";
 
 // The service worker still has exactly ONE registration: useRegisterSW inside
@@ -46,13 +43,9 @@ window.addEventListener("vite:preloadError", (event) => {
 // actually serves. A missing config.json resolves immediately.
 await loadRuntimeConfig();
 
-// BEFORE the app mounts, and before anything opens IndexedDB: /qc runs the
-// whole stack against a throwaway database and identity init opens the real
-// one on the first frame. Doing this in the component would be too late.
-// The sweep clears databases a crashed quick page left behind.
-if (window.location.pathname.replace(/\/$/, "") === "/qc" && useQc()) {
-  useQuickStorage();
-}
+// Databases a crashed quick page left behind. /qc does its OWN switch, once
+// the person has said whether they are a guest or their account - it has to
+// read the real database first to know an account is even there.
 void sweepOrphanQuickStorage();
 
 const app = mount(App, {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,7 +1,11 @@
 import { mount } from "svelte";
 import "./app.css";
 import App from "./App.svelte";
-import { loadRuntimeConfig } from "$lib/runtime-config";
+import { loadRuntimeConfig, useQc } from "$lib/runtime-config";
+import {
+  sweepOrphanQuickStorage,
+  useQuickStorage,
+} from "$lib/quick/quick-storage";
 import { captureInstallPrompt } from "$lib/install-prompt.svelte";
 
 // The service worker still has exactly ONE registration: useRegisterSW inside
@@ -41,6 +45,15 @@ window.addEventListener("vite:preloadError", (event) => {
 // them capture the build-time fallback instead of what the instance
 // actually serves. A missing config.json resolves immediately.
 await loadRuntimeConfig();
+
+// BEFORE the app mounts, and before anything opens IndexedDB: /qc runs the
+// whole stack against a throwaway database and identity init opens the real
+// one on the first frame. Doing this in the component would be too late.
+// The sweep clears databases a crashed quick page left behind.
+if (window.location.pathname.replace(/\/$/, "") === "/qc" && useQc()) {
+  useQuickStorage();
+}
+void sweepOrphanQuickStorage();
 
 const app = mount(App, {
   target: document.getElementById("app")!,


### PR DESCRIPTION
## app: two pages that need no account - /qs and /qc (1594aa9, 687fb66)

Both are behind runtime flags and off unless an instance turns them on (`APP_USE_QS` / `APP_USE_QC`, or the bare `USE_QS` / `USE_QC` an operator's .env already spells that way). Runtime configuration rather than build flags, so the bundle stays identical across instances the way runtime-config.ts intends. A disabled route falls through to the landing page: the flag is an operator's choice, not a broken link.

**/qs sends a file to one person.** Deliberately built on the two storage-free layers and nothing else - LibP2PTransport to introduce the peers, WebTorrentFileTransport for the bytes - and it does NOT import transport.svelte.ts, which would drag in the message store, the attachment store and at-rest crypto, all of which exist to remember things this page must not. Offered files sit in an in-memory Map, so "gone when the tab closes" is a property of the code rather than a cleanup routine that has to run. Nothing downloads until somebody clicks: the descriptor is the sender's claim until the bytes are hashed.

**/qc is a call, and takes the opposite trade.** Presence heartbeats, the voice roster, SFU placement and plugin call tiles are the hardest part of this codebase and all of it reads the app's own stores, so /qc runs the real stack and makes the two things that must not persist ephemeral instead: a keypair held only in memory (`createEphemeralIdentity`, which activates a session exactly as an unlock does but writes nothing), and a database named for the page and deleted on pagehide (quick-storage.ts, with a Web-Lock sweep for pages that crashed). It hands over to ChatView rather than rendering a call view of its own, so the message list, the composer, the plugin slash commands and VoiceVideoCallView all arrive together - a quick call is a room nobody keeps, so it works like one.

**You can call as the account this device already has.** /qc asks who to be when there is an identity here. The account path unlocks with the app's own screen, copies the whole profile ROW into the throwaway database - the row, not the display store, because an uploaded avatar is bytes and a `blob:` URL means nothing to the other side - and runs the call under your real DID, with your name, colour and tag. The call itself stays disposable: it never joins your saved rooms and its database goes with the tab. That is why the storage switch lives in the page rather than main.ts: it has to read the real database to know an account is there, then switches and closes the cached handle. Nothing may join before that switch, so `startQuickCall` refuses outright rather than joining - that is the one path that would write a call into the real database.

**Codes are ten characters**, shown as `XXX-XXXX-XXX`. Rooms are permanent and their codes are worth grinding for; a call or a file hand-off is alive for hours and then names nothing. At a wildly generous 10,000 guesses a second against the relay's rendezvous - there is no offline oracle - a four-hour attack has one chance in eight thousand of landing on ANY live session across a thousand of them. Eight characters is where that stops holding, at 13%, which is why it is not shorter still. A quick code is a different LENGTH from a room code rather than a different alphabet, so neither parser can be handed the other's input: a link carrying a room code is refused instead of joining a real room with it.

Both pages connect under a random per-page libp2p key (session-key.ts) and take no node seat. Two nodes in one profile is fine; two nodes sharing one peerId is the reconnect loop from the 2026-09-04 and 09-06 diag packs - and a quick page has to run beside a tab already signed in. The key is minted once and reused, not generated per connect(), or a relay bounce would turn you into a stranger mid-transfer. Both pages use the app's own card, mono type, avatar ring and checkbox rather than a second visual language living at two URLs.

Also: an ephemeral identity no longer leaves its at-rest sweep marker in localStorage, scoped to the identity that page used so an account's own marker survives and its next unlock does not re-sweep. `formatSize` moves to utils (the third copy was the one) and `isFileSignalWireMessage` moves next to its wire type so /qs can route the envelope without pulling the attachment store in with it.

## files: a link that neither connects nor fails is given up on (41f3782)

Reported from a real instance: files over 512 KB never loaded in an ordinary room, forever, with no error.

That limit is where a file stops riding inside the message over libp2p and starts needing its own WebRTC link - the only thing in the app that does. Chat, voice, video and smaller files have the relay circuit or the SFU to fall back on; WebTorrent's link has only TURN. Between two NATs with a STUN-only ICE list that link does not fail: it sits in `checking` and never emits `error` or `close`. Nothing had a clock on it, so it stayed in wtPeers for the session, and both recovery mechanisms read it as healthy - `dial()` skips a pair that already has a peer, and `allExhausted()` refuses to give up while one exists. The transfer therefore stayed "downloading" with no error and no retry button, holding one of the 32 link slots. The existing exhaustion test could not see any of it because it destroys each peer by hand, which is the case that does emit close.

A link now has 30 seconds to connect, past the browser's own ICE failure detection so one it would have failed by itself is never cut short. On expiry the peer is destroyed, its close handler frees the slot, the reconcile tick dials again, and the attempt count can finally reach WT_MAX_ATTEMPTS and say "Could not reach the sender" with a button that starts the count over. The new test fails without the fix (one link, forever, transfer never fails) and passes with it.

This makes the failure visible and recoverable; it does not make the file arrive. The underlying cause on an affected instance is likely that its relay hands out no TURN - an unset `TURN_SECRET` answers `/turn-credentials` with 204 and the client stays STUN-only, which is exactly this symptom and nothing else.

## app: opening a room changes the screen on the click, not after the join (49f5622)

Already on dev before the above. Clicking a room did nothing visible until the join had decrypted the history, read the roster and broadcast the profile. The view now switches on the click and backs out if the join fails or loses to a newer click; on a phone the drawer closes on the tap too.

---

Typecheck clean; 1621 frontend tests pass; relay tests pass. e2e against a local relay and two headless browsers: quick-send, quick-send-alongside-app, quick-call, quick-call-alongside-app, quick-call-account and large-file all pass. The quick-* scenarios need the routes enabled on the dev server (`VITE_USE_QS=true VITE_USE_QC=true`) and say so if they are not.