### PR TITLE
Dev to main: choosing a camera, a green room for /qc, and devices reachable from the call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ group video.
   with, not replaces, your OS's full-disk encryption.
 - **Installable PWA**: opens offline with your full history; sending waits
   for peers.
+- **Two pages that need no account**, optional and off unless an instance
+  turns them on (`USE_QS`, `USE_QC`): `/qs` hands a file to one person or
+  several over a peer-to-peer link that is never uploaded anywhere, with a
+  one-time switch that closes the link once it has delivered; `/qc` is a call
+  with no room and no account, under a throwaway identity in a database
+  deleted when the tab closes.
 
 ## How private is it, exactly
 
@@ -172,7 +178,10 @@ iptables DNAT instead, which costs nothing.
 `VITE_API_URL`, `VITE_RELAY_MULTIADDR` and the two SFU variables are the
 instance's own addresses. They are NOT compiled into the app: the frontend
 container writes them to `/config.json` when it starts and the app reads that
-before it mounts, so changing one takes a restart rather than a rebuild.
+before it mounts, so changing one takes a restart rather than a rebuild. The
+two optional pages, `USE_QS` and `USE_QC`, ride the same file and behave the
+same way: `docker compose up -d frontend` is enough, and `curl
+https://<domain>/config.json` says which of them an instance is serving.
 
 That is also what makes a build checkable. Two instances running the *same
 build* - same commit and the same `PLUGIN_SOURCES`, since plugins compile in -
@@ -222,6 +231,8 @@ whose context holds no repository declares no commit.
 | `PLUGIN_SOURCES_ALLOW_UNPINNED` | no | `1` allows a plugin source that names no commit. Leave it off: plugins compile into the bundle, so an unpinned source can ship different code on the next build with no diff to review |
 | `SFU_TELEMETRY` | no | `1` answers a client's `ms:diag` with a live snapshot and prints one `[sfu-telemetry]` line per room per sweep to the SFU log |
 | `SFU_DIAG_MIN_INTERVAL_MS` | no | floor between one peer's `ms:diag` requests, default 10000 |
+| `USE_QS` | no | `1` serves `/qs`, which hands a file to one person or several with no account: the bytes go peer to peer and are never uploaded anywhere, everyone holding the link serves what they have finished, and a one-time switch closes the link as soon as it has delivered. Unset answers that path with the landing page, and the app never mentions the feature |
+| `USE_QC` | no | `1` serves `/qc`, a call with no room and no account: camera, screen share and text chat under a throwaway identity in a database deleted when the tab closes. An identity already on the device can be used instead, and the call stays just as disposable. Unset answers that path with the landing page |
 
 Firewall: open 80/443 (web), 3478 tcp+udp (TURN), 5349 tcp+udp (TURN TLS,
 when configured), the SFU media range **tcp and udp**

--- a/frontend/src/lib/call-tile-menu.test.ts
+++ b/frontend/src/lib/call-tile-menu.test.ts
@@ -391,3 +391,32 @@ describe("tileMenuHeight", () => {
     expect(tileMenuHeight([])).toBeGreaterThan(0);
   });
 });
+
+describe("a call nobody keeps", () => {
+  it("offers the volume and the call controls, and no phonebook", () => {
+    // /qc: the identity on the other side lasts as long as their tab, so a
+    // saved contact for somebody who cannot be contacted again is not a
+    // feature - and opening a DM would persist a room for them.
+    const rows = buildTileMenu(
+      tileMenuState({
+        kind: "camera",
+        label: "Guest 4821",
+        canMessage: false,
+        inPhonebook: false,
+        hasVideo: true,
+        pipSupported: true,
+      })
+    );
+    const labels = rows
+      .filter((r) => r.type === "item")
+      .map((r) => (r as { label: string }).label);
+
+    expect(labels).not.toContain("Add to phonebook");
+    expect(labels).not.toContain("Remove from phonebook");
+    expect(labels).not.toContain("Message");
+    // What is about the call itself stays.
+    expect(labels.some((l) => /mute/i.test(l))).toBe(true);
+    expect(rows.some((r) => r.type === "volume")).toBe(true);
+    expect(labels.some((l) => /spotlight|focus/i.test(l))).toBe(true);
+  });
+});

--- a/frontend/src/lib/cameras.svelte.ts
+++ b/frontend/src/lib/cameras.svelte.ts
@@ -1,0 +1,113 @@
+/**
+ * Which cameras exist, and which one to use.
+ *
+ * The app never enumerated video devices at all. startCamera asked for
+ * `{ video: { width, height, frameRate } }` and took whatever the browser
+ * called default, and no screen anywhere offered a choice - so a camera that
+ * is not the default could not be selected, however plainly it was there.
+ * That is why an iPhone offering itself as a Continuity Camera showed up in
+ * Zoom and Meet and not here: they list video inputs and this did not.
+ *
+ * Two things follow, and the second is the one that matters for a phone:
+ *
+ * Labels are empty until camera permission has been granted at least once.
+ * Before that the browser returns entries with blank labels, so a picker
+ * shown to somebody who has never turned their camera on can only offer
+ * "Camera 1". Turning it on once fixes it for good, which is why the list is
+ * refreshed after every successful start.
+ *
+ * And the set CHANGES while the page is open. A Continuity Camera attaches
+ * when the phone is unlocked and near the Mac, and detaches when it is not; a
+ * USB webcam arrives mid-call. `devicechange` is the only notice of either,
+ * so a list read once at mount is wrong within a minute.
+ */
+
+import { loadAudioPrefs, saveAudioPrefs } from "$lib/transport/audio-prefs";
+import {
+  onCameraStarted,
+  startCamera,
+  stopCamera,
+} from "$lib/transport/call.svelte";
+import { transportState } from "$lib/transport/transport.svelte";
+
+interface CameraState {
+  /** Video inputs, newest listing. Empty before the first refresh. */
+  devices: MediaDeviceInfo[];
+  /** The remembered choice, or null for the browser's default. */
+  selected: string | null;
+  /**
+   * True when the browser is still withholding labels, i.e. camera
+   * permission has never been granted. The picker says so rather than
+   * showing a list of "Camera 1, Camera 2" as though that were the name.
+   */
+  unnamed: boolean;
+}
+
+export const cameras = $state<CameraState>({
+  devices: [],
+  selected: loadAudioPrefs().cameraDevice,
+  unnamed: false,
+});
+
+/** Read the current video inputs. Safe to call often; it is a cheap query. */
+export async function refreshCameras(): Promise<void> {
+  if (typeof navigator === "undefined" || !navigator.mediaDevices) return;
+  try {
+    const all = await navigator.mediaDevices.enumerateDevices();
+    const video = all.filter((d) => d.kind === "videoinput");
+    cameras.devices = video;
+    cameras.unnamed = video.length > 0 && video.every((d) => !d.label);
+    // A remembered camera that is no longer here stops being the answer, or
+    // the picker shows a selection that does not exist and getUserMedia
+    // quietly returns something else.
+    if (cameras.selected && !video.some((d) => d.deviceId === cameras.selected)) {
+      cameras.selected = null;
+      saveAudioPrefs({ cameraDevice: null });
+    }
+  } catch {
+    // Blocked or unsupported: no list, and the default camera still works.
+  }
+}
+
+let watching = false;
+
+/**
+ * Keep the list current for the life of the page. Idempotent, and never
+ * removed - it is one listener, and both shells that show a picker would
+ * otherwise register their own.
+ */
+export function watchCameras(): void {
+  if (watching || typeof navigator === "undefined" || !navigator.mediaDevices) {
+    return;
+  }
+  watching = true;
+  navigator.mediaDevices.addEventListener("devicechange", () => {
+    void refreshCameras();
+  });
+  // A first successful start is when the labels stop being blank.
+  onCameraStarted(() => void refreshCameras());
+  void refreshCameras();
+}
+
+/**
+ * Use this camera from now on.
+ *
+ * Restarts a camera that is already running, because that is the whole point
+ * of choosing one mid-call: stop and start republishes the track to the SFU,
+ * which is what the other side needs to see the new picture.
+ */
+export async function setCamera(deviceId: string | null): Promise<void> {
+  cameras.selected = deviceId;
+  saveAudioPrefs({ cameraDevice: deviceId });
+  if (transportState.cameraOff) return;
+  stopCamera();
+  await startCamera();
+  // Permission has certainly been granted by now, so the labels the first
+  // listing lacked are available.
+  await refreshCameras();
+}
+
+/** The label to show for a device, never an empty string. */
+export function cameraLabel(device: MediaDeviceInfo, index: number): string {
+  return device.label || `Camera ${index + 1}`;
+}

--- a/frontend/src/lib/cameras.test.ts
+++ b/frontend/src/lib/cameras.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The camera list is the whole fix, so the things worth pinning are the two
+ * that made an iPhone invisible: a list that goes stale, and a remembered
+ * choice that outlives the device it names.
+ */
+
+let deviceList: { kind: string; deviceId: string; label: string }[] = [];
+let listeners: (() => void)[] = [];
+const prefs: Record<string, unknown> = {};
+const transportState = { cameraOff: true };
+
+vi.mock("$lib/transport/audio-prefs", () => ({
+  loadAudioPrefs: () => ({ cameraDevice: prefs.cameraDevice ?? null }),
+  saveAudioPrefs: (patch: Record<string, unknown>) =>
+    void Object.assign(prefs, patch),
+}));
+vi.mock("$lib/transport/call.svelte", () => ({
+  onCameraStarted: vi.fn(),
+  startCamera: vi.fn(async () => {}),
+  stopCamera: vi.fn(),
+}));
+vi.mock("$lib/transport/transport.svelte", () => ({ transportState }));
+
+function installMediaDevices() {
+  listeners = [];
+  vi.stubGlobal("navigator", {
+    mediaDevices: {
+      enumerateDevices: async () => deviceList,
+      addEventListener: (_type: string, fn: () => void) => listeners.push(fn),
+    },
+  });
+}
+
+async function load() {
+  vi.resetModules();
+  installMediaDevices();
+  return import("./cameras.svelte");
+}
+
+const CAM = (deviceId: string, label = "") => ({
+  kind: "videoinput",
+  deviceId,
+  label,
+});
+
+describe("cameras", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    deviceList = [];
+    for (const k of Object.keys(prefs)) delete prefs[k];
+    transportState.cameraOff = true;
+  });
+
+  it("lists video inputs and nothing else", async () => {
+    deviceList = [
+      CAM("cam-1", "FaceTime HD"),
+      { kind: "audioinput", deviceId: "mic-1", label: "Mic" },
+      CAM("cam-2", "Flavio's iPhone"),
+    ];
+    const m = await load();
+    await m.refreshCameras();
+    expect(m.cameras.devices.map((d) => d.deviceId)).toEqual(["cam-1", "cam-2"]);
+  });
+
+  it("notices a camera that arrives while the page is open", async () => {
+    // The iPhone case: a Continuity Camera attaches when the phone is
+    // unlocked and nearby, long after any list read at mount.
+    deviceList = [CAM("cam-1", "FaceTime HD")];
+    const m = await load();
+    m.watchCameras();
+    await Promise.resolve();
+    expect(m.cameras.devices).toHaveLength(1);
+
+    deviceList = [CAM("cam-1", "FaceTime HD"), CAM("cam-2", "Flavio's iPhone")];
+    for (const fire of listeners) fire();
+    await vi.waitFor(() => expect(m.cameras.devices).toHaveLength(2));
+    expect(m.cameras.devices[1].label).toBe("Flavio's iPhone");
+  });
+
+  it("forgets a remembered camera once it is gone", async () => {
+    prefs.cameraDevice = "cam-2";
+    deviceList = [CAM("cam-1", "FaceTime HD")];
+    const m = await load();
+    expect(m.cameras.selected).toBe("cam-2");
+    await m.refreshCameras();
+    // Otherwise the picker shows a selection that does not exist and
+    // getUserMedia quietly hands back something else.
+    expect(m.cameras.selected).toBeNull();
+    expect(prefs.cameraDevice).toBeNull();
+  });
+
+  it("keeps a remembered camera that is still there", async () => {
+    prefs.cameraDevice = "cam-2";
+    deviceList = [CAM("cam-1"), CAM("cam-2", "Flavio's iPhone")];
+    const m = await load();
+    await m.refreshCameras();
+    expect(m.cameras.selected).toBe("cam-2");
+  });
+
+  it("says when the browser is withholding the names", async () => {
+    deviceList = [CAM("cam-1"), CAM("cam-2")];
+    const m = await load();
+    await m.refreshCameras();
+    expect(m.cameras.unnamed).toBe(true);
+    expect(m.cameraLabel(m.cameras.devices[0], 0)).toBe("Camera 1");
+
+    deviceList = [CAM("cam-1", "FaceTime HD"), CAM("cam-2")];
+    await m.refreshCameras();
+    expect(m.cameras.unnamed).toBe(false);
+  });
+
+  it("restarts a running camera when the choice changes", async () => {
+    deviceList = [CAM("cam-1", "FaceTime HD"), CAM("cam-2", "iPhone")];
+    const m = await load();
+    const { startCamera, stopCamera } = await import(
+      "$lib/transport/call.svelte"
+    );
+    transportState.cameraOff = false;
+
+    await m.setCamera("cam-2");
+
+    // Stop and start is what republishes the track, which is the only way
+    // the other side sees the new picture.
+    expect(stopCamera).toHaveBeenCalled();
+    expect(startCamera).toHaveBeenCalled();
+    expect(prefs.cameraDevice).toBe("cam-2");
+  });
+
+  it("does not start a camera that was off", async () => {
+    deviceList = [CAM("cam-1"), CAM("cam-2")];
+    const m = await load();
+    const { startCamera } = await import("$lib/transport/call.svelte");
+    await m.setCamera("cam-2");
+    expect(startCamera).not.toHaveBeenCalled();
+    expect(prefs.cameraDevice).toBe("cam-2");
+  });
+
+  it("survives a browser with no media devices at all", async () => {
+    vi.resetModules();
+    vi.stubGlobal("navigator", {});
+    const m = await import("./cameras.svelte");
+    await expect(m.refreshCameras()).resolves.toBeUndefined();
+    expect(() => m.watchCameras()).not.toThrow();
+  });
+});

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -144,6 +144,8 @@
     leaveConfirm?: boolean;
     /** Passed to the call view's hang-up. See VoiceVideoCallView. */
     onHangUp?: () => void;
+    /** Passed to the call view's tile menus. See VoiceVideoCallView. */
+    personActions?: boolean;
     onOpenSidebar?: () => void;
     onOpenDm?: (peerId: string) => Promise<void> | void;
     incomingSharedFiles?: File[];
@@ -158,6 +160,7 @@
     leaveLabel,
     leaveConfirm = true,
     onHangUp,
+    personActions = true,
     onOpenSidebar,
     onOpenDm,
     incomingSharedFiles = [],
@@ -1925,7 +1928,7 @@
           ? 'min-w-0 flex-1'
           : 'shrink-0'}"
       >
-        <VoiceVideoCallView beside={callBeside} {onHangUp} />
+        <VoiceVideoCallView beside={callBeside} {onHangUp} {personActions} />
       </div>
     {/if}
     <div

--- a/frontend/src/lib/components/ChatView.svelte
+++ b/frontend/src/lib/components/ChatView.svelte
@@ -134,18 +134,25 @@
      * "Leave call", because a quick call is not a room anybody is deleting -
      * there is nothing saved to delete.
      */
-    leaveLabel?: string;
     /**
-     * Whether the leave control needs a second click. On by default because
-     * in a room it deletes one. /qc turns it off: there is nothing to delete
-     * that hanging up does not already take, and a confirm nothing signposts
-     * reads as a button that does not work.
+     * This conversation is not kept: it is a quick call, and closing it
+     * destroys everything it held.
+     *
+     * One flag rather than the four settings it used to be, because they were
+     * four spellings of the same fact and could only ever be set together.
+     * What it decides:
+     *
+     *  - the leave control says "Leave call" rather than "Delete room", since
+     *    there is no saved room to delete;
+     *  - it needs no second click, because hanging up already takes
+     *    everything and a confirm nothing signposts reads as a broken button;
+     *  - hanging up in the call bar LEAVES rather than just ending the call,
+     *    the way it does in every other call app - here the two are the same
+     *    act, which is why onLeave can serve as both;
+     *  - the tile menus drop message, profile and phonebook, which are all
+     *    about a person who exists for as long as their tab does.
      */
-    leaveConfirm?: boolean;
-    /** Passed to the call view's hang-up. See VoiceVideoCallView. */
-    onHangUp?: () => void;
-    /** Passed to the call view's tile menus. See VoiceVideoCallView. */
-    personActions?: boolean;
+    ephemeral?: boolean;
     onOpenSidebar?: () => void;
     onOpenDm?: (peerId: string) => Promise<void> | void;
     incomingSharedFiles?: File[];
@@ -157,10 +164,7 @@
     roomCode,
     roomName,
     onLeave,
-    leaveLabel,
-    leaveConfirm = true,
-    onHangUp,
-    personActions = true,
+    ephemeral = false,
     onOpenSidebar,
     onOpenDm,
     incomingSharedFiles = [],
@@ -1565,7 +1569,11 @@
   /** What the leave control says. /qc overrides it: a quick call is not a
    *  room anybody is deleting, because there is nothing saved to delete. */
   const leaveText = $derived(
-    leaveLabel ?? (isDmChat ? "Delete conversation" : "Delete room")
+    ephemeral
+      ? "Leave call"
+      : isDmChat
+        ? "Delete conversation"
+        : "Delete room"
   );
 
   // Desktop only: below sm there is no room for two columns, and the call
@@ -1878,7 +1886,7 @@
               variant="ghost"
               size="icon"
               onclick={() => {
-                if (leaveConfirm && !confirmingDelete) {
+                if (!ephemeral && !confirmingDelete) {
                   confirmingDelete = true;
                   setTimeout(() => (confirmingDelete = false), 3000);
                   return;
@@ -1928,7 +1936,12 @@
           ? 'min-w-0 flex-1'
           : 'shrink-0'}"
       >
-        <VoiceVideoCallView beside={callBeside} {onHangUp} {personActions} />
+        <!-- In a call nobody keeps, hanging up and leaving are one act. -->
+        <VoiceVideoCallView
+          beside={callBeside}
+          onHangUp={ephemeral ? onLeave : undefined}
+          personActions={!ephemeral}
+        />
       </div>
     {/if}
     <div

--- a/frontend/src/lib/components/DeviceCheck.svelte
+++ b/frontend/src/lib/components/DeviceCheck.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  /**
+   * The green room: see yourself and watch your own level before joining.
+   *
+   * Every other call app puts this in front of you, and /qc had nothing -
+   * you picked a name and were in, with whatever camera and microphone the
+   * browser felt like, and no way to find out beforehand that the wrong one
+   * was selected or that the mic was dead.
+   *
+   * It runs its own preview stream rather than borrowing the call's, because
+   * it exists BEFORE there is a call. That has a second use: getUserMedia is
+   * what makes a browser hand over device labels, so opening this is also
+   * what turns "Camera 1" into the camera's actual name.
+   *
+   * The stream is stopped on unmount and whenever the panel is closed. A
+   * preview left running holds the camera light on behind a joined call.
+   */
+  import { onDestroy } from "svelte";
+  import { Mic, Video, VideoOff } from "@lucide/svelte";
+  import { Label } from "$lib/components/ui/label";
+  import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+  } from "$lib/components/ui/select";
+  import { cameraLabel, cameras, refreshCameras, watchCameras } from "$lib/cameras.svelte";
+  import { loadAudioPrefs, saveAudioPrefs } from "$lib/transport/audio-prefs";
+
+  let { open = false }: { open?: boolean } = $props();
+
+  let video = $state<HTMLVideoElement | null>(null);
+  // $state: the template reads it to show the "no picture" placeholder.
+  let stream = $state<MediaStream | null>(null);
+  let mics = $state<MediaDeviceInfo[]>([]);
+  let mic = $state<string | null>(loadAudioPrefs().inputDevice);
+  let camera = $state<string | null>(cameras.selected);
+  /** 0..1, smoothed. Drives the bar that tells you the mic is alive. */
+  let level = $state(0);
+  let error = $state<string | null>(null);
+  let audioCtx: AudioContext | null = null;
+  let raf = 0;
+
+  watchCameras();
+
+  function teardown() {
+    cancelAnimationFrame(raf);
+    raf = 0;
+    stream?.getTracks().forEach((t) => t.stop());
+    stream = null;
+    void audioCtx?.close().catch(() => {});
+    audioCtx = null;
+    level = 0;
+  }
+
+  onDestroy(teardown);
+
+  // Open and close, and every device change, rebuild the preview.
+  $effect(() => {
+    if (!open) {
+      teardown();
+      return;
+    }
+    void start(camera, mic);
+  });
+
+  async function start(cameraId: string | null, micId: string | null) {
+    teardown();
+    error = null;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: cameraId ? { deviceId: { ideal: cameraId } } : true,
+        audio: micId ? { deviceId: { ideal: micId } } : true,
+      });
+    } catch (err) {
+      // A refused permission or a camera another app is holding. The mic and
+      // camera pickers are still worth showing; joining is still allowed.
+      error =
+        err instanceof Error && err.name === "NotAllowedError"
+          ? "Your browser is not letting this page use the camera or microphone."
+          : "Could not open the camera or microphone.";
+      return;
+    }
+    if (video) video.srcObject = stream;
+    // Labels arrive with permission, so this is the moment the lists become
+    // readable rather than a row of "Camera 1".
+    void refreshCameras();
+    void navigator.mediaDevices
+      .enumerateDevices()
+      .then((all) => (mics = all.filter((d) => d.kind === "audioinput")))
+      .catch(() => {});
+    meter();
+  }
+
+  /** A plain RMS meter. Enough to answer "is it hearing me". */
+  function meter() {
+    const track = stream?.getAudioTracks()[0];
+    if (!track) return;
+    audioCtx = new AudioContext();
+    const analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 512;
+    audioCtx.createMediaStreamSource(new MediaStream([track])).connect(analyser);
+    const bins = new Float32Array(analyser.fftSize);
+    const tick = () => {
+      analyser.getFloatTimeDomainData(bins);
+      let sum = 0;
+      for (const v of bins) sum += v * v;
+      const rms = Math.sqrt(sum / bins.length);
+      // Decay slowly, rise fast: a bar that tracks the raw value exactly
+      // reads as noise rather than as speech.
+      level = Math.max(Math.min(rms * 4, 1), level * 0.88);
+      raf = requestAnimationFrame(tick);
+    };
+    tick();
+  }
+
+  function pickCamera(id: string) {
+    camera = id || null;
+    saveAudioPrefs({ cameraDevice: camera });
+    cameras.selected = camera;
+  }
+
+  function pickMic(id: string) {
+    mic = id || null;
+    saveAudioPrefs({ inputDevice: mic });
+  }
+</script>
+
+{#if open}
+  <div class="flex w-full flex-col gap-3">
+    <div
+      class="relative aspect-video w-full overflow-hidden rounded-lg border border-border bg-muted/40"
+    >
+      <!-- muted: this is your own microphone coming back at you. -->
+      <!-- svelte-ignore a11y_media_has_caption -->
+      <video
+        bind:this={video}
+        autoplay
+        playsinline
+        muted
+        class="size-full scale-x-[-1] object-cover"
+      ></video>
+      {#if !stream}
+        <div
+          class="absolute inset-0 flex items-center justify-center text-muted-foreground"
+        >
+          <VideoOff class="size-6" />
+        </div>
+      {/if}
+    </div>
+
+    {#if error}
+      <p class="text-xs text-destructive font-mono leading-relaxed">{error}</p>
+    {/if}
+
+    <div class="flex items-center gap-2">
+      <Mic class="size-3.5 shrink-0 text-muted-foreground" />
+      <div class="h-1.5 flex-1 overflow-hidden rounded bg-muted">
+        <div
+          class="h-full bg-green-500 transition-[width] duration-75"
+          style="width: {Math.round(level * 100)}%"
+        ></div>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+      >
+        <Video class="mr-1 inline size-3" /> Camera
+      </Label>
+      <Select type="single" value={camera ?? ""} onValueChange={pickCamera}>
+        <SelectTrigger class="bg-background border-input font-mono text-sm">
+          <span class="block truncate">
+            {cameras.devices.find((d) => d.deviceId === camera)?.label ||
+              "System default"}
+          </span>
+        </SelectTrigger>
+        <SelectContent class="bg-popover border-border font-mono">
+          {#each cameras.devices as dev, i (dev.deviceId)}
+            <SelectItem value={dev.deviceId} class="font-mono text-sm">
+              <span class="block truncate">{cameraLabel(dev, i)}</span>
+            </SelectItem>
+          {/each}
+        </SelectContent>
+      </Select>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+      >
+        <Mic class="mr-1 inline size-3" /> Microphone
+      </Label>
+      <Select type="single" value={mic ?? ""} onValueChange={pickMic}>
+        <SelectTrigger class="bg-background border-input font-mono text-sm">
+          <span class="block truncate">
+            {mics.find((d) => d.deviceId === mic)?.label || "System default"}
+          </span>
+        </SelectTrigger>
+        <SelectContent class="bg-popover border-border font-mono">
+          {#each mics as dev, i (dev.deviceId)}
+            <SelectItem value={dev.deviceId} class="font-mono text-sm">
+              <span class="block truncate"
+                >{dev.label || `Microphone ${i + 1}`}</span
+              >
+            </SelectItem>
+          {/each}
+        </SelectContent>
+      </Select>
+    </div>
+  </div>
+{/if}

--- a/frontend/src/lib/components/DeviceCheck.svelte
+++ b/frontend/src/lib/components/DeviceCheck.svelte
@@ -15,7 +15,7 @@
    * The stream is stopped on unmount and whenever the panel is closed. A
    * preview left running holds the camera light on behind a joined call.
    */
-  import { onDestroy } from "svelte";
+  import { onDestroy, untrack } from "svelte";
   import { Mic, Video, VideoOff } from "@lucide/svelte";
   import { Label } from "$lib/components/ui/label";
   import {
@@ -55,17 +55,47 @@
 
   onDestroy(teardown);
 
-  // Open and close, and every device change, rebuild the preview.
+  /**
+   * Attach the stream to the element, whichever arrives second.
+   *
+   * Assigning inside start() raced the element into existence: the panel is
+   * behind an {#if}, so on the first open the <video> may not be bound yet,
+   * and a single assignment that finds `video` null never happens again -
+   * a black box with a live stream behind it. And `autoplay` is not enough
+   * on its own for a srcObject set from script, so it is asked to play.
+   */
   $effect(() => {
-    if (!open) {
-      teardown();
-      return;
-    }
-    void start(camera, mic);
+    if (!video || !stream) return;
+    video.srcObject = stream;
+    void video.play().catch(() => {});
+  });
+
+  /**
+   * Open and close, and every device change, rebuild the preview.
+   *
+   * The body is untracked and the dependencies are read deliberately above
+   * it, because the obvious version ate itself: teardown() READS `stream` and
+   * start() WRITES it, so the effect depended on the very thing it set. Each
+   * run stopped the stream the previous run had just acquired and asked for
+   * another, forever - which is what a black preview and a level bar pinned
+   * at zero actually were. The tracks were live for a moment and then
+   * "ended", which is the tell.
+   *
+   * Teardown moves into the cleanup, where Svelte runs it before the next run
+   * and once more on destroy - so there is exactly one place that stops a
+   * stream, and it cannot race the place that starts one.
+   */
+  $effect(() => {
+    const wantOpen = open;
+    const wantCamera = camera;
+    const wantMic = mic;
+    untrack(() => {
+      if (wantOpen) void start(wantCamera, wantMic);
+    });
+    return () => untrack(teardown);
   });
 
   async function start(cameraId: string | null, micId: string | null) {
-    teardown();
     error = null;
     try {
       stream = await navigator.mediaDevices.getUserMedia({
@@ -81,7 +111,6 @@
           : "Could not open the camera or microphone.";
       return;
     }
-    if (video) video.srcObject = stream;
     // Labels arrive with permission, so this is the moment the lists become
     // readable rather than a row of "Camera 1".
     void refreshCameras();
@@ -97,6 +126,11 @@
     const track = stream?.getAudioTracks()[0];
     if (!track) return;
     audioCtx = new AudioContext();
+    // A context created off the back of an awaited getUserMedia is not
+    // covered by the click that started it, so it begins suspended and every
+    // analyser read comes back as silence - a level bar that never moves.
+    // The call's own detector resumes for the same reason (speakers.svelte).
+    void audioCtx.resume().catch(() => {});
     const analyser = audioCtx.createAnalyser();
     analyser.fftSize = 512;
     audioCtx.createMediaStreamSource(new MediaStream([track])).connect(analyser);

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -182,10 +182,7 @@
           roomName="Quick call"
           selfId={identityStore.did ?? ""}
           onLeave={endQuickCall}
-          onHangUp={endQuickCall}
-          leaveLabel="Leave call"
-          leaveConfirm={false}
-          personActions={false}
+          ephemeral
         />
       </div>
     </div>

--- a/frontend/src/lib/components/QuickCall.svelte
+++ b/frontend/src/lib/components/QuickCall.svelte
@@ -10,11 +10,12 @@
    */
   import { onDestroy, onMount } from "svelte";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
-  import { Check, Copy, LogIn, UserRound } from "@lucide/svelte";
+  import { Check, Copy, LogIn, Settings2, UserRound } from "@lucide/svelte";
   import { Button } from "$lib/components/ui/button/index.js";
   import { Input } from "$lib/components/ui/input/index.js";
   import * as Card from "$lib/components/ui/card/index.js";
   import AvatarPickerDialog from "$lib/components/AvatarPickerDialog.svelte";
+  import DeviceCheck from "$lib/components/DeviceCheck.svelte";
   import ChatView from "$lib/components/ChatView.svelte";
   import UnlockIdentity from "$lib/components/UnlockIdentity.svelte";
   import { identityStore } from "$lib/identity/identity.svelte";
@@ -43,6 +44,9 @@
   let name = $state(quickCall.profile.name);
   let remember = $state(quickCall.remembered);
   let pickerOpen = $state(false);
+  /** The green room. Closed by default so the page does not grab a camera
+   *  from somebody who only wants to type a name and join. */
+  let checking = $state(false);
   let copied = $state(false);
   /** True when this page minted the code rather than following a link. */
   let isHost = $state(false);
@@ -181,6 +185,7 @@
           onHangUp={endQuickCall}
           leaveLabel="Leave call"
           leaveConfirm={false}
+          personActions={false}
         />
       </div>
     </div>
@@ -232,7 +237,9 @@
       class="min-h-dvh overflow-y-auto bg-background text-foreground flex items-center justify-center p-4 font-mono"
     >
       <Card.Root
-        class="w-full max-w-sm bg-card border-border text-card-foreground"
+        class="w-full {checking
+          ? 'max-w-md'
+          : 'max-w-sm'} bg-card border-border text-card-foreground transition-[max-width]"
       >
         <Card.Header class="pb-4">
           <div class="flex items-center gap-2 mb-1">
@@ -299,6 +306,16 @@
               placeholder="Your display name"
               class="bg-background border-input text-foreground placeholder:text-muted-foreground font-mono text-center focus-visible:ring-ring"
             />
+
+            <button
+              type="button"
+              onclick={() => (checking = !checking)}
+              class="flex w-full items-center justify-center gap-1.5 text-xs font-mono text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              <Settings2 class="size-3.5" />
+              {checking ? "Hide camera and mic" : "Check camera and mic"}
+            </button>
+            <DeviceCheck open={checking} />
 
             {#if quickCall.identity === "account"}
               <p class="text-xs text-muted-foreground font-mono text-center">

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -2719,7 +2719,9 @@ import {
         Camera and audio
       </DialogTitle>
     </DialogHeader>
-    <div class="flex-1 overflow-y-auto px-4 py-4">
+    <!-- pb only: DialogContent is a grid with gap-4, so a top padding here
+         doubles the space under the header. Same as SettingsDialog. -->
+    <div class="flex-1 overflow-y-auto px-4 pb-4">
       <AudioSettings />
     </div>
   </DialogContent>

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -126,7 +126,21 @@ import {
      * it the way it does in every other call app.
      */
     onHangUp = leaveCall,
-  }: { beside?: boolean; onHangUp?: () => void } = $props();
+    /**
+     * Whether a tile menu offers the things that outlast the call: message
+     * this person, view their profile, keep them in the phonebook. Off for
+     * /qc, where the identity on the other side exists for as long as their
+     * tab does - a saved contact for somebody who cannot be contacted again
+     * is not a feature, and opening a DM would persist a room for them.
+     * What the menu keeps there is what is about the CALL: their volume,
+     * the spotlight, fullscreen, picture-in-picture.
+     */
+    personActions = true,
+  }: {
+    beside?: boolean;
+    onHangUp?: () => void;
+    personActions?: boolean;
+  } = $props();
 
   $effect(() => {
     loadProfile();
@@ -684,7 +698,7 @@ import {
       isFullscreen,
       pipSupported: browserPipSupported(),
       pipOpen: callPipPanel.browserPip,
-      canMessage: !tile.isLocal && !!tile.peerId,
+      canMessage: personActions && !tile.isLocal && !!tile.peerId,
       inPhonebook: !tile.isLocal && !!tile.peerId && isInPhonebook(tile.peerId),
       // Off the slider, which openTileMenu seeds from the live gain: it is
       // reactive, so dragging it to 0 flips the row to Unmute in place.

--- a/frontend/src/lib/components/VoiceVideoCallView.svelte
+++ b/frontend/src/lib/components/VoiceVideoCallView.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
   import { Tip } from "$lib/components/ui/tooltip";
+  import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+  } from "$lib/components/ui/dialog";
+  import AudioSettings from "./settings/AudioSettings.svelte";
   import { formatReactorNames } from "$lib/reaction-names";
   import GifImage from "./GifImage.svelte";
   import { RELAY_TIP } from "$lib/copy";
@@ -141,6 +148,17 @@ import {
     onHangUp?: () => void;
     personActions?: boolean;
   } = $props();
+
+  /**
+   * The device picker, opened from the call bar.
+   *
+   * It has to live HERE rather than in the app's settings dialog, because
+   * /qc has no sidebar and therefore no settings at all: once a quick call
+   * started, there was no way to change camera, microphone or speaker.
+   * Putting it on the controls fixes that and saves the app several clicks
+   * for the thing people reach for mid-call anyway.
+   */
+  let deviceSettingsOpen = $state(false);
 
   $effect(() => {
     loadProfile();
@@ -2302,6 +2320,23 @@ import {
             {/if}
           </div>
 
+          <Tip text="Camera and audio">
+            {#snippet children(props)}
+          <button
+            {...props}
+            type="button"
+            onclick={() => (deviceSettingsOpen = true)}
+            aria-label="Camera and audio settings"
+            class={cn(
+              "group relative flex items-center justify-center rounded-lg bg-white/10 text-zinc-100 transition-all duration-200 hover:bg-white/20 hover:scale-105 shrink-0",
+              coarsePointer ? "h-11 w-11" : "h-8 w-8 md:h-10 md:w-10"
+            )}
+          >
+            <SlidersHorizontal class="md:size-5 size-4" />
+          </button>
+            {/snippet}
+          </Tip>
+
           <Tip text="Leave call">
             {#snippet children(props)}
           <button
@@ -2674,6 +2709,21 @@ import {
     inPhonebook={isInPhonebook(profileCardFor.peerId)}
   />
 {/if}
+
+<Dialog bind:open={deviceSettingsOpen}>
+  <DialogContent
+    class="bg-card border-border text-card-foreground font-mono w-full sm:max-w-lg flex flex-col p-0 max-h-[85dvh]"
+  >
+    <DialogHeader class="px-6 py-4 border-b border-border shrink-0">
+      <DialogTitle class="font-mono text-base font-semibold">
+        Camera and audio
+      </DialogTitle>
+    </DialogHeader>
+    <div class="flex-1 overflow-y-auto px-4 py-4">
+      <AudioSettings />
+    </div>
+  </DialogContent>
+</Dialog>
 
 <svelte:window
   onclick={closeMenus}

--- a/frontend/src/lib/components/settings/AudioSettings.svelte
+++ b/frontend/src/lib/components/settings/AudioSettings.svelte
@@ -12,6 +12,12 @@
   import { Button } from "$lib/components/ui/button";
   import { transportState, _dtln } from "$lib/transport/transport.svelte";
   import {
+    cameraLabel,
+    cameras,
+    setCamera,
+    watchCameras,
+  } from "$lib/cameras.svelte";
+  import {
     getVoiceActiveInputDevice,
     getVoiceActiveOutputDevice,
     getVoiceInputDevices,
@@ -106,6 +112,10 @@
   }
   let inputSlider = $state<number[]>([liveInputSlider()]);
   let outputSlider = $state<number[]>([liveOutputSlider()]);
+
+  // The list is live: a phone offering itself as a camera attaches and
+  // detaches while this dialog is open.
+  watchCameras();
 
   $effect(() => {
     activeInput = getVoiceActiveInputDevice();
@@ -301,6 +311,58 @@
 </script>
 
 <div class="flex flex-col gap-6">
+  <!-- Camera Section -->
+  <div
+    class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"
+  >
+    <div class="flex items-center gap-2">
+      <div class="w-1 h-4 bg-blue-500 rounded-full"></div>
+      <Label
+        class="select-none text-xs font-mono text-muted-foreground uppercase tracking-wider"
+        >Camera</Label
+      >
+    </div>
+
+    {#if cameras.devices.length > 0}
+      <Select
+        type="single"
+        value={cameras.selected ?? ""}
+        onValueChange={(v) => void setCamera(v || null)}
+      >
+        <SelectTrigger
+          class="bg-background border-input font-mono text-sm focus:ring-ring"
+        >
+          <span class="block truncate">
+            {cameras.devices.find((d) => d.deviceId === cameras.selected)
+              ?.label || "System default"}
+          </span>
+        </SelectTrigger>
+        <SelectContent class="bg-popover border-border font-mono">
+          {#each cameras.devices as dev, i (dev.deviceId)}
+            <SelectItem value={dev.deviceId} class="font-mono text-sm">
+              <span class="block truncate">{cameraLabel(dev, i)}</span>
+            </SelectItem>
+          {/each}
+        </SelectContent>
+      </Select>
+      {#if cameras.unnamed}
+        <p class="text-xs text-muted-foreground font-mono">
+          Turn your camera on once and these get their real names - a browser
+          withholds them until it has been allowed a camera.
+        </p>
+      {:else}
+        <p class="text-xs text-muted-foreground font-mono">
+          Changes take effect at once if your camera is on. A phone offering
+          itself as a camera appears here as soon as it does.
+        </p>
+      {/if}
+    {:else}
+      <p class="text-xs text-muted-foreground font-mono">
+        No cameras found on this device.
+      </p>
+    {/if}
+  </div>
+
   <!-- Microphone Section -->
   <div
     class="flex flex-col gap-4 p-4 bg-muted/30 rounded-lg border border-border/50"

--- a/frontend/src/lib/transport/audio-prefs.ts
+++ b/frontend/src/lib/transport/audio-prefs.ts
@@ -1,7 +1,13 @@
 /**
- * Audio settings survive a reload. They live in localStorage rather than
- * IndexedDB because they belong to the device, not the identity: the mic you
- * picked on this machine should not follow you to another one through sync.
+ * Media-device settings survive a reload. They live in localStorage rather
+ * than IndexedDB because they belong to the device, not the identity: the mic
+ * you picked on this machine should not follow you to another one through
+ * sync.
+ *
+ * The camera lives here too, despite the file's name. It is the same kind of
+ * setting with the same lifetime, and a second store with identical mechanics
+ * would buy nothing; the localStorage key stays as it is so nobody's existing
+ * audio settings are lost to a rename.
  */
 
 const KEY = "awful_audio_prefs";
@@ -9,6 +15,12 @@ const KEY = "awful_audio_prefs";
 export interface AudioPrefs {
   inputDevice: string | null;
   outputDevice: string | null;
+  /**
+   * deviceId of the camera to ask for, or null for whatever the browser
+   * calls default. A device that has since gone away is not an error: the
+   * constraint is `ideal`, so getUserMedia falls back rather than failing.
+   */
+  cameraDevice: string | null;
   inputGain: number;
   outputVolume: number;
   dtlnEnabled: boolean;
@@ -31,6 +43,7 @@ export interface AudioPrefs {
 export const AUDIO_PREF_DEFAULTS: AudioPrefs = {
   inputDevice: null,
   outputDevice: null,
+  cameraDevice: null,
   inputGain: 1.0,
   outputVolume: 1.0,
   dtlnEnabled: true,
@@ -71,6 +84,7 @@ export function loadAudioPrefs(): AudioPrefs {
     return {
       inputDevice: typeof p.inputDevice === "string" ? p.inputDevice : null,
       outputDevice: typeof p.outputDevice === "string" ? p.outputDevice : null,
+      cameraDevice: typeof p.cameraDevice === "string" ? p.cameraDevice : null,
       inputGain: num(p.inputGain, AUDIO_PREF_DEFAULTS.inputGain, 0, 2.5),
       outputVolume: num(p.outputVolume, AUDIO_PREF_DEFAULTS.outputVolume, 0, 2),
       dtlnEnabled:

--- a/frontend/src/lib/transport/call.svelte.ts
+++ b/frontend/src/lib/transport/call.svelte.ts
@@ -401,14 +401,26 @@ export function toggleMute(): void {
   _sendCallState();
 }
 
+/** Set by cameras.svelte, which cannot be imported here without a cycle. */
+let _onCameraStarted: (() => void) | null = null;
+
+export function onCameraStarted(fn: () => void): void {
+  _onCameraStarted = fn;
+}
+
 export async function startCamera(): Promise<void> {
   // Clear any pending error timeout and reset the error state. Attempting
   // the operation again makes any stale error irrelevant.
   cancelErrorClear();
   transportState.error = null;
   try {
+    // `ideal`, not `exact`: a remembered camera that has since been unplugged
+    // (or an iPhone that stopped offering itself) must fall back to whatever
+    // is there rather than failing the whole call's video.
+    const preferred = loadAudioPrefs().cameraDevice;
     const stream = await navigator.mediaDevices.getUserMedia({
       video: {
+        ...(preferred ? { deviceId: { ideal: preferred } } : {}),
         width: { ideal: 1280 },
         height: { ideal: 720 },
         frameRate: { ideal: 30 },
@@ -417,6 +429,12 @@ export async function startCamera(): Promise<void> {
     });
     transportState.localCameraStream = stream;
     transportState.cameraOff = false;
+    // Permission has just been granted, if it had not been before, so the
+    // device labels the browser was withholding are now readable. Told
+    // rather than polled, and deliberately not imported: cameras.svelte
+    // imports THIS module to restart a camera, so a direct call would be a
+    // cycle.
+    _onCameraStarted?.();
     playCameraOnSound();
     try {
       await _video.startCamera(stream);


### PR DESCRIPTION
Six commits, all from using the thing. The first is a gap in the app rather than in /qc.

## call: you can choose which camera (870479d)

Reported: an iPhone offering itself as a camera is picked up by Zoom and by Meet and not by this. The cause is not subtle - **the app never enumerated video devices at all**. startCamera asked for `{ video: { width, height, frameRate } }`, took whatever the browser called default, and no screen anywhere offered a choice. Audio has had device pickers in settings all along; video had none, so a camera that was not the default could not be selected however plainly it was there.

Video inputs are listed now, the choice is remembered per device beside the mic and speaker, and startCamera asks for it - `ideal` rather than `exact`, so a remembered camera that has since been unplugged falls back instead of failing the call's video.

Two details decide whether this works for a phone rather than just a webcam. The set CHANGES while the page is open: a Continuity Camera attaches when the phone is unlocked and nearby and detaches when it is not, so a list read once at mount is wrong within a minute and `devicechange` keeps it current. And labels are empty until camera permission has been granted once, which is why a picker can only say "Camera 1" to somebody who has never turned theirs on; the list refreshes after the first successful start and says so meanwhile rather than passing the placeholder off as a name.

## qc: a green room, and a tile menu about the call (0da4c76)

/qc put you straight into a call with whatever camera and microphone the browser felt like. There is a preview now behind "Check camera and mic" on the setup card: your own picture, a level bar that moves when you speak, and both pickers. Closed by default, because a page that grabs a camera from somebody who only wants to type a name and join is worse than one that never offers. It runs its own stream, which has a second use: getUserMedia is what makes a browser release device labels, so opening it is also what turns "Camera 1" into the camera's name.

The tile menu offered Message, View profile and Add to phonebook. All three are about a person who exists for as long as their tab does, and opening a DM would persist a room for them (ensureDmRoomForPeer). What the menu keeps in /qc is what is about the CALL: volume, mute, spotlight, fullscreen, picture-in-picture.

## qc: the preview ate itself, and four flags become one (5764e18)

The green room showed a black box and a level bar pinned at zero. The tell was in the tracks - "audio:ended, video:ended", acquired and then stopped. The effect building the preview was eating its own output: teardown() READS `stream` and start() WRITES it, so the effect depended on the very thing it set, and every run stopped the stream the previous run had just acquired. Teardown moves into the effect's cleanup and the body is untracked, so one place stops a stream, one place starts one, and they cannot race. The AudioContext is resumed too - one created off the back of an awaited getUserMedia is not covered by the click that opened the panel, so it starts suspended and every analyser read is silence.

That corrects something claimed in an earlier commit message: a headless browser CAN run an AudioContext, and this meter reads 28% in one. The reason speaking detection reads empty in the harness is something else and is not pinned.

The four props ChatView had grown for /qc - leaveLabel, leaveConfirm, onHangUp, personActions - were four spellings of one fact and could only be set together. They collapse into `ephemeral`: this conversation is not kept. It decides the label, the confirm, whether tile menus offer the things that outlast a call, and that hanging up leaves, which is why onLeave can serve as the hang-up too.

## call: the devices are reachable from the call itself (12de491, 99c97d3)

Asked after using it: once you are in, can you still change any of this? In /qc the answer was no, and not by degree - SettingsDialog is rendered by the app's sidebar, which a quick call does not have, so the green room was the only chance and the choice was final. Plug the phone in after joining and you were stuck.

A control on the call bar, next to the hang-up: the one surface both shells share, opening the same picker the settings dialog shows. The app gains it too, where reaching those mid-call meant leaving the call view for the sidebar. Deliberately not a prompt when the camera is switched on - asking every time is in the way of the common case, and the remembered camera survives calls and reloads so it is picked once.

## docs: the flags were nowhere a self-hoster would look (c7d6c49)

USE_QS and USE_QC were in .env.example and in comments in the compose files and the entrypoint, which is every place except the one .env.example points at: "the README's self-hosting section explains each variable". Both are in the variable table now, and the paragraph about the addresses written to /config.json says the flags ride the same file - so the answer to "why has my instance not got it" is a frontend restart and a curl, not a rebuild.

---

`pnpm check` clean (5123 files - worth saying, since a bare `svelte-check` checks 217 and is what let four type errors reach the last PR), 1646 frontend tests, vite build clean. e2e against a local relay and real browsers: quick-call-live, quick-call, quick-send, quick-send-swarm, quick-send-once, room-open-feedback. The preview and the in-call picker were each read out of a live browser: videoWidth 640, readyState 4, both tracks live, level bar moving; the dialog opening in /qc with camera, microphone and gain in it.