### PR TITLE
Dev to main: a multi-peer /qs with a one-time switch, /qc that speaks and cleans up, and both pages findable

### DIFF
--- a/frontend/e2e/run-all.sh
+++ b/frontend/e2e/run-all.sh
@@ -12,7 +12,7 @@ SCENARIOS="dm-extras sync-recovers dm-removal title-and-sound dtln-gain clock-sk
 room-removal reconnect-churn audio-prefs peer-volume background-sync rapid-switch
 drag-drop room-clock backfill-below-window call-status call-roster-ttl
 call-late-join call-join-speed call-without-sfu relay-upgrade history-pull mobile-shell
-device-sync quick-send quick-send-alongside-app quick-call
+device-sync quick-send quick-send-swarm quick-send-once quick-send-alongside-app quick-call
 quick-call-alongside-app quick-call-account"
 # The quick-* scenarios need their routes turned on: start the dev server with
 # VITE_USE_QS=true VITE_USE_QC=true, or they fail saying so.

--- a/frontend/e2e/scenarios/quick-call-live.mjs
+++ b/frontend/e2e/scenarios/quick-call-live.mjs
@@ -128,8 +128,13 @@ try {
     alice.eval(`window.__qc.state.stage === 'ended'`)
   );
   check.ok(
-    await alice.eval(`document.body.innerText.includes('Call ended')`),
-    "and the page says the call ended"
+    await alice.eval(`document.body.innerText.includes('You left the call')`),
+    "and the page says SHE left, not that the call is over for everyone"
+  );
+  // Which it is not: bob is still in it.
+  check.ok(
+    await bob.eval(`window.__awful.state.inCall === true`),
+    "bob is still in the call the host walked out of"
   );
 
   // The bytes, gone. Not "gone when the tab closes" - gone now.

--- a/frontend/e2e/scenarios/quick-call-live.mjs
+++ b/frontend/e2e/scenarios/quick-call-live.mjs
@@ -109,7 +109,13 @@ try {
   }, { timeout: 60_000 });
   check.ok(heardAgain.tracked.length > 0, "detection survived the reload", heardAgain);
 
-  // Hanging up is a decision: a reload after it must not walk back in.
+  // Hanging up takes the call with it: the chat, and the database it lived in.
+  const dbs = `indexedDB.databases().then((d) => JSON.stringify(
+    d.map((x) => x.name).filter((n) => n && n.startsWith('awful-quick-'))))`;
+  const during = await alice.json(dbs);
+  check.equal(during.length, 1, "the call has a database while it runs", during);
+  const callDb = await alice.eval(`window.__qc.dbName()`);
+
   // ChatView puts leaving behind a two-click confirm, and a quick call is not
   // a room anybody is deleting, so it says so.
   check.ok(
@@ -118,10 +124,35 @@ try {
   );
   await sleep(300);
   await alice.clickLabel("Leave call");
-  await alice.waitFor("alice leaves", () =>
-    alice.eval(`window.__qc.state.stage !== 'in-call'`)
+  await alice.waitFor("the call ends", () =>
+    alice.eval(`window.__qc.state.stage === 'ended'`)
   );
-  await sleep(1500);
+  check.ok(
+    await alice.eval(`document.body.innerText.includes('Call ended')`),
+    "and the page says the call ended"
+  );
+
+  // The bytes, gone. Not "gone when the tab closes" - gone now.
+  //
+  // What may remain is the EMPTY scope the drop rotates to, because leaveRoom
+  // finishes asynchronously and its participant removal has to land somewhere
+  // disposable rather than in the user's real database. So the promise is
+  // about the database the call actually wrote to, by name.
+  const left = await alice.waitFor("the call's database goes with it", async () => {
+    const names = await alice.json(dbs);
+    return names.includes(callDb) ? null : names;
+  }, { timeout: 30_000 });
+  check.ok(!left.includes(callDb), "nothing the call wrote survived it", {
+    callDb,
+    left,
+  });
+  check.ok(
+    left.every((n) => n !== callDb),
+    "and whatever is left is a different, empty scope",
+    left
+  );
+
+  // And a reload lands on a fresh page rather than walking back in.
   await alice.bidi.send("browsingContext.reload", {
     context: alice.bidi.context,
     wait: "complete",

--- a/frontend/e2e/scenarios/quick-call-live.mjs
+++ b/frontend/e2e/scenarios/quick-call-live.mjs
@@ -110,10 +110,14 @@ try {
   check.ok(heardAgain.tracked.length > 0, "detection survived the reload", heardAgain);
 
   // Hanging up is a decision: a reload after it must not walk back in.
-  // ChatView puts leaving behind a two-click confirm.
-  check.ok(await alice.clickLabel("Delete room"), "the leave control is there");
+  // ChatView puts leaving behind a two-click confirm, and a quick call is not
+  // a room anybody is deleting, so it says so.
+  check.ok(
+    await alice.clickLabel("Leave call"),
+    "the leave control says what it does"
+  );
   await sleep(300);
-  await alice.clickLabel("Delete room");
+  await alice.clickLabel("Leave call");
   await alice.waitFor("alice leaves", () =>
     alice.eval(`window.__qc.state.stage !== 'in-call'`)
   );

--- a/frontend/e2e/scenarios/quick-call-live.mjs
+++ b/frontend/e2e/scenarios/quick-call-live.mjs
@@ -116,15 +116,15 @@ try {
   check.equal(during.length, 1, "the call has a database while it runs", during);
   const callDb = await alice.eval(`window.__qc.dbName()`);
 
-  // ChatView puts leaving behind a two-click confirm, and a quick call is not
-  // a room anybody is deleting, so it says so.
+  // The red hang-up in the call bar, which is the button a person reaches
+  // for. In a room it leaves the CALL and keeps the conversation; here it has
+  // to end the whole thing, the way every other call app does - and on one
+  // click, because an unsignposted confirm reads as a button that is broken.
   check.ok(
     await alice.clickLabel("Leave call"),
-    "the leave control says what it does"
+    "the hang-up is where a person looks for it"
   );
-  await sleep(300);
-  await alice.clickLabel("Leave call");
-  await alice.waitFor("the call ends", () =>
+  await alice.waitFor("the call ends on one click", () =>
     alice.eval(`window.__qc.state.stage === 'ended'`)
   );
   check.ok(

--- a/frontend/e2e/scenarios/quick-call-live.mjs
+++ b/frontend/e2e/scenarios/quick-call-live.mjs
@@ -1,0 +1,135 @@
+/**
+ * Two things /qc got wrong that the app gets right, because /qc mounts no
+ * AppView and a page load is not the same thing twice.
+ *
+ * 1. The speaking ring. Detection is fed by an effect that lived in AppView,
+ *    so a quick call had every part of the indicator except the thing that
+ *    drives it, and nobody ever lit up. What is checked here is that the
+ *    analyser is being FED - whether a ring visibly lights needs an audible
+ *    microphone and an AudioContext the browser has allowed to run, and a
+ *    headless run has neither (the app scores an empty `speaking` set in this
+ *    harness too). An empty `tracked` while a call is up is the actual bug:
+ *    nobody calling updateSpeakerTracks at all.
+ *
+ * 2. A refresh. It used to be a silent eviction: a new identity, back on the
+ *    setup card being told you had been "invited" to the call you started,
+ *    and a ghost of you left in everyone else's roster. It should be a
+ *    reconnect - same person, straight back in.
+ */
+import { Peer, closeAll, sleep } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("a quick call speaks and survives a refresh");
+const alice = new Peer(9307, "Alice");
+const bob = new Peer(9308, "Bob");
+
+const state = `JSON.stringify({
+  stage: window.__qc?.state.stage,
+  code: window.__qc?.state.code,
+  did: window.__qc?.did(),
+  inCall: !!window.__awful?.state.inCall,
+  callPeers: [...(window.__awful?.state.callPeerIds ?? [])].length,
+  names: [...(window.__awful?.state.peerNames?.values() ?? [])],
+})`;
+
+async function join(peer, name) {
+  await peer.waitFor(`${name} reaches the setup screen`, () =>
+    peer.eval(`window.__qc?.state.stage === 'setup'`)
+  );
+  if (!(await peer.fill("Your display name", name))) {
+    throw new Error(`${name}: no name field`);
+  }
+  await peer.clickText("Join call");
+  await peer.waitFor(`${name} is in the call`, async () => {
+    const s = await peer.json(state);
+    if (s.stage === "failed") throw new Error(await peer.eval(`window.__qc.state.error`));
+    return s.stage === "in-call";
+  }, { timeout: 60_000 });
+}
+
+try {
+  await alice.start();
+  await bob.start();
+
+  await alice.go("/qc");
+  const code = await alice.waitFor("alice gets a code", () =>
+    alice.eval(`window.__qc?.state.code || null`)
+  );
+
+  // The host, before joining: a refresh here must not tell them they were
+  // invited to their own call.
+  check.ok(
+    await alice.eval(`document.body.innerText.includes('Send the link')`),
+    "the host is told it is their call"
+  );
+
+  await join(alice, "Alice");
+  await bob.go(`/qc#${code}`);
+  await join(bob, "Bob");
+  await alice.waitFor("the two are in one call", () =>
+    alice.eval(`[...window.__awful.state.callPeerIds].length >= 1`),
+    { timeout: 90_000 }
+  );
+
+  const heard = await alice.waitFor("the analyser is fed", async () => {
+    const s = await alice.json(`JSON.stringify(window.__speakers())`);
+    return s.tracked.length ? s : null;
+  }, { timeout: 60_000 });
+  check.ok(heard.tracked.length > 0, "the speaking ring has something to light", heard);
+
+  const before = await alice.json(state);
+
+  // A real reload, not a same-document hash navigation.
+  await alice.bidi.send("browsingContext.reload", {
+    context: alice.bidi.context,
+    wait: "complete",
+  });
+
+  const after = await alice.waitFor("alice walks back into the call", async () => {
+    const s = await alice.json(state);
+    if (s.stage === "failed") throw new Error(await alice.eval(`window.__qc.state.error`));
+    return s.stage === "in-call" ? s : null;
+  }, { timeout: 90_000 });
+
+  check.equal(after.code, before.code, "the same call");
+  check.equal(after.did, before.did, "as the same person, so no ghost is left behind");
+  check.ok(after.inCall, "and actually in it, without asking anything again");
+
+  // The other side sees a reconnect, not a stranger: one peer, still named.
+  const bobSees = await bob.waitFor("bob still has exactly one peer", async () => {
+    const s = await bob.json(state);
+    return s.callPeers === 1 && s.names.includes("Alice") ? s : null;
+  }, { timeout: 90_000 });
+  check.equal(bobSees.callPeers, 1, "no duplicate of alice appeared", bobSees);
+
+  // And the page that came back is feeding it too.
+  const heardAgain = await alice.waitFor("the analyser is fed after the reload", async () => {
+    const s = await alice.json(`JSON.stringify(window.__speakers())`);
+    return s.tracked.length ? s : null;
+  }, { timeout: 60_000 });
+  check.ok(heardAgain.tracked.length > 0, "detection survived the reload", heardAgain);
+
+  // Hanging up is a decision: a reload after it must not walk back in.
+  // ChatView puts leaving behind a two-click confirm.
+  check.ok(await alice.clickLabel("Delete room"), "the leave control is there");
+  await sleep(300);
+  await alice.clickLabel("Delete room");
+  await alice.waitFor("alice leaves", () =>
+    alice.eval(`window.__qc.state.stage !== 'in-call'`)
+  );
+  await sleep(1500);
+  await alice.bidi.send("browsingContext.reload", {
+    context: alice.bidi.context,
+    wait: "complete",
+  });
+  await sleep(4000);
+  const afterLeave = await alice.json(state);
+  check.ok(
+    afterLeave.stage !== "in-call",
+    "a reload after leaving stays out",
+    afterLeave
+  );
+} finally {
+  check.finish();
+  await closeAll([alice, bob]);
+}

--- a/frontend/e2e/scenarios/quick-send-once.mjs
+++ b/frontend/e2e/scenarios/quick-send-once.mjs
@@ -1,0 +1,105 @@
+/**
+ * A one-time /qs link is dead after it delivers.
+ *
+ * The mirror image of quick-send-swarm.mjs, and the assertion that matters is
+ * the negative one: Alice offers with the one-time switch on, Bob takes the
+ * file, and Carol - who arrives afterwards with the same link, while Alice's
+ * page is still open - is offered nothing at all. Bob has the bytes and does
+ * not serve them; Alice has left the room.
+ */
+import { Peer, closeAll, sleep } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("a one-time quick send closes after it delivers");
+const alice = new Peer(9307, "Alice");
+const bob = new Peer(9308, "Bob");
+const carol = new Peer(9309, "Carol");
+
+const qsState = `(() => JSON.stringify({
+  status: window.__qs?.state.status ?? 'none',
+  code: window.__qs?.state.code ?? '',
+  peers: window.__qs?.state.peers ?? 0,
+  mode: window.__qs?.state.mode ?? '',
+  heardMode: window.__qs?.state.heardMode ?? '',
+  closed: !!window.__qs?.state.closed,
+  incoming: (window.__qs?.state.incoming ?? []).map((f) => f.infoHash),
+  transfers: [...(window.__qs?.state.transfers ?? new Map()).values()].map((t) => ({
+    h: t.infoHash, status: t.status, progress: t.progress, seeding: !!t.seeding,
+  })),
+}))()`;
+
+try {
+  await alice.start();
+  await bob.start();
+  await carol.start();
+
+  await alice.go("/qs");
+  const code = await alice.waitFor("alice gets a code", () =>
+    alice.eval(`window.__qs?.state.status === 'ready' ? window.__qs.state.code : null`)
+  );
+
+  // The switch, through the DOM: it is the thing being shipped.
+  const flipped = await alice.eval(`(() => {
+    const box = [...document.querySelectorAll('input[type=checkbox]')][0];
+    if (!box) return false;
+    box.click();
+    return true;
+  })()`);
+  check.ok(flipped, "the one-time switch is on the page");
+  check.equal(await alice.eval(`window.__qs.state.mode`), "once", "it turns the link one-time");
+
+  await alice.eval(`(async () => {
+    const bytes = new Uint8Array(700 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 17) & 0xff;
+    await window.__qs.offerFiles([new File([bytes], 'secret.bin')]);
+    return true;
+  })()`);
+
+  await bob.go(`/qs#${code}`);
+  const offered = await bob.waitFor("bob is offered the file", async () => {
+    const s = await bob.json(qsState);
+    return s.incoming.length ? s.incoming[0] : null;
+  }, { timeout: 60_000 });
+  check.equal(
+    await bob.eval(`window.__qs.state.heardMode`),
+    "once",
+    "bob is told the link is one-time"
+  );
+
+  await bob.eval(`window.__qs.acceptFile(${JSON.stringify(offered)})`);
+  const bobGot = await bob.waitFor("bob completes the download", async () => {
+    const s = await bob.json(qsState);
+    const t = s.transfers.find((t) => t.h === offered);
+    if (!t || (t.status !== "complete" && t.status !== "seeding" && t.status !== "failed")) {
+      return null;
+    }
+    return t;
+  }, { timeout: 90_000 });
+  check.ok(bobGot.status !== "failed" && bobGot.progress >= 1, "bob got the file", bobGot);
+  check.equal(bobGot.seeding, false, "bob does not serve it on");
+
+  // Alice's page is STILL OPEN - what closes the link is the delivery.
+  const closed = await alice.waitFor("alice's link closes itself", async () => {
+    const s = await alice.json(qsState);
+    return s.closed ? s : null;
+  }, { timeout: 30_000 });
+  check.equal(closed.status, "closed", "the link reports itself closed");
+  check.ok(
+    await alice.eval(`document.body.innerText.includes('this link is closed')`),
+    "and says so on the page"
+  );
+
+  // Carol arrives with a link that used to work. Give the room every chance
+  // to offer her something - a miss has to be a real miss, not impatience.
+  await carol.go(`/qs#${code}`);
+  await carol.waitFor("carol's page is up", () =>
+    carol.eval(`window.__qs?.state.status === 'ready'`)
+  );
+  await sleep(20_000);
+  const carolState = await carol.json(qsState);
+  check.equal(carolState.incoming.length, 0, "carol is offered nothing", carolState);
+  check.equal(carolState.transfers.length, 0, "and pulls nothing", carolState);
+} finally {
+  check.finish();
+  await closeAll([alice, bob, carol]);
+}

--- a/frontend/e2e/scenarios/quick-send-swarm.mjs
+++ b/frontend/e2e/scenarios/quick-send-swarm.mjs
@@ -1,0 +1,100 @@
+/**
+ * /qs is multi-peer: the link is a swarm, not a queue at the sender.
+ *
+ * The claim being tested is the one that actually matters, and it is not
+ * "three people can download" - it is that the SENDER CAN LEAVE. Alice offers
+ * a file, Bob takes it, Alice closes her page entirely, and only then does
+ * Carol arrive. The bytes Carol gets can only have come from Bob.
+ */
+import { Peer, closeAll, sleep } from "../driver.mjs";
+import { Check } from "../assert.mjs";
+
+const check = new Check("a quick send survives the sender leaving");
+const alice = new Peer(9307, "Alice");
+const bob = new Peer(9308, "Bob");
+const carol = new Peer(9309, "Carol");
+
+const qsState = `(() => JSON.stringify({
+  status: window.__qs?.state.status ?? 'none',
+  code: window.__qs?.state.code ?? '',
+  peers: window.__qs?.state.peers ?? 0,
+  incoming: (window.__qs?.state.incoming ?? []).map((f) => ({ h: f.infoHash, n: f.filename })),
+  transfers: [...(window.__qs?.state.transfers ?? new Map()).values()].map((t) => ({
+    h: t.infoHash, status: t.status, progress: t.progress, seeding: !!t.seeding,
+    seeders: t.seeders ?? 0, error: t.error ?? null,
+  })),
+}))()`;
+
+/** Take the one file on offer and wait for it to land. */
+async function receive(peer, name) {
+  const offered = await peer.waitFor(`${name} is offered the file`, async () => {
+    const s = await peer.json(qsState);
+    return s.incoming.length ? s.incoming[0] : null;
+  }, { timeout: 60_000 });
+  await peer.eval(`window.__qs.acceptFile(${JSON.stringify(offered.h)})`);
+  return peer.waitFor(`${name} completes the download`, async () => {
+    const s = await peer.json(qsState);
+    const t = s.transfers.find((t) => t.h === offered.h);
+    if (!t || (t.status !== "complete" && t.status !== "seeding" && t.status !== "failed")) {
+      return null;
+    }
+    return t;
+  }, { timeout: 90_000 });
+}
+
+try {
+  await alice.start();
+  await bob.start();
+  await carol.start();
+
+  await alice.go("/qs");
+  const code = await alice.waitFor("alice gets a code", () =>
+    alice.eval(`window.__qs?.state.status === 'ready' ? window.__qs.state.code : null`)
+  );
+
+  // Over the inline limit, so this is a real WebTorrent transfer.
+  await alice.eval(`(async () => {
+    const bytes = new Uint8Array(700 * 1024);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 13) & 0xff;
+    await window.__qs.offerFiles([new File([bytes], 'party.bin')]);
+    return true;
+  })()`);
+
+  await bob.go(`/qs#${code}`);
+  const bobGot = await receive(bob, "Bob");
+  check.ok(bobGot.status !== "failed" && bobGot.progress >= 1, "bob got it from alice", bobGot);
+
+  // Bob serves it on: that is what makes the next arrival possible.
+  const bobSeeding = await bob.waitFor("bob starts sharing it on", async () => {
+    const s = await bob.json(qsState);
+    return s.transfers.some((t) => t.seeding) ? s : null;
+  }, { timeout: 30_000 });
+  check.ok(bobSeeding !== null, "bob is seeding what he received");
+
+  // Alice leaves. Not a background tab - the page is gone, its transport
+  // disconnected and its in-memory copy of the file with it.
+  await alice.go("/");
+  await alice.waitFor("alice's page is gone", () =>
+    alice.eval(`!window.__qs || window.__qs.state.status === 'idle'`)
+  );
+  await sleep(3000);
+
+  // Only now does Carol arrive, so nothing she gets can have come from Alice.
+  await carol.go(`/qs#${code}`);
+  const carolGot = await receive(carol, "Carol");
+  check.ok(
+    carolGot.status !== "failed" && carolGot.progress >= 1,
+    "carol got it with the sender gone",
+    carolGot
+  );
+
+  // And she now serves it too, so the swarm outlives any one member.
+  const carolSeeding = await carol.waitFor("carol shares it on as well", async () => {
+    const s = await carol.json(qsState);
+    return s.transfers.some((t) => t.seeding);
+  }, { timeout: 30_000 });
+  check.ok(carolSeeding, "every finished receiver becomes a source");
+} finally {
+  check.finish();
+  await closeAll([alice, bob, carol]);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,6 +141,22 @@
           },
           {
             "@type": "Question",
+            "name": "Can I send someone a file without either of us having an account?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Open /qs, drop the file in and send the short link it gives you. The file goes straight to whoever opens it over an encrypted peer-to-peer connection, so it is never uploaded to a server and nothing caps its size but your own machine. Everyone holding the link shares what they have already finished, so sending something large to a group does not mean uploading it once per person, and you can close the tab once somebody has it. There is also a one-time switch that closes the link the moment it has delivered."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I start a video call without signing up?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Open /qc and send the link. Whoever opens it picks a name and joins: camera, screen share, text chat and the same apps that run in any other room. Voice is peer-to-peer. Nothing about the call is kept - close the tab and the call, its chat and the throwaway identity it ran under are all gone, and it never appears in anybody's saved rooms."
+            }
+          },
+          {
+            "@type": "Question",
             "name": "Is it really free and open source?",
             "acceptedAnswer": {
               "@type": "Answer",

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -12,6 +12,17 @@ of it. Voice calls are fully peer-to-peer. Group video and
 screen share are routed through a mediasoup SFU. Files transfer via
 WebTorrent between peers.
 
+Two pages skip the app and the identity entirely, when an instance enables
+them (USE_QS / USE_QC):
+- /qs - hand a file to one person or several. The bytes go peer-to-peer over
+  WebTorrent and are never uploaded to a server. Everyone holding the link
+  seeds what they have finished, so the sender can leave once somebody has it.
+  A one-time switch closes the link as soon as it has delivered.
+- /qc - a call with no room and no account: camera, screen share, text chat
+  and plugins, under a throwaway identity in a database deleted when the tab
+  closes. An existing identity on the device can be used instead, and the call
+  is still disposable.
+
 Key properties:
 - No sign-up: create an identity locally, back it up with 12 words
 - End-to-end encrypted messaging (noise protocol between peers)

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -5,4 +5,22 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <!--
+    The two pages that need no account. Listed because awful.chat serves
+    them; an instance that leaves USE_QS / USE_QC unset answers these paths
+    with the landing page instead, so drop these two entries when self-hosting
+    without them. Everything else here is already awful.chat-specific (the
+    canonical link and og:url in index.html name it outright), so this is no
+    less portable than the rest.
+  -->
+  <url>
+    <loc>https://awful.chat/qs</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://awful.chat/qc</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import { ensurePushSubscription } from "$lib/push.svelte";
   import { parseRoomCode } from "$lib/palette/query";
   import { useQc, useQs } from "$lib/runtime-config";
+  import { applyRouteMeta } from "$lib/page-meta";
   import QuickSend from "$lib/components/QuickSend.svelte";
   import QuickCall from "$lib/components/QuickCall.svelte";
 
@@ -110,6 +111,9 @@
     } else {
       currentRoute = "landing";
     }
+    // /qs and /qc are the only routes worth finding from a search, so they
+    // say who they are instead of canonicalising to the root - see page-meta.
+    applyRouteMeta(currentRoute);
   });
 
   function handlePopState() {
@@ -129,6 +133,7 @@
     } else {
       currentRoute = "landing";
     }
+    applyRouteMeta(currentRoute);
   }
 </script>
 

--- a/frontend/src/Landing.svelte
+++ b/frontend/src/Landing.svelte
@@ -1,9 +1,25 @@
 <script lang="ts">
+  import { useQc, useQs } from "$lib/runtime-config";
+
   let currentSection = $state("");
+
+  // Both are optional pages an operator turns on, so everything about them on
+  // this page - the nav entry, the section, the FAQ answers - is conditional.
+  // An instance that does not serve them must not advertise them.
+  const quickAny = useQs() || useQc();
+
+  /**
+   * The sections are numbered in sequence and 04 only exists when the optional
+   * pages do, so everything after it shifts up by one when they are off.
+   * Takes the number the section has WITH them, which is the order on screen.
+   */
+  const sectionNo = (withQuick: number) =>
+    String(quickAny ? withQuick : withQuick - 1).padStart(2, "0");
 
   const navLinks = [
     { href: "#hero", label: "Awful.chat", accent: true },
     { href: "#features", label: "Features" },
+    ...(useQs() || useQc() ? [{ href: "#quick", label: "No account" }] : []),
     { href: "#stack", label: "Stack" },
     { href: "#deploy", label: "Deploy" },
     { href: "#faq", label: "FAQ" },
@@ -45,6 +61,22 @@
       q: "What if I lose my seed phrase?",
       a: "It is gone, and so is the identity - there is no reset email because there is no account. Back up the 12 words; syncing a second device via QR code also works as a backup.",
     },
+    ...(useQs()
+      ? [
+          {
+            q: "Can I send someone a file without either of us having an account?",
+            a: "Yes. Open /qs, drop the file in and send the short link it gives you. The file goes straight to whoever opens it over an encrypted peer-to-peer connection, so it is never uploaded to a server and nothing caps its size but your own machine. Everyone holding the link shares what they have already finished, so sending something large to a group does not mean uploading it once per person, and you can close the tab once somebody has it. There is also a one-time switch that closes the link the moment it has delivered, for when the link might outlive the handover.",
+          },
+        ]
+      : []),
+    ...(useQc()
+      ? [
+          {
+            q: "Can I start a video call without signing up?",
+            a: "Yes. Open /qc and send the link. Whoever opens it picks a name, or takes the one it remembers from last time, and joins: camera, screen share, text chat and the same apps that run in any other room here. Voice is peer-to-peer. Nothing about the call is kept - close the tab and the call, its chat and the throwaway identity it ran under are all gone, and it never appears in anybody's saved rooms. If you already have an identity on the device you can call as yourself instead, and the call is still disposable.",
+          },
+        ]
+      : []),
     {
       q: "Is it really free and open source?",
       a: "Yes. Apache-2.0, source on GitHub, no premium tier, no data harvesting to pay for it.",
@@ -440,9 +472,66 @@
   </section>
 
   <!-- Stack Section -->
+  <!-- Optional pages, so the whole section is conditional. -->
+  {#if quickAny}
+    <section id="quick" class="section-center">
+      <div class="container">
+        <div class="section-num">04 - NO ACCOUNT</div>
+        <h2 class="display-large section-title">
+          Nothing to sign<br /><span class="text-accent">up for.</span>
+        </h2>
+        <p class="section-desc">
+          Two pages that skip the app entirely. Open one, send the link, done.
+          Neither asks for an account, an email or a name you do not feel like
+          giving, and neither leaves anything behind on this device once the
+          tab is closed.
+        </p>
+        <div class="grid-2col" style="margin-top: 3rem; text-align: left;">
+          {#if useQs()}
+            <div>
+              <div class="bento-category font-mono">/qs</div>
+              <div class="bento-title">Send a file</div>
+              <p class="bento-desc text-muted">
+                Drop a file in and send one short link. The bytes go straight
+                to whoever opens it over an encrypted peer-to-peer connection:
+                nothing is uploaded to a server, nothing is scanned, and there
+                is no size limit anyone else decided. Everyone holding the link
+                shares what they have finished, so a big file reaches a group
+                without you uploading it once per person, and you can close the
+                tab as soon as somebody has it. Or make it a one-time link that
+                closes itself the moment it has delivered.
+              </p>
+              <a href="/qs" class="btn btn-outline" style="margin-top: 1.5rem;">
+                Send a file &rarr;
+              </a>
+            </div>
+          {/if}
+          {#if useQc()}
+            <div>
+              <div class="bento-category font-mono">/qc</div>
+              <div class="bento-title">Start a call</div>
+              <p class="bento-desc text-muted">
+                A link, a name if you want one, and you are in a call: camera,
+                screen share, text chat and the same apps that run in any other
+                room here. Voice goes peer-to-peer. Nothing about it is kept,
+                so when the tab closes the call and its chat are gone, and it
+                never appears in anybody's saved rooms. Already have an
+                identity on this device? You can call as yourself instead, and
+                the call stays just as disposable.
+              </p>
+              <a href="/qc" class="btn btn-outline" style="margin-top: 1.5rem;">
+                Start a call &rarr;
+              </a>
+            </div>
+          {/if}
+        </div>
+      </div>
+    </section>
+  {/if}
+
   <section id="stack" class="section-padded">
     <div class="container">
-      <div class="section-num">04 - STACK</div>
+      <div class="section-num">{sectionNo(5)} - STACK</div>
       <h2 class="display-large section-title">
         Built for the<br /><span class="text-accent">privacy concerned.</span>
       </h2>
@@ -466,7 +555,7 @@
   <!-- Self-host Section -->
   <section id="deploy" class="section-center">
     <div class="container">
-      <div class="section-num">05 - DEPLOY</div>
+      <div class="section-num">{sectionNo(6)} - DEPLOY</div>
       <div class="grid-2col">
         <div>
           <h2 class="display-large">
@@ -524,7 +613,7 @@
   <!-- FAQ Section -->
   <section id="faq" class="section-center">
     <div class="container">
-      <div class="section-num">06 - FAQ</div>
+      <div class="section-num">{sectionNo(7)} - FAQ</div>
       <h2 class="display-large section-title">
         Common<br /><span class="text-accent">questions.</span>
       </h2>

--- a/frontend/src/lib/call-speakers.ts
+++ b/frontend/src/lib/call-speakers.ts
@@ -1,0 +1,86 @@
+/**
+ * The bridge between call state and speaker detection.
+ *
+ * speakers.svelte.ts is deliberately a leaf - it takes participant state as
+ * arguments rather than importing the transport, so it can be tested without
+ * bootstrapping media streams - which means somebody has to feed it. That was
+ * an effect inside AppView, and /qc does not mount AppView: it renders
+ * ChatView directly. So a quick call had every part of the speaking indicator
+ * except the thing that drives it, and nobody's ring ever lit up.
+ *
+ * Living here rather than being copied into the second shell: there is one
+ * correct way to feed the analyser and it should not be written twice.
+ */
+
+import {
+  _trackedSpeakers,
+  resumeAudioContextOnVisibilityChange,
+  speakers,
+  stopAllSpeakers,
+  updateSpeakerTracks,
+} from "$lib/speakers.svelte";
+import { selfId, transportState } from "$lib/transport/transport.svelte";
+import { callPipPanel } from "$lib/call-pip.svelte";
+import { exitBrowserPip } from "$lib/call-spotlight.svelte";
+
+/**
+ * Hand the analyser whoever is currently in the call.
+ *
+ * Call this from an `$effect` in whichever shell is mounted; every read below
+ * registers as a dependency, so it re-runs when the roster, the mute state or
+ * the local mic changes. Detection follows the CALL, not the stage: the tiles
+ * unmount when the user navigates away from the call room, and the floating
+ * panel still has to show who is talking.
+ */
+export function syncSpeakersFromCall(): void {
+  if (!transportState.inCall) {
+    stopAllSpeakers();
+    return;
+  }
+  // null to undefined, for the leaf module's narrower argument type.
+  const participants = new Map(
+    Array.from(transportState.participants).map(([peerId, p]) => [
+      peerId,
+      {
+        audioTrack: p.audioTrack ?? undefined,
+        videoTrack: p.videoTrack ?? undefined,
+        screenTrack: p.screenTrack ?? undefined,
+        screenAudioTrack: p.screenAudioTrack ?? undefined,
+      },
+    ])
+  );
+  updateSpeakerTracks(
+    participants,
+    transportState.muted,
+    transportState.localMicStream,
+    selfId()
+  );
+}
+
+let watching = false;
+
+/**
+ * Resume the audio context when the tab comes back, and close the browser PiP
+ * the tab switch opened - the call is on screen again.
+ *
+ * Idempotent, and never removed: it is one listener for the life of the page,
+ * and two shells that both mount would otherwise register two.
+ */
+export function watchVisibilityForCall(): void {
+  if (watching || typeof document === "undefined") return;
+  watching = true;
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden || !transportState.inCall) return;
+    resumeAudioContextOnVisibilityChange();
+    if (callPipPanel.browserPip) void exitBrowserPip();
+  });
+}
+
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  // Dev-only handle. Whether the ring lights up is only observable with a
+  // real microphone and a real call, which is what the e2e browsers have.
+  (window as unknown as Record<string, unknown>).__speakers = () => ({
+    speaking: [...speakers.speaking],
+    tracked: _trackedSpeakers(),
+  });
+}

--- a/frontend/src/lib/components/AppView.svelte
+++ b/frontend/src/lib/components/AppView.svelte
@@ -68,7 +68,10 @@
   import FloatingDmPanel from "$lib/components/FloatingDmPanel.svelte";
   import CallPipPanel from "$lib/components/CallPipPanel.svelte";
   import { normalizeRoomCode } from "$lib/room-code";
-  import { updateSpeakerTracks, stopAllSpeakers, resumeAudioContextOnVisibilityChange } from "$lib/speakers.svelte";
+  import {
+    syncSpeakersFromCall,
+    watchVisibilityForCall,
+  } from "$lib/call-speakers";
   import { callFocus } from "$lib/call-focus.svelte";
   import { speakers } from "$lib/speakers.svelte";
   import { spotlight } from "$lib/spotlight";
@@ -220,45 +223,15 @@
     consumeSharedIfPresent().catch(() => {});
   });
 
-  // Speaker detection must run while in call, not just while the stage is mounted.
-  // The stage unmounts when the user navigates away from the call room, but speaker
-  // detection must continue for the floating panel to show who is speaking.
+  // Speaker detection follows the CALL, not the stage: the tiles unmount when
+  // the user navigates away from the call room and the floating panel still
+  // has to show who is talking. Shared with /qc, which mounts no AppView -
+  // see call-speakers.ts.
   $effect(() => {
-    if (!transportState.inCall) {
-      stopAllSpeakers();
-      return;
-    }
-    // Update speaker tracks whenever call state changes.
-    // Convert null to undefined for type compatibility.
-    const participants = new Map(
-      Array.from(transportState.participants).map(([peerId, p]) => [
-        peerId,
-        {
-          audioTrack: p.audioTrack ?? undefined,
-          videoTrack: p.videoTrack ?? undefined,
-          screenTrack: p.screenTrack ?? undefined,
-          screenAudioTrack: p.screenAudioTrack ?? undefined,
-        },
-      ])
-    );
-    updateSpeakerTracks(
-      participants,
-      transportState.muted,
-      transportState.localMicStream,
-      selfId()
-    );
+    syncSpeakersFromCall();
   });
 
-  // Resume audio context when visibility changes (tab becomes active), and
-  // close the PiP window the tab switch opened: the call is on screen again.
-  if (typeof document !== "undefined") {
-    document.addEventListener("visibilitychange", () => {
-      if (!document.hidden && transportState.inCall) {
-        resumeAudioContextOnVisibilityChange();
-        if (callPipPanel.browserPip) void exitBrowserPip();
-      }
-    });
-  }
+  watchVisibilityForCall();
 
   let activeRoomCode = $state<string | null>(null);
   let activeRoomName = $state<string>("");

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -135,6 +135,15 @@
      * there is nothing saved to delete.
      */
     leaveLabel?: string;
+    /**
+     * Whether the leave control needs a second click. On by default because
+     * in a room it deletes one. /qc turns it off: there is nothing to delete
+     * that hanging up does not already take, and a confirm nothing signposts
+     * reads as a button that does not work.
+     */
+    leaveConfirm?: boolean;
+    /** Passed to the call view's hang-up. See VoiceVideoCallView. */
+    onHangUp?: () => void;
     onOpenSidebar?: () => void;
     onOpenDm?: (peerId: string) => Promise<void> | void;
     incomingSharedFiles?: File[];
@@ -147,6 +156,8 @@
     roomName,
     onLeave,
     leaveLabel,
+    leaveConfirm = true,
+    onHangUp,
     onOpenSidebar,
     onOpenDm,
     incomingSharedFiles = [],
@@ -1864,7 +1875,7 @@
               variant="ghost"
               size="icon"
               onclick={() => {
-                if (!confirmingDelete) {
+                if (leaveConfirm && !confirmingDelete) {
                   confirmingDelete = true;
                   setTimeout(() => (confirmingDelete = false), 3000);
                   return;
@@ -1914,7 +1925,7 @@
           ? 'min-w-0 flex-1'
           : 'shrink-0'}"
       >
-        <VoiceVideoCallView beside={callBeside} />
+        <VoiceVideoCallView beside={callBeside} {onHangUp} />
       </div>
     {/if}
     <div

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -129,6 +129,12 @@
     roomName: string;
     selfId: string;
     onLeave: () => void;
+    /**
+     * What the leave control says. Defaults to the room/DM wording; /qc passes
+     * "Leave call", because a quick call is not a room anybody is deleting -
+     * there is nothing saved to delete.
+     */
+    leaveLabel?: string;
     onOpenSidebar?: () => void;
     onOpenDm?: (peerId: string) => Promise<void> | void;
     incomingSharedFiles?: File[];
@@ -140,6 +146,7 @@
     roomCode,
     roomName,
     onLeave,
+    leaveLabel,
     onOpenSidebar,
     onOpenDm,
     incomingSharedFiles = [],
@@ -177,6 +184,12 @@
 
   const peersInThisRoom = $derived(
     [...callPeerIds].filter((peerId) => callPeerRooms.get(peerId) === roomCode)
+  );
+
+  /** What the leave control says. /qc overrides it: a quick call is not a
+   *  room anybody is deleting, because there is nothing saved to delete. */
+  const leaveText = $derived(
+    leaveLabel ?? (isDmChat ? "Delete conversation" : "Delete room")
   );
 
   const showCallView = $derived(
@@ -1844,13 +1857,7 @@
             {/snippet}
           </Tip>
         {/if}
-        <Tip
-          text={confirmingDelete
-            ? "Click again to confirm"
-            : isDmChat
-              ? "Delete conversation"
-              : "Delete room"}
-        >
+        <Tip text={confirmingDelete ? "Click again to confirm" : leaveText}>
           {#snippet children(props)}
             <Button
               {...props}
@@ -1865,7 +1872,7 @@
                 confirmingDelete = false;
                 onLeave();
               }}
-              aria-label={isDmChat ? "Delete conversation" : "Delete room"}
+              aria-label={leaveText}
               class="text-red-400 hover:bg-destructive/10! hover:text-destructive! {confirmingDelete
                 ? 'bg-destructive/20!'
                 : ''}"

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -186,12 +186,6 @@
     [...callPeerIds].filter((peerId) => callPeerRooms.get(peerId) === roomCode)
   );
 
-  /** What the leave control says. /qc overrides it: a quick call is not a
-   *  room anybody is deleting, because there is nothing saved to delete. */
-  const leaveText = $derived(
-    leaveLabel ?? (isDmChat ? "Delete conversation" : "Delete room")
-  );
-
   const showCallView = $derived(
     (inCall && callRoomCode === roomCode) || peersInThisRoom.length > 0
   );
@@ -1552,6 +1546,12 @@
 
   const isDmChat = $derived(
     transportState.chatMode === "dm" && !!transportState.activeDmPeerId
+  );
+
+  /** What the leave control says. /qc overrides it: a quick call is not a
+   *  room anybody is deleting, because there is nothing saved to delete. */
+  const leaveText = $derived(
+    leaveLabel ?? (isDmChat ? "Delete conversation" : "Delete room")
   );
 
   // Desktop only: below sm there is no room for two columns, and the call

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -18,6 +18,10 @@
   import ChatView from "$lib/components/ChatView.svelte";
   import UnlockIdentity from "$lib/components/UnlockIdentity.svelte";
   import { identityStore } from "$lib/identity/identity.svelte";
+  import {
+    syncSpeakersFromCall,
+    watchVisibilityForCall,
+  } from "$lib/call-speakers";
   import { profileStore } from "$lib/profile.svelte";
   import { formatQuickCode } from "$lib/room-code";
   import {
@@ -27,6 +31,7 @@
     hasAccount,
     prepareAsGuest,
     quickCall,
+    resumableSession,
     quickCallLink,
     rememberQuickProfile,
     setQuickCallCode,
@@ -58,15 +63,23 @@
 
   onMount(() => {
     const fromLink = window.location.hash.slice(1);
-    isHost = !fromLink;
-    setQuickCallCode(fromLink || undefined);
+    // A reload of a call in progress, rather than a fresh arrival. Everything
+    // this person already answered is answered again from the tab's own
+    // session, so a refresh is a reconnect and not a fresh sign-up.
+    const resume = resumableSession(fromLink || "");
+    isHost = resume ? resume.isHost : !fromLink;
+    setQuickCallCode(fromLink || undefined, isHost);
     // The code IS the secret, so it lives in the fragment and never in the
     // path - same reasoning as room invites, see App.svelte.
     if (isHost) {
       history.replaceState(history.state, "", `/qc#${quickCall.code}`);
     }
-    // With no account on this device there is nothing to choose between.
-    if (!hasAccount()) void prepareAsGuest();
+    if (resume) {
+      void resumeCall(resume);
+    } else if (!hasAccount()) {
+      // With no account on this device there is nothing to choose between.
+      void prepareAsGuest();
+    }
     // pagehide, not beforeunload: it is the one that fires on mobile when the
     // tab is discarded, and dropping the database is the whole promise here.
     const bye = () => teardownQuickCall();
@@ -76,12 +89,54 @@
 
   onDestroy(teardownQuickCall);
 
+  /**
+   * Walk a refresh back to where it was.
+   *
+   * A guest comes back under the same mnemonic, so the same DID: the other
+   * side sees a reconnect rather than a stranger with a familiar name, and
+   * the room's history is pulled back off them by the ordinary digest. An
+   * account has to unlock again - its key is never put in session storage -
+   * and the effect below carries on from there.
+   */
+  async function resumeCall(resume: {
+    identity: "guest" | "account";
+    mnemonic?: string;
+    name: string;
+    avatarUrl?: string;
+    inCall: boolean;
+  }) {
+    name = resume.name || name;
+    nameTouched = true;
+    if (resume.identity === "account") {
+      chooseAccount();
+      return;
+    }
+    await prepareAsGuest(resume.mnemonic);
+    if (resume.inCall && quickCall.stage === "setup") {
+      await startQuickCall({ name, avatarUrl: resume.avatarUrl ?? avatar });
+    }
+  }
+
+  // The app shell does this too, and /qc mounts no app shell: without it the
+  // analyser is never fed and nobody's speaking ring ever lights up.
+  $effect(() => {
+    syncSpeakersFromCall();
+  });
+  watchVisibilityForCall();
+
   // UnlockIdentity runs the whole unlock itself, remembered password and all,
   // so the only thing left here is to notice that it landed.
   $effect(() => {
     if (quickCall.stage !== "unlocking") return;
     if (!identityStore.isUnlocked) return;
-    void adoptAccount();
+    void adoptAccount().then(() => {
+      // A refresh of a call this account was already in walks straight back
+      // in, rather than stopping to ask the questions it already answered.
+      const resume = resumableSession(quickCall.code);
+      if (resume?.inCall && quickCall.stage === "setup") {
+        void startQuickCall({ name, avatarUrl: avatar });
+      }
+    });
   });
 
   // Take the name the account (or the remembered profile) turned out to have,

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -35,6 +35,7 @@
     quickCallLink,
     rememberQuickProfile,
     setQuickCallCode,
+    startAnotherCall,
     startQuickCall,
     teardownQuickCall,
   } from "$lib/quick/quick-call.svelte";
@@ -180,6 +181,53 @@
           leaveLabel="Leave call"
         />
       </div>
+    </div>
+  {:else if quickCall.stage === "ended"}
+    <div
+      class="min-h-dvh overflow-y-auto bg-background text-foreground flex items-center justify-center p-4 font-mono"
+    >
+      <Card.Root
+        class="w-full max-w-sm bg-card border-border text-card-foreground"
+      >
+        <Card.Header class="pb-4">
+          <div class="flex items-center gap-2 mb-1">
+            <div class="w-2 h-2 rounded-full bg-muted-foreground"></div>
+            <Card.Title class="text-lg font-mono font-semibold">
+              Call ended
+            </Card.Title>
+          </div>
+          <Card.Description class="text-muted-foreground text-xs font-mono">
+            The call, its chat and everything it wrote are gone
+          </Card.Description>
+        </Card.Header>
+        <Card.Content>
+          <p class="text-xs text-muted-foreground font-mono leading-relaxed">
+            A quick call keeps nothing: there is no history to go back to, and
+            the old link no longer reaches anything of yours. If you want a
+            conversation that stays, make a room instead.
+          </p>
+        </Card.Content>
+        <Card.Footer class="flex-col gap-2">
+          <Button
+            onclick={() => {
+              const code = startAnotherCall();
+              isHost = true;
+              nameTouched = true;
+              history.replaceState(history.state, "", `/qc#${code}`);
+            }}
+            class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-mono"
+          >
+            Start a new call
+          </Button>
+          <Button
+            variant="ghost"
+            href="/app"
+            class="w-full font-mono text-xs text-muted-foreground"
+          >
+            Go to the app
+          </Button>
+        </Card.Footer>
+      </Card.Root>
     </div>
   {:else if quickCall.stage === "unlocking"}
     <UnlockIdentity />

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -177,6 +177,7 @@
           roomName="Quick call"
           selfId={identityStore.did ?? ""}
           onLeave={endQuickCall}
+          leaveLabel="Leave call"
         />
       </div>
     </div>

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -178,7 +178,9 @@
           roomName="Quick call"
           selfId={identityStore.did ?? ""}
           onLeave={endQuickCall}
+          onHangUp={endQuickCall}
           leaveLabel="Leave call"
+          leaveConfirm={false}
         />
       </div>
     </div>
@@ -200,13 +202,6 @@
             The call, its chat and everything it wrote are gone
           </Card.Description>
         </Card.Header>
-        <Card.Content>
-          <p class="text-xs text-muted-foreground font-mono leading-relaxed">
-            A quick call keeps nothing: there is no history to go back to, and
-            the old link no longer reaches anything of yours. If you want a
-            conversation that stays, make a room instead.
-          </p>
-        </Card.Content>
         <Card.Footer class="flex-col gap-2">
           <Button
             onclick={() => {

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -195,11 +195,12 @@
           <div class="flex items-center gap-2 mb-1">
             <div class="w-2 h-2 rounded-full bg-muted-foreground"></div>
             <Card.Title class="text-lg font-mono font-semibold">
-              Call ended
+              You left the call
             </Card.Title>
           </div>
           <Card.Description class="text-muted-foreground text-xs font-mono">
-            The call, its chat and everything it wrote are gone
+            Everything it wrote here is gone · anyone still on it carries on
+            without you
           </Card.Description>
         </Card.Header>
         <Card.Footer class="flex-col gap-2">

--- a/frontend/src/lib/components/QuickSend.svelte
+++ b/frontend/src/lib/components/QuickSend.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   /**
    * /qs - the whole page. No sidebar, no chat, no identity: what the code
-   * names is a two-person room that exists for as long as this tab does.
+   * names is a swarm that exists for as long as somebody in it holds the
+   * file. Everyone who finishes one serves it on, so "the sender" stops
+   * being a role after the first delivery.
    */
   import { onDestroy, onMount } from "svelte";
   import { Check, Copy, Download, Upload, Users } from "@lucide/svelte";
@@ -14,6 +16,7 @@
     offerFiles,
     quickSend,
     quickSendLink,
+    setQuickSendMode,
     startQuickSend,
     stopQuickSend,
   } from "$lib/quick/quick-send.svelte";
@@ -96,7 +99,8 @@
         </Card.Title>
       </div>
       <Card.Description class="text-muted-foreground text-xs font-mono">
-        Send a file to one person · no account · the bytes go straight to them
+        Hand a file to one person or several · no account · multi-peer, so the
+        bytes go straight between you
       </Card.Description>
     </Card.Header>
 
@@ -117,6 +121,16 @@
         >
           Try again
         </Button>
+      </Card.Content>
+    {:else if quickSend.status === "closed"}
+      <Card.Content class="space-y-2">
+        <p class="text-sm font-mono">Delivered · this link is closed.</p>
+        <p class="text-xs text-muted-foreground font-mono leading-relaxed">
+          Somebody has the whole file, so nothing more is served from here and
+          the link no longer reaches anything. Whoever received it still has
+          it - a one-time link limits who can fetch it from you, not what they
+          do with it afterwards.
+        </p>
       </Card.Content>
     {:else if quickSend.status === "ready"}
       <Card.Content class="space-y-4">
@@ -146,11 +160,38 @@
               Waiting for the other side · send them the link
             {:else if quickSend.peers === 1}
               One person is here
+            {:else if quickSend.heardMode === "once"}
+              {quickSend.peers} people are here · only the first to finish
+              gets it
             {:else}
-              {quickSend.peers} people are here · anyone with the link can join
+              {quickSend.peers} people are here · they share with each other
             {/if}
           </p>
         </div>
+
+        {#if quickSend.isHost}
+          <label class="flex items-start gap-2.5 cursor-pointer group">
+            <input
+              type="checkbox"
+              checked={quickSend.mode === "once"}
+              onchange={(e) =>
+                setQuickSendMode(e.currentTarget.checked ? "once" : "multi")}
+              class="mt-0.5 w-4 h-4 rounded border-input bg-background accent-primary cursor-pointer"
+            />
+            <span
+              class="text-xs text-muted-foreground group-hover:text-foreground transition-colors font-mono leading-relaxed"
+            >
+              One-time link · closes as soon as one person has the file, and
+              they do not share it on. Use it when the link might outlive the
+              handover.
+            </span>
+          </label>
+        {:else if quickSend.heardMode === "once"}
+          <p class="text-xs text-muted-foreground font-mono leading-relaxed">
+            One-time link · you are the only recipient, and this page will not
+            share the file on to anyone else.
+          </p>
+        {/if}
 
         <div
           class="rounded-lg border border-dashed p-6 text-center transition-colors {dragging
@@ -200,8 +241,10 @@
                   <p class="text-sm font-mono truncate">{file.filename}</p>
                   <p class="text-xs text-muted-foreground font-mono">
                     {formatSize(file.size)} · {transfer?.peers
-                      ? `${transfer.peers} downloading`
-                      : "ready"}
+                      ? `${transfer.peers} connected`
+                      : "ready"}{(transfer?.seeders ?? 0) > 0
+                      ? ` · ${transfer?.seeders} also sharing`
+                      : ""}
                   </p>
                 </div>
               </div>
@@ -221,7 +264,9 @@
                   <div class="min-w-0">
                     <p class="text-sm font-mono truncate">{file.filename}</p>
                     <p class="text-xs text-muted-foreground font-mono">
-                      {formatSize(file.size)}
+                      {formatSize(file.size)}{transfer?.seeding
+                        ? " · sharing it on"
+                        : ""}
                     </p>
                   </div>
                   {#if transfer?.blobURL}
@@ -283,10 +328,12 @@
 
     <Card.Footer>
       <p class="text-xs text-muted-foreground font-mono leading-relaxed">
-        The relay introduces the two of you and TURN may carry the connection
-        when neither side is directly reachable · the file itself never
-        touches a server. Anyone with the link can join, so send it to one
-        person.
+        The relay introduces you and TURN may carry the connection when two
+        sides cannot reach each other directly · the file itself never touches
+        a server. Everyone holding the link is in one swarm and serves what
+        they have finished, so the sender can leave once somebody has it -
+        which also means anyone with the link can join. Send it to the people
+        you mean to.
       </p>
     </Card.Footer>
   </Card.Root>

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -117,7 +117,16 @@ import {
     /** The call stage is a column beside the chat, not a band above it. */
     beside?: boolean;
   }
-  let { beside = false }: Props = $props();
+    let {
+    beside = false,
+    /**
+     * What the red hang-up does. Defaults to leaving the CALL and staying in
+     * the room, which is right for a room: the conversation outlives the call.
+     * /qc overrides it, because there the call IS the thing - hanging up ends
+     * it the way it does in every other call app.
+     */
+    onHangUp = leaveCall,
+  }: { beside?: boolean; onHangUp?: () => void } = $props();
 
   $effect(() => {
     loadProfile();
@@ -2104,7 +2113,7 @@ import {
             <button
               {...props}
               type="button"
-              onclick={leaveCall}
+              onclick={onHangUp}
               aria-label="Leave call"
               class="group relative flex h-11 w-16 items-center justify-center rounded-lg bg-linear-to-br from-red-500 to-red-600 text-white shadow-lg shadow-red-500/30 transition-all duration-200 hover:from-red-400 hover:to-red-500"
             >
@@ -2284,7 +2293,7 @@ import {
           <button
             {...props}
             type="button"
-            onclick={leaveCall}
+            onclick={onHangUp}
             aria-label="Leave call"
             class={cn(
               "group relative flex items-center justify-center rounded-lg bg-linear-to-br from-red-500 to-red-600 text-white shadow-lg shadow-red-500/30 transition-all duration-200 hover:from-red-400 hover:to-red-500 hover:scale-105 hover:shadow-red-500/50 shrink-0",

--- a/frontend/src/lib/identity/identity.svelte.ts
+++ b/frontend/src/lib/identity/identity.svelte.ts
@@ -150,8 +150,8 @@ export async function create(password: string): Promise<string> {
  * there is no record to load, and nothing should offer to lock or back up
  * an identity that cannot be recovered.
  */
-export async function createEphemeral(): Promise<void> {
-  const keypair = await createEphemeralIdentity();
+export async function createEphemeral(mnemonic?: string): Promise<void> {
+  const keypair = await createEphemeralIdentity(mnemonic);
   identityStore.isUnlocked = true;
   identityStore.did = keypair.did;
   identityStore.publicKey = keypair.publicKey;

--- a/frontend/src/lib/identity/identity.ts
+++ b/frontend/src/lib/identity/identity.ts
@@ -311,11 +311,16 @@ export async function createIdentity(
  * Deliberately paired with a quick storage scope (quick-storage.ts): these
  * rows are sealed with a key that dies with the page, so writing them into
  * the real database would leave undecryptable junk in it.
+ *
+ * `mnemonic` is for ONE case: /qc holding its identity across a page reload,
+ * so a refresh mid-call comes back as the same person rather than as a
+ * stranger with the same name. It is kept in sessionStorage, which the tab
+ * takes with it when it closes - see quick-call.svelte.ts.
  */
-export async function createEphemeralIdentity(): Promise<KeypairRecord> {
-  const { privateKey, publicKey } = deriveKeypairFromMnemonic(
-    generateMnemonic()
-  );
+export async function createEphemeralIdentity(
+  mnemonic = generateMnemonic()
+): Promise<KeypairRecord> {
+  const { privateKey, publicKey } = deriveKeypairFromMnemonic(mnemonic);
   const did = publicKeyToDid(publicKey);
   await _activateSession(privateKey, publicKey, did);
   return { id: "keypair", did, publicKey };

--- a/frontend/src/lib/page-meta.test.ts
+++ b/frontend/src/lib/page-meta.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The one thing that must not break: visiting /qs and coming back must leave
+ * the landing page's own title and description exactly as index.html wrote
+ * them. A route that "restores" the wrong values is worse than one that never
+ * touched them, because the landing page is the page that actually ranks.
+ *
+ * A hand-rolled head rather than jsdom, which this repo does not carry and
+ * which is not worth a dependency for six attributes. The cost is that the
+ * fake is keyed by the exact selector strings the module uses, so a change to
+ * one has to be made in both places - the assertions below would fail loudly
+ * rather than silently pass, which is the tradeoff worth having.
+ */
+
+class FakeEl {
+  attrs = new Map<string, string>();
+  getAttribute(name: string) {
+    return this.attrs.get(name) ?? null;
+  }
+  setAttribute(name: string, value: string) {
+    this.attrs.set(name, value);
+  }
+}
+
+let els: Map<string, FakeEl>;
+
+function buildHead(): void {
+  els = new Map();
+  const put = (sel: string, attr: string, value: string) => {
+    const el = new FakeEl();
+    el.setAttribute(attr, value);
+    els.set(sel, el);
+  };
+  put('meta[name="description"]', "content", "Landing description.");
+  put('meta[property="og:title"]', "content", "Awful.chat");
+  put('meta[property="og:description"]', "content", "Landing description.");
+  put('meta[property="og:url"]', "content", "https://awful.chat");
+  put('meta[name="twitter:title"]', "content", "Awful.chat");
+  put('meta[name="twitter:description"]', "content", "Landing description.");
+  put('link[rel="canonical"]', "href", "https://awful.chat");
+
+  vi.stubGlobal("document", {
+    title: "Awful.chat - private peer-to-peer chat",
+    head: { querySelector: (sel: string) => els.get(sel) ?? null },
+  });
+  vi.stubGlobal("window", { location: { origin: "https://example.test" } });
+}
+
+function head() {
+  const get = (sel: string, attr: string) => els.get(sel)?.getAttribute(attr) ?? null;
+  return {
+    title: (globalThis as unknown as { document: { title: string } }).document.title,
+    description: get('meta[name="description"]', "content"),
+    canonical: get('link[rel="canonical"]', "href"),
+    ogUrl: get('meta[property="og:url"]', "content"),
+    ogTitle: get('meta[property="og:title"]', "content"),
+  };
+}
+
+async function load() {
+  vi.resetModules();
+  buildHead();
+  return import("./page-meta");
+}
+
+describe("per-route page metadata", () => {
+  beforeEach(() => vi.unstubAllGlobals());
+
+  it("leaves the landing page exactly as index.html wrote it", async () => {
+    const m = await load();
+    m.applyRouteMeta("landing");
+    expect(head()).toEqual({
+      title: "Awful.chat - private peer-to-peer chat",
+      description: "Landing description.",
+      canonical: "https://awful.chat",
+      ogUrl: "https://awful.chat",
+      ogTitle: "Awful.chat - private peer-to-peer chat",
+    });
+  });
+
+  it("gives /qs a title, a description and a canonical of its own", async () => {
+    const m = await load();
+    m.applyRouteMeta("qs");
+    const h = head();
+    expect(h.title).toMatch(/Send a file with no account/);
+    expect(h.description).toMatch(/peer-to-peer/);
+    // Origin-relative, unlike index.html's hardcoded tag: a self-hosted
+    // instance canonicalises to itself rather than to awful.chat.
+    expect(h.canonical).toBe("https://example.test/qs");
+    expect(h.ogUrl).toBe("https://example.test/qs");
+  });
+
+  it("gives /qc its own, and the two do not collide", async () => {
+    const m = await load();
+    m.applyRouteMeta("qs");
+    const qs = head();
+    m.applyRouteMeta("qc");
+    const qc = head();
+    expect(qc.title).toMatch(/video call with no account/i);
+    expect(qc.canonical).toBe("https://example.test/qc");
+    expect(qc.title).not.toBe(qs.title);
+    expect(qc.description).not.toBe(qs.description);
+  });
+
+  it("puts the landing title and description back on the way home", async () => {
+    const m = await load();
+    m.applyRouteMeta("qs");
+    m.applyRouteMeta("landing");
+    const h = head();
+    expect(h.title).toBe("Awful.chat - private peer-to-peer chat");
+    expect(h.description).toBe("Landing description.");
+    expect(h.ogTitle).toBe("Awful.chat - private peer-to-peer chat");
+  });
+
+  it("survives a head with none of the tags in it", async () => {
+    const m = await load();
+    els.clear();
+    expect(() => m.applyRouteMeta("qs")).not.toThrow();
+  });
+
+  it("does nothing at all where there is no document", async () => {
+    vi.resetModules();
+    vi.stubGlobal("document", undefined);
+    const m = await import("./page-meta");
+    expect(() => m.applyRouteMeta("qs")).not.toThrow();
+  });
+});

--- a/frontend/src/lib/page-meta.ts
+++ b/frontend/src/lib/page-meta.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-route title, description and canonical.
+ *
+ * index.html carries one static set for the landing page, including
+ * `<link rel="canonical" href="https://awful.chat">`. That single canonical is
+ * doing real work: nginx answers every unknown path with the app shell at 200,
+ * so without it the whole URL space would be duplicate content. It also means
+ * every route declares itself a copy of the root - fine for /app and /r/,
+ * which are behind robots.txt and have nothing to index anyway.
+ *
+ * /qs and /qc are the exception. They are the two pages somebody might arrive
+ * at from a search ("send a large file without uploading it", "video call with
+ * no account"), and a page that canonicalises to the root can never answer
+ * one. So they say who they are instead.
+ *
+ * Origin-relative on purpose, unlike the static tag: a self-hosted instance
+ * that turns these on gets a canonical naming itself rather than awful.chat.
+ */
+
+interface RouteMeta {
+  title: string;
+  description: string;
+  /** Path to self-canonicalise to, or null to leave the static tag alone. */
+  path: string | null;
+}
+
+const META: Record<string, RouteMeta> = {
+  qs: {
+    title: "Send a file with no account - Awful.chat",
+    description:
+      "Send a file straight to someone over an encrypted peer-to-peer connection. No account, no sign-up, and nothing uploaded to a server. Share the link with several people and they share it with each other, or make it a one-time link that closes as soon as it has delivered.",
+    path: "/qs",
+  },
+  qc: {
+    title: "Start a video call with no account - Awful.chat",
+    description:
+      "A video call from one link: camera, screen share and text chat, with no account and no sign-up. Voice is peer-to-peer. Nothing is kept - close the tab and the call and its chat are gone.",
+    path: "/qc",
+  },
+};
+
+function setMeta(selector: string, attr: string, value: string): void {
+  const el = document.head.querySelector(selector);
+  if (el) el.setAttribute(attr, value);
+}
+
+/**
+ * Point the document at whichever route is on screen. Called on every route
+ * change, including a popstate back to the landing page, so the static values
+ * have to be restorable - which is why `base` is read once, before anything
+ * has been overwritten.
+ */
+let base: RouteMeta | null = null;
+
+export function applyRouteMeta(route: string): void {
+  if (typeof document === "undefined") return;
+  base ??= {
+    title: document.title,
+    description:
+      document.head
+        .querySelector('meta[name="description"]')
+        ?.getAttribute("content") ?? "",
+    path: null,
+  };
+  const meta = META[route] ?? base;
+  document.title = meta.title;
+  setMeta('meta[name="description"]', "content", meta.description);
+  setMeta('meta[property="og:title"]', "content", meta.title);
+  setMeta('meta[property="og:description"]', "content", meta.description);
+  setMeta('meta[name="twitter:title"]', "content", meta.title);
+  setMeta('meta[name="twitter:description"]', "content", meta.description);
+  if (meta.path) {
+    const url = `${window.location.origin}${meta.path}`;
+    setMeta('link[rel="canonical"]', "href", url);
+    setMeta('meta[property="og:url"]', "content", url);
+  }
+}
+
+/** Test seam: the module remembers index.html's values on first use. */
+export function _resetPageMetaForTest(): void {
+  base = null;
+}

--- a/frontend/src/lib/palette/commands/actions.ts
+++ b/frontend/src/lib/palette/commands/actions.ts
@@ -74,7 +74,9 @@ export const actionCommands: CmdSource = () => {
       icon: Upload,
       action: {
         kind: "act",
-        perform: () => window.open("/qs", "_blank", "noopener"),
+        perform: () => {
+          window.open("/qs", "_blank", "noopener");
+        },
       },
     });
   }
@@ -89,7 +91,9 @@ export const actionCommands: CmdSource = () => {
       icon: Video,
       action: {
         kind: "act",
-        perform: () => window.open("/qc", "_blank", "noopener"),
+        perform: () => {
+          window.open("/qc", "_blank", "noopener");
+        },
       },
     });
   }

--- a/frontend/src/lib/palette/commands/actions.ts
+++ b/frontend/src/lib/palette/commands/actions.ts
@@ -15,6 +15,8 @@ import {
   RefreshCw,
   Search,
   Trash2,
+  Upload,
+  Video,
 } from "@lucide/svelte";
 import { openSearch } from "$lib/search/ui.svelte";
 import { transportState, connect } from "$lib/transport/transport.svelte";
@@ -30,6 +32,7 @@ import {
 import { lock } from "$lib/identity/identity.svelte";
 import { requestPersistentStorage, wipeLocalDatabase } from "$lib/storage";
 import { openSettings } from "$lib/ui-state.svelte";
+import { useQc, useQs } from "$lib/runtime-config";
 import type { Cmd } from "../types";
 import type { CmdSource } from "../host";
 
@@ -56,6 +59,40 @@ export const actionCommands: CmdSource = () => {
       perform: () => openSearch(null),
     },
   });
+
+  // The pages that need no account, when this instance serves them. A real
+  // navigation rather than a router push: they run their own transport and
+  // their own storage scope, and both of those are decided before the app
+  // mounts. Opened in a new tab so whatever is going on here survives.
+  if (useQs()) {
+    cmds.push({
+      id: "actions.quickSend",
+      title: "Quick send a file",
+      subtitle: "No account, straight to them, nothing kept",
+      keywords: ["qs", "share", "transfer", "upload", "guest"],
+      group: "Actions",
+      icon: Upload,
+      action: {
+        kind: "act",
+        perform: () => window.open("/qs", "_blank", "noopener"),
+      },
+    });
+  }
+
+  if (useQc()) {
+    cmds.push({
+      id: "actions.quickCall",
+      title: "Quick call",
+      subtitle: "A call with no room, nothing kept",
+      keywords: ["qc", "meet", "guest", "video", "link"],
+      group: "Actions",
+      icon: Video,
+      action: {
+        kind: "act",
+        perform: () => window.open("/qc", "_blank", "noopener"),
+      },
+    });
+  }
 
   cmds.push({
     id: "actions.call.toggle",

--- a/frontend/src/lib/quick/quick-call.svelte.ts
+++ b/frontend/src/lib/quick/quick-call.svelte.ts
@@ -21,6 +21,7 @@
  */
 
 import { createEphemeral, identityStore } from "$lib/identity/identity.svelte";
+import { generateMnemonic } from "$lib/identity/identity";
 import { loadProfile, saveAvatar, saveName } from "$lib/profile.svelte";
 import {
   clearAtRestFlagForCurrentOwner,
@@ -115,6 +116,76 @@ export function rememberQuickProfile(profile: QuickProfile | null): void {
   }
 }
 
+/**
+ * What a page reload has to come back as.
+ *
+ * sessionStorage, not localStorage: it survives a refresh and dies with the
+ * tab, which is exactly the lifetime this page promises. Without it a refresh
+ * mid-call was a silent eviction - a new identity, a new database, back on the
+ * setup card being told you had been "invited" to the call you started, while
+ * the other side kept a ghost of you in its roster until the TTL swept it.
+ *
+ * Coming back under the SAME key is what avoids that ghost: the roster entry
+ * is reused rather than duplicated, and the room's history is pulled back off
+ * the other peers by the ordinary digest, so nothing has to be persisted for
+ * it. A guest's mnemonic goes in here to make that possible; an account's key
+ * never does, and a reload asks it to unlock again.
+ */
+const SESSION_KEY = "awful_qc_session";
+
+interface QuickSession {
+  code: string;
+  isHost: boolean;
+  identity: "guest" | "account";
+  /** Guest only. Re-derives the same DID, so peers see a reconnect. */
+  mnemonic?: string;
+  name: string;
+  avatarUrl?: string;
+  /** Whether to walk straight back into the call rather than the setup card. */
+  inCall: boolean;
+}
+
+let session: QuickSession | null = null;
+
+function readSession(): QuickSession | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as QuickSession;
+    return typeof p?.code === "string" && p.code ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveSession(patch: Partial<QuickSession>): void {
+  session = { ...(session ?? ({} as QuickSession)), ...patch };
+  try {
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  } catch {
+    // Blocked: a refresh then behaves as it did before, which is survivable.
+  }
+}
+
+function clearSession(): void {
+  session = null;
+  try {
+    sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    /* nothing to clear */
+  }
+}
+
+/**
+ * Whether this page load is a refresh of a call already in progress, for the
+ * code on screen. The caller uses it to skip the screens the person has
+ * already been through.
+ */
+export function resumableSession(code: string): QuickSession | null {
+  const found = readSession();
+  return found && found.code === code ? found : null;
+}
+
 const remembered = readRememberedProfile();
 
 export const quickCall = $state<QuickCallState>({
@@ -132,9 +203,13 @@ export const quickCall = $state<QuickCallState>({
  * A link carrying something else falls back to a fresh code rather than
  * joining whatever the string happened to name.
  */
-export function setQuickCallCode(fromLink?: string): string {
+export function setQuickCallCode(fromLink?: string, isHost?: boolean): string {
   quickCall.code =
     (fromLink ? normalizeQuickCode(fromLink) : "") || newQuickCode();
+  // Host-ness cannot be re-derived after a reload: the person who STARTED the
+  // call has the code in their address bar by then, and would be told they
+  // had been invited to it.
+  saveSession({ code: quickCall.code, isHost: isHost ?? !fromLink });
   return quickCall.code;
 }
 
@@ -163,13 +238,17 @@ let prepared = false;
  * Call as a stranger: a keypair that exists only in memory, under whatever
  * name was remembered from last time.
  */
-export async function prepareAsGuest(): Promise<void> {
+export async function prepareAsGuest(mnemonic?: string): Promise<void> {
   if (prepared) return;
   quickCall.identity = "guest";
   quickCall.error = null;
   try {
     switchToThrowawayStorage();
-    await createEphemeral();
+    // Minted here rather than inside createEphemeral so the same words can be
+    // put away for a reload. A resume passes back what it kept.
+    const words = mnemonic ?? generateMnemonic();
+    await createEphemeral(words);
+    saveSession({ identity: "guest", mnemonic: words });
     await saveName(quickCall.profile.name);
     if (quickCall.profile.avatarUrl) {
       await saveAvatar(quickCall.profile.avatarUrl);
@@ -206,6 +285,7 @@ export async function adoptAccount(): Promise<void> {
   try {
     const mine = await getOwnProfile(identityStore.did ?? undefined);
     switchToThrowawayStorage();
+    saveSession({ identity: "account" });
     if (mine) await putOwnProfile({ ...mine, isMe: true });
     await loadProfile();
     quickCall.profile = {
@@ -244,6 +324,11 @@ export async function startQuickCall(profile: QuickProfile): Promise<void> {
     if (!joined) throw new Error("Could not join the call.");
     await joinCall();
     quickCall.stage = "in-call";
+    saveSession({
+      inCall: true,
+      name: profile.name,
+      avatarUrl: profile.avatarUrl,
+    });
   } catch (err) {
     quickCall.stage = "failed";
     quickCall.error = err instanceof Error ? err.message : String(err);
@@ -255,6 +340,13 @@ export function endQuickCall(): void {
   leaveCall();
   leaveRoom();
   quickCall.stage = "setup";
+  // Hanging up is a decision. A reload after it should not walk back in.
+  saveSession({ inCall: false });
+}
+
+/** Leave for good: nothing here is resumed by a later page load. */
+export function forgetQuickCallSession(): void {
+  clearSession();
 }
 
 /** Whether this device has an account that could be brought into the call. */

--- a/frontend/src/lib/quick/quick-call.svelte.ts
+++ b/frontend/src/lib/quick/quick-call.svelte.ts
@@ -58,6 +58,8 @@ export type QuickCallStage =
   | "setup"
   | "joining"
   | "in-call"
+  /** Hung up. The call, the chat and the database it lived in are gone. */
+  | "ended"
   | "failed";
 
 interface QuickCallState {
@@ -335,13 +337,41 @@ export async function startQuickCall(profile: QuickProfile): Promise<void> {
   }
 }
 
-/** Hang up and go back to the setup screen, still on the same code. */
+/**
+ * Hang up, and take the call with you.
+ *
+ * leaveRoom already does the wire half - it broadcasts the leave so the others
+ * see you go, unsubscribes the topic, hangs up, and empties the messages on
+ * screen. What it does not do is get rid of what the call wrote, and for a
+ * quick call that is the whole promise: there is no history here, and anybody
+ * who wants some makes a room instead.
+ *
+ * So the database goes too. The cached connection is closed first or the
+ * delete queues behind it and the rows outlive the call; dropQuickStorage
+ * then rotates to a fresh empty scope, so the participant removal still in
+ * flight from leaveRoom lands somewhere disposable rather than in the user's
+ * real database.
+ */
 export function endQuickCall(): void {
   leaveCall();
   leaveRoom();
+  // Nothing resumes a call that was deliberately ended.
+  clearSession();
+  closeDatabase();
+  void dropQuickStorage();
+  quickCall.stage = "ended";
+}
+
+/**
+ * Start over on a new code, in the empty scope the hang-up left behind. The
+ * identity is the same one - it lives in memory and dies with the tab either
+ * way - so this is a new call, not a new person.
+ */
+export function startAnotherCall(): string {
+  quickCall.error = null;
+  const code = setQuickCallCode(undefined, true);
   quickCall.stage = "setup";
-  // Hanging up is a decision. A reload after it should not walk back in.
-  saveSession({ inCall: false });
+  return code;
 }
 
 /** Leave for good: nothing here is resumed by a later page load. */

--- a/frontend/src/lib/quick/quick-call.svelte.ts
+++ b/frontend/src/lib/quick/quick-call.svelte.ts
@@ -338,7 +338,13 @@ export async function startQuickCall(profile: QuickProfile): Promise<void> {
 }
 
 /**
- * Hang up, and take the call with you.
+ * Hang up, and take YOUR side of the call with you.
+ *
+ * Local only, and it has to be: the code names a gossipsub topic with no
+ * owner, so "host" means nothing more than whoever minted it. Leaving tells
+ * the others you are gone and nothing else - they keep talking, and the link
+ * still reaches them. There is no seat here from which to end a call for
+ * everybody, and pretending otherwise in the wording was the bug.
  *
  * leaveRoom already does the wire half - it broadcasts the leave so the others
  * see you go, unsubscribes the topic, hangs up, and empties the messages on

--- a/frontend/src/lib/quick/quick-call.test.ts
+++ b/frontend/src/lib/quick/quick-call.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 const store = new Map<string, string>();
+const tabStore = new Map<string, string>();
 let quota = Infinity;
 
 const fakeLocalStorage = {
@@ -42,19 +43,27 @@ vi.mock("$lib/transport/transport.svelte", () => ({
   leaveRoom: vi.fn(),
   useEphemeralSession: vi.fn(),
 }));
-vi.mock("$lib/transport/call.svelte", () => ({
-  joinCall: vi.fn(async () => {}),
-  leaveCall: vi.fn(),
-}));
 vi.mock("./quick-storage", () => ({
   useQuickStorage: vi.fn(() => "awful-quick-test"),
   dropQuickStorage: vi.fn(async () => {}),
   dbName: () => "awful-quick-test",
 }));
+vi.mock("$lib/transport/call.svelte", () => ({
+  joinCall: vi.fn(async () => {}),
+  leaveCall: vi.fn(),
+}));
+
+/** Per-tab, so a reload keeps it and a closed tab does not. */
+const fakeSessionStorage = {
+  getItem: (k: string) => tabStore.get(k) ?? null,
+  setItem: (k: string, v: string) => void tabStore.set(k, v),
+  removeItem: (k: string) => void tabStore.delete(k),
+};
 
 async function load() {
   vi.resetModules();
   vi.stubGlobal("localStorage", fakeLocalStorage);
+  vi.stubGlobal("sessionStorage", fakeSessionStorage);
   return import("./quick-call.svelte");
 }
 
@@ -62,6 +71,7 @@ describe("quick call profile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     store.clear();
+    tabStore.clear();
     quota = Infinity;
     identityStore.keypair = null;
     ownProfile = undefined;
@@ -194,6 +204,54 @@ describe("quick call profile", () => {
     await m.prepareAsGuest();
     m.teardownQuickCall();
     expect(clearAtRestFlagForCurrentOwner).toHaveBeenCalled();
+  });
+
+  it("hanging up takes the call's database with it", async () => {
+    const m = await load();
+    const { closeDatabase } = await import("$lib/storage");
+    const { dropQuickStorage } = await import("./quick-storage");
+    const { leaveRoom } = await import("$lib/transport/transport.svelte");
+    const order: string[] = [];
+    vi.mocked(closeDatabase).mockImplementation(() => void order.push("close"));
+    vi.mocked(dropQuickStorage).mockImplementation(async () => {
+      order.push("drop");
+    });
+    vi.mocked(leaveRoom).mockImplementation(() => void order.push("leave"));
+
+    await m.prepareAsGuest();
+    m.setQuickCallCode("7QK3M9AB2C");
+    await m.startQuickCall({ name: "Ada" });
+    order.length = 0; // the guest setup closed the real database on its way in
+    m.endQuickCall();
+
+    // The wire first, then the bytes - and the connection has to be closed
+    // before the delete or it queues behind it.
+    expect(order).toEqual(["leave", "close", "drop"]);
+    expect(m.quickCall.stage).toBe("ended");
+  });
+
+  it("a call that was ended is never resumed", async () => {
+    const m = await load();
+    await m.prepareAsGuest();
+    m.setQuickCallCode("7QK3M9AB2C");
+    await m.startQuickCall({ name: "Ada" });
+    expect(m.resumableSession("7QK3M9AB2C")).not.toBeNull();
+
+    m.endQuickCall();
+    expect(m.resumableSession("7QK3M9AB2C")).toBeNull();
+  });
+
+  it("starting another call mints a new code and hosts it", async () => {
+    const m = await load();
+    await m.prepareAsGuest();
+    m.setQuickCallCode("7QK3M9AB2C");
+    await m.startQuickCall({ name: "Ada" });
+    m.endQuickCall();
+
+    const next = m.startAnotherCall();
+    expect(next).toMatch(/^[0-9A-HJKMNP-TV-Z]{10}$/);
+    expect(next).not.toBe("7QK3M9AB2C");
+    expect(m.quickCall.stage).toBe("setup");
   });
 
   it("does not sit in 'joining' when the join fails", async () => {

--- a/frontend/src/lib/quick/quick-send.svelte.ts
+++ b/frontend/src/lib/quick/quick-send.svelte.ts
@@ -1,5 +1,10 @@
 /**
- * /qs - send a file to one person, with no account and no room.
+ * /qs - hand a file to one person or several, with no account and no room.
+ *
+ * Multi-peer: everyone holding the link is in one swarm. A receiver that
+ * finishes a file starts serving it too, so the sender uploads once rather
+ * than once per person - and can close the tab as soon as somebody has it,
+ * because the others can now get it from each other.
  *
  * Deliberately built on the two storage-free layers and nothing else:
  * LibP2PTransport for introduction and signalling, WebTorrentFileTransport
@@ -37,7 +42,44 @@ import type {
   FileTransferSnapshot,
 } from "$lib/transport/types";
 
-export type QuickSendStatus = "idle" | "connecting" | "ready" | "failed";
+export type QuickSendStatus =
+  | "idle"
+  | "connecting"
+  | "ready"
+  | "failed"
+  /** A one-time link that has delivered. Nothing more is served from here. */
+  | "closed";
+
+/**
+ * What the link is for.
+ *
+ * `multi` - everyone holding it is in one swarm and serves what they have
+ * finished, so the sender can leave once somebody has the file. The link
+ * stays good for as long as anyone in it still holds the bytes.
+ *
+ * `once` - the link is for ONE delivery. Receivers do not serve it on, and
+ * the sender stops the moment a receiver says it has the whole file, so the
+ * link is dead from then on. This is about a link that LEAKS after you sent
+ * it - a group chat scrolled back through, a forwarded message, a shared
+ * laptop - not about the person you sent it to, who has the file and can do
+ * what they like with it.
+ */
+export type QuickSendMode = "multi" | "once";
+
+/**
+ * /qs speaks two small messages of its own on top of the file signals.
+ *
+ * Deliberately NOT extra kinds on FileSignalEnvelope: the main app shares
+ * that union and would have to grow a case for something only this page says.
+ */
+type QuickWire =
+  | { type: "__qs_mode"; mode: QuickSendMode }
+  | { type: "__qs_ack"; infoHash: string };
+
+function isQuickWire(value: unknown): value is QuickWire {
+  const t = (value as { type?: unknown } | null)?.type;
+  return t === "__qs_mode" || t === "__qs_ack";
+}
 
 interface QuickSendState {
   status: QuickSendStatus;
@@ -54,6 +96,18 @@ interface QuickSendState {
   incoming: FileDescriptor[];
   /** infoHash -> live progress, for both directions. */
   transfers: Map<string, FileTransferSnapshot>;
+  /** What this page offers under. Only the page that minted the code sets it. */
+  mode: QuickSendMode;
+  /**
+   * The strictest mode anyone in this room has announced.
+   *
+   * Strictest, not latest: everyone here already holds the link, so a peer
+   * could otherwise announce "multi" and talk the others into serving on a
+   * file whose sender asked for one delivery. Once heard, `once` sticks.
+   */
+  heardMode: QuickSendMode;
+  /** A one-time link that has already delivered. */
+  closed: boolean;
 }
 
 export const quickSend = $state<QuickSendState>({
@@ -65,6 +119,9 @@ export const quickSend = $state<QuickSendState>({
   offered: [],
   incoming: [],
   transfers: new Map(),
+  mode: "multi",
+  heardMode: "multi",
+  closed: false,
 });
 
 let transport: LibP2PTransport | null = null;
@@ -83,6 +140,26 @@ let files: WebTorrentFileTransport | null = null;
  * it when somebody actually hits the ceiling.
  */
 const localFiles = new Map<string, File>();
+
+/**
+ * Whether to serve a file this device received.
+ *
+ * On by default: it is what makes the link multi-peer rather than a queue at
+ * the sender, and the bytes are resident anyway - the received Blob is held
+ * for the Save link whether or not anyone else wants it, so sharing costs
+ * upload, not memory.
+ *
+ * Save-Data is the one honest exception. A receiver uploading is a cost they
+ * never agreed to, and someone whose browser is asking every site on the
+ * internet to use less data has agreed to it least of all. No setting for
+ * this: the browser already carries the answer.
+ */
+function shouldReshare(): boolean {
+  const conn = (
+    navigator as Navigator & { connection?: { saveData?: boolean } }
+  ).connection;
+  return conn?.saveData !== true;
+}
 
 /** Peers we have wired into the file transport, so teardown is exact. */
 const wired = new Set<string>();
@@ -103,7 +180,50 @@ function wirePeer(peerId: string): void {
   if (!files || wired.has(peerId) || !isRoomPeer(peerId)) return;
   wired.add(peerId);
   files.onPeerConnect(peerId);
+  // Before anything is served: a receiver has to know not to serve it on.
+  sendQuick(peerId, { type: "__qs_mode", mode: quickSend.mode });
   refreshPeerCount();
+}
+
+function sendQuick(peerId: string, msg: QuickWire): void {
+  void transport?.send(peerId, encode(msg));
+}
+
+/** Tell everyone here what this link is for. */
+function announceMode(): void {
+  for (const peerId of wired) {
+    sendQuick(peerId, { type: "__qs_mode", mode: quickSend.mode });
+  }
+}
+
+/**
+ * Set what the link is for. The page that minted the code owns this; a page
+ * that followed a link takes the sender's word for it (see heardMode).
+ */
+export function setQuickSendMode(mode: QuickSendMode): void {
+  if (quickSend.mode === mode) return;
+  quickSend.mode = mode;
+  if (mode === "once") quickSend.heardMode = "once";
+  announceMode();
+}
+
+/**
+ * A one-time link has done its job.
+ *
+ * Leaving the room is what closes it: a peer is only ever wired once the
+ * relay places it here (wirePeer), so nobody new can be told what we hold.
+ * Transfers already running are direct WebRTC links and finish on their own -
+ * cutting somebody off mid-file to enforce a promise about NEW arrivals
+ * would be pure spite. The seeded copy is deliberately left in place for
+ * exactly that reason.
+ */
+function closeLink(): void {
+  if (quickSend.closed) return;
+  quickSend.closed = true;
+  quickSend.status = "closed";
+  transport?.leaveRoom(quickSend.code);
+  wired.clear();
+  quickSend.peers = 0;
 }
 
 function unwirePeer(peerId: string): void {
@@ -128,6 +248,19 @@ function noteIncoming(file: FileDescriptor): void {
   if (localFiles.has(file.infoHash)) return; // our own, echoed back
   if (quickSend.incoming.some((f) => f.infoHash === file.infoHash)) return;
   quickSend.incoming = [...quickSend.incoming, file];
+}
+
+function handleQuickWire(msg: QuickWire): void {
+  if (msg.type === "__qs_mode") {
+    // Strictest wins and never relaxes - see heardMode.
+    if (msg.mode === "once") quickSend.heardMode = "once";
+    return;
+  }
+  // An ack for something WE offered, on a one-time link: delivered, so the
+  // link is done. An ack for anything else is somebody else's business.
+  if (quickSend.mode !== "once" || quickSend.closed) return;
+  if (!quickSend.offered.some((f) => f.infoHash === msg.infoHash)) return;
+  closeLink();
 }
 
 /**
@@ -177,6 +310,24 @@ export async function startQuickSend(joinCode?: string): Promise<void> {
     );
   });
   f.on("transfer", (snapshot) => putTransfer(snapshot));
+  f.on("downloaded", (infoHash, blob) => {
+    const desc = quickSend.incoming.find((f) => f.infoHash === infoHash);
+    if (!desc) return;
+    // Say so first, and whatever the mode: it is what lets a one-time link
+    // know it is done, and it costs one small frame.
+    for (const peerId of wired) {
+      sendQuick(peerId, { type: "__qs_ack", infoHash });
+    }
+    // A one-time link is ONE delivery, so this copy goes no further. In
+    // multi-peer this is what makes the swarm a swarm: seedFiles announces to
+    // every peer we are wired to, so the next person to ask has two places to
+    // pull from - and localFiles is what serves it, exactly as it serves the
+    // sender's own.
+    if (quickSend.heardMode === "once" || !shouldReshare()) return;
+    const file = new File([blob], desc.filename, { type: desc.mimeType });
+    localFiles.set(infoHash, file);
+    void f.seedFiles([file]);
+  });
 
   t.on("connect", wirePeer);
   t.on("disconnect", unwirePeer);
@@ -194,7 +345,11 @@ export async function startQuickSend(joinCode?: string): Promise<void> {
     try {
       decoded = decode(data);
     } catch {
-      return; // not ours; this page speaks one message type
+      return; // not ours; this page speaks three message types
+    }
+    if (isQuickWire(decoded)) {
+      handleQuickWire(decoded);
+      return;
     }
     if (!isFileSignalWireMessage(decoded)) return;
     if (decoded.payload.kind === "file-seeder") {
@@ -259,6 +414,10 @@ export function stopQuickSend(): void {
   quickSend.incoming = [];
   quickSend.transfers = new Map();
   quickSend.error = null;
+  // `mode` survives: it is this person's choice for the page, not state of a
+  // particular link. What the room told us does not.
+  quickSend.heardMode = quickSend.mode;
+  quickSend.closed = false;
 }
 
 if (import.meta.env.DEV && typeof window !== "undefined") {

--- a/frontend/src/lib/quick/quick-send.test.ts
+++ b/frontend/src/lib/quick/quick-send.test.ts
@@ -23,8 +23,12 @@ class FakeTransport {
     for (const h of this.handlers.get(event) ?? []) h(...args);
   }
   async connect() {}
+  left: string[] = [];
   joinRoom(code: string) {
     this.joined.push(code);
+  }
+  leaveRoom(code: string) {
+    this.left.push(code);
   }
   isRoomPeer(_room: string, peerId: string) {
     return this.roomPeers.has(peerId);
@@ -63,7 +67,9 @@ class FakeFiles {
   setLocalFileLookup(fn: (infoHash: string) => Promise<File | null>) {
     this.lookup = fn;
   }
+  seeded: string[] = [];
   async seedFiles(files: File[]) {
+    for (const f of files) this.seeded.push(f.name);
     return files.map((f, i) => ({
       infoHash: `hash${i}`,
       filename: f.name,
@@ -240,6 +246,134 @@ describe("quick send", () => {
     expect(files.downloads).toEqual([]);
     qs.acceptFile("abc");
     expect(files.downloads).toEqual(["abc"]);
+  });
+
+  it("serves on a file it finished, so the swarm has two sources", async () => {
+    const qs = await load();
+    await qs.startQuickSend("7QK3M9AB2C");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
+    transport.emit("message", "friend", frame(OFFER));
+    qs.acceptFile("abc");
+
+    files.emit("downloaded", "abc", new Blob(["bytes"]));
+    await Promise.resolve();
+
+    // seedFiles announces to every wired peer, which is what makes the next
+    // person's download have somewhere else to come from.
+    expect(files.seeded).toEqual(["holiday.mp4"]);
+    // And it is served locally from here on, exactly like our own offer.
+    expect(await files.lookup?.("abc")).toBeInstanceOf(File);
+  });
+
+  it("does not serve on a file nobody offered us", async () => {
+    const qs = await load();
+    await qs.startQuickSend("7QK3M9AB2C");
+    // A "downloaded" for a hash that was never in `incoming` has no
+    // descriptor to name it, and re-announcing something unnamed would put a
+    // file with a wrong name in front of the next person.
+    files.emit("downloaded", "not-ours", new Blob(["bytes"]));
+    await Promise.resolve();
+    expect(files.seeded).toEqual([]);
+  });
+
+  it("does not upload for a browser asking sites to save data", async () => {
+    const qs = await load();
+    vi.stubGlobal("navigator", { connection: { saveData: true } });
+    try {
+      await qs.startQuickSend("7QK3M9AB2C");
+      transport.roomPeers.add("friend");
+      transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
+      transport.emit("message", "friend", frame(OFFER));
+      files.emit("downloaded", "abc", new Blob(["bytes"]));
+      await Promise.resolve();
+      expect(files.seeded).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("a one-time link neither shares on nor stays open", async () => {
+    const qs = await load();
+    await qs.startQuickSend("7QK3M9AB2C");
+    qs.setQuickSendMode("once");
+    await qs.offerFiles([new File(["x"], "secret.pdf")]);
+    files.seeded.length = 0;
+
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
+    // Every peer is told what the link is for as it is wired.
+    const told = transport.sent
+      .map((s) => JSON.parse(new TextDecoder().decode(s.data)))
+      .filter((m) => m.type === "__qs_mode");
+    expect(told.at(-1)).toEqual({ type: "__qs_mode", mode: "once" });
+
+    // The receiver says it has the whole file, and the link shuts.
+    transport.emit(
+      "message",
+      "friend",
+      frame({ type: "__qs_ack", infoHash: "hash0" })
+    );
+    expect(qs.quickSend.status).toBe("closed");
+    expect(qs.quickSend.closed).toBe(true);
+    expect(transport.left).toEqual(["7QK3M9AB2C"]);
+    expect(qs.quickSend.peers).toBe(0);
+  });
+
+  it("ignores an ack for a file it never offered", async () => {
+    const qs = await load();
+    await qs.startQuickSend("7QK3M9AB2C");
+    qs.setQuickSendMode("once");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
+    transport.emit(
+      "message",
+      "friend",
+      frame({ type: "__qs_ack", infoHash: "someone-elses" })
+    );
+    expect(qs.quickSend.status).toBe("ready");
+    expect(transport.left).toEqual([]);
+  });
+
+  it("a receiver on a one-time link does not share it on", async () => {
+    const qs = await load();
+    await qs.startQuickSend("7QK3M9AB2C");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
+    transport.emit("message", "friend", frame(OFFER));
+    transport.emit(
+      "message",
+      "friend",
+      frame({ type: "__qs_mode", mode: "once" })
+    );
+    qs.acceptFile("abc");
+
+    files.emit("downloaded", "abc", new Blob(["bytes"]));
+    await Promise.resolve();
+
+    expect(files.seeded).toEqual([]);
+    // It still tells the sender, which is what closes the link.
+    const acks = transport.sent
+      .map((s) => JSON.parse(new TextDecoder().decode(s.data)))
+      .filter((m) => m.type === "__qs_ack");
+    expect(acks).toEqual([{ type: "__qs_ack", infoHash: "abc" }]);
+  });
+
+  it("cannot be talked out of one-time by a later peer", async () => {
+    // Everyone in the room holds the link already, so a peer could otherwise
+    // announce "multi" and talk the others into serving on a file whose
+    // sender asked for one delivery.
+    const qs = await load();
+    await qs.startQuickSend("7QK3M9AB2C");
+    transport.roomPeers.add("friend");
+    transport.emit("roomPeers", "7QK3M9AB2C", ["friend"]);
+    transport.emit("message", "friend", frame(OFFER));
+    transport.emit("message", "friend", frame({ type: "__qs_mode", mode: "once" }));
+    transport.emit("message", "friend", frame({ type: "__qs_mode", mode: "multi" }));
+
+    files.emit("downloaded", "abc", new Blob(["bytes"]));
+    await Promise.resolve();
+    expect(files.seeded).toEqual([]);
   });
 
   it("survives a frame that is not ours", async () => {

--- a/frontend/src/lib/quick/quick-storage.test.ts
+++ b/frontend/src/lib/quick/quick-storage.test.ts
@@ -79,15 +79,29 @@ describe("quick storage", () => {
     expect(m.useQuickStorage()).toBe(name); // idempotent
   });
 
-  it("deletes its own database on the way out", async () => {
+  it("deletes its own database and opens an empty one in its place", async () => {
     const m = await load();
     const name = m.useQuickStorage();
     await m.dropQuickStorage();
     expect(deleted).toEqual([name]);
-    // And stops claiming a scope it no longer has, so nothing writes into a
-    // database that is being deleted.
-    expect(m.isQuickStorage()).toBe(false);
-    expect(m.dbName()).toBe("awful-chat");
+    // NEVER back to the real database. A page that has been quick stays
+    // quick: anything still in flight after a hang-up - a participant
+    // removal, a stray sync - has to land somewhere disposable rather than in
+    // the user's own data.
+    expect(m.isQuickStorage()).toBe(true);
+    expect(m.dbName()).not.toBe("awful-chat");
+    expect(m.dbName()).toMatch(/^awful-quick-[0-9a-f]{16}$/);
+    expect(m.dbName()).not.toBe(name);
+  });
+
+  it("the scope it rotates to is not a database until something writes", async () => {
+    const m = await load();
+    m.useQuickStorage();
+    await m.dropQuickStorage();
+    // Nothing opened the new name, so there is nothing of it to find.
+    existing = [];
+    await m.sweepOrphanQuickStorage();
+    expect(deleted.length).toBe(1);
   });
 
   it("sweeps a database whose page is gone", async () => {

--- a/frontend/src/lib/quick/quick-storage.ts
+++ b/frontend/src/lib/quick/quick-storage.ts
@@ -75,15 +75,31 @@ function deleteDatabase(name: string): Promise<void> {
 }
 
 /**
- * Drop this page's database. Called on pagehide, where there is no time to
- * wait for anything - the promise is best effort and the sweep is the net.
+ * Delete this page's database and open an empty scope in its place.
+ *
+ * ROTATES rather than clears, and that is the point: a page that has once
+ * been quick must never fall back to the real database. Setting `quick` to
+ * null would make dbName() answer "awful-chat" again, so anything written
+ * between a hang-up and the next switch - a participant removal still in
+ * flight, a profile write, a stray sync - would land in the user's actual
+ * data. Rotating makes that fallback unreachable: the answer is always some
+ * throwaway name.
+ *
+ * The new name costs nothing until something writes, because a name is not a
+ * database until it is opened. If nothing does, none is created and the sweep
+ * has nothing to find.
+ *
+ * The CALLER closes the cached connection first (storage.closeDatabase), or
+ * the delete blocks behind it and the bytes outlive the call they belong to.
+ * This module deliberately does not import the store to do that itself.
  */
 export async function dropQuickStorage(): Promise<void> {
   if (!quick) return;
   const name = quick;
-  quick = null;
   releaseLock?.();
   releaseLock = null;
+  quick = null;
+  useQuickStorage();
   await deleteDatabase(name);
 }
 

--- a/frontend/src/lib/speakers.svelte.ts
+++ b/frontend/src/lib/speakers.svelte.ts
@@ -315,6 +315,19 @@ export function updateSpeakerTracks(
  *
  * Wave 2 will call this in the cleanup of an effect that watches `inCall`.
  */
+/**
+ * Which peers currently have an analyser attached.
+ *
+ * A test seam, and the only observable proof that something is FEEDING this
+ * module: whether a ring visibly lights up needs an audible microphone and an
+ * AudioContext the browser has allowed to run, neither of which a headless
+ * run has. An empty list while a call is up means nobody is calling
+ * updateSpeakerTracks, which is exactly the bug /qc had.
+ */
+export function _trackedSpeakers(): string[] {
+  return [...analysers.keys()];
+}
+
 export function stopAllSpeakers(): void {
   if (rafId) {
     cancelAnimationFrame(rafId);


### PR DESCRIPTION
Five commits on top of #55, which shipped /qs and /qc behind their flags.

## qs: the link is a swarm, and can be made to close after one delivery (ee531a4)

/qs was already many-to-many in the only sense the transport cares about - the code names a room and anyone holding the link joins it - but receivers never served what they had. The app does this for room attachments (files.svelte.ts re-seeds the blob on "downloaded") and the quick page simply never wired that handler, so every download came from the sender, once per person, and the transfer died with their tab. A finished download is now seeded on, which means that after one person has the file the sender is no longer needed to get it to anybody else.

No switch for that part: with a single receiver there is nobody to serve, so on and off behave identically, and what it would really gate is the RECEIVER's upload, which is not the sender's to decide. The bytes are resident either way - the received Blob is held for the Save link whether or not anyone else wants it - so sharing costs upload, not memory. Save-Data is the one exception and needs no setting, because the browser already carries the answer.

One-time is the switch that does earn its place, because its off state changes what happens after delivery. A /qs link is the whole access control and stays good for as long as the tab is open; the risk is not guessing it (ten characters is fifty bits) but the link LEAKING after it was sent. The receiver acks when its download completes, the sender leaves the room on that ack, and a peer is only ever wired once the relay places it there - so nobody new can be told what we hold. Transfers already running finish on their own; cutting somebody off mid-file to enforce a promise about NEW arrivals would be spite. It also suppresses the sharing-on, or the link is not closed at all, and the strictest mode heard wins and never relaxes: everyone in the room already holds the link, so otherwise a peer could announce "multi" and talk the others into serving on a file whose sender asked for one delivery.

What one-time does not promise, and the page says so: the recipient has the file, a hostile receiver can withhold the ack, and it is one DELIVERY rather than one person you choose.

## landing: say the two pages exist, and let them be found (8626f1e)

They were reachable only by typing the URL. A "NO ACCOUNT" section, a nav entry, two FAQ answers mirrored into index.html's FAQPage JSON-LD, two command palette rows, and sitemap/llms.txt entries - every one of them behind the flag that decides whether the instance serves the pages at all.

The SEO half needed something the plan first missed: index.html's static canonical applies to every path, which is what keeps the app shell from becoming duplicate content across the whole URL space, but it also means /qs would declare itself a copy of the root and could never answer a search. Those two routes now set their own title, description and canonical at runtime, origin-relative rather than hardcoded, so a self-hosted instance canonicalises to itself. The landing page's own values are captured before anything is overwritten and put back on the way home.

This assumes awful.chat runs with USE_QS / USE_QC on. If not, drop the two sitemap entries - there is a comment there saying so.

## qc: the speaking ring, and a refresh that is a reconnect (f1e71fd)

The ring never lit up. speakers.svelte.ts is deliberately a leaf - it takes participant state as arguments rather than importing the transport - so something has to feed it, and that something was an effect inside AppView. /qc renders ChatView directly, so it had every part of the indicator except the thing that drives it. The feed moved to call-speakers.ts and both shells call it.

A refresh was a silent eviction: a new identity in a new database, on the setup card, being told it had been "invited" to the call it started (host-ness was derived from whether the address bar had the code, which after a reload it always does), with a ghost left in the other side's roster. Measured with two browsers, one reload, both sides read out before and after. It is a reconnect now: the tab keeps the code, host-ness, name and a guest's mnemonic in sessionStorage, which survives a refresh and dies with the tab. Coming back under the same key is what removes the ghost, and the room's history is pulled back off the other peers by the ordinary digest. An account's key is never stored; a reload asks it to unlock again.

Worth knowing about the verification: whether a ring visibly lights needs an audible microphone and an AudioContext the browser will run, and a headless run has neither - the APP scores an empty speaking set in this harness too, which is how the difference was pinned to the feed rather than the detector. So the test asserts the analyser is being fed.

## chat: the leave control says what it is leaving (a3f5700)

In /qc that button was ChatView's red "Delete room", which is the wrong promise twice over. ChatView takes a leaveLabel now, defaulting to what it already said.

Also worth recording: svelte-check does not catch Svelte template compile errors. The first attempt used a `{@const}` where the compiler does not allow one, svelte-check reported zero errors, and the page rendered completely EMPTY with nothing in the console for the driver to see. `vite build` catches it in seconds.

## qc: hanging up takes the call with it (273521e)

Leaving already did the wire half. It did not get rid of what the call had written, and it put you back on the setup card - the same code, a Join button, "Send the link" - which is the screen you see BEFORE a call. The database is now deleted at hang-up rather than at tab close, and the page says so: a "Call ended" card with a button that mints a new code.

The hazard that made this worth arguing about first is fixed rather than avoided: dropping the scope used to set it to null, which makes dbName() answer "awful-chat" again - and leaveRoom finishes asynchronously, so its participant removal lands AFTER the drop and would have written into the user's own database. dropQuickStorage rotates to a fresh throwaway name instead of clearing, so a page that has once been quick can never address the real database again. The cached connection is closed before the delete, or it queues behind it.

A consequence to know: rejoining a code after hanging up starts empty. If the other person is still there the history comes back from their copy; if not, it is gone.

---

Typecheck clean, vite build clean, 1638 frontend tests pass. e2e against a local relay and real browsers: quick-send, quick-send-swarm, quick-send-once, quick-send-alongside-app, quick-call, quick-call-live, quick-call-alongside-app, quick-call-account, large-file and room-open-feedback. The quick-* scenarios need the routes enabled on the dev server (VITE_USE_QS=true VITE_USE_QC=true) and say so if they are not.